### PR TITLE
 Allow for smaller width resource take cards #511

### DIFF
--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/resourcetakes/view/RecordResourceFragment.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/resourcetakes/view/RecordResourceFragment.kt
@@ -47,7 +47,11 @@ class RecordResourceFragment(
             region {
                 hgrow = Priority.ALWAYS
             }
-            add(dragTarget)
+            add(
+                dragTarget.apply {
+                    hgrow = Priority.ALWAYS
+                }
+            )
             region {
                 hgrow = Priority.ALWAYS
             }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/resourcetakes/view/RecordResourceStyles.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/resourcetakes/view/RecordResourceStyles.kt
@@ -21,7 +21,6 @@ class RecordResourceStyles : Stylesheet() {
         fun takeWidthHeight() = mixin {
             minHeight = takeMinHeight
             maxWidth = takeMaxWidth
-            minWidth = maxWidth
             maxHeight = minHeight
         }
 

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/takemanagement/view/RecordableFragment.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/takemanagement/view/RecordableFragment.kt
@@ -54,6 +54,7 @@ abstract class RecordableFragment(
             }
 
     private val dragContainer = VBox().apply {
+        this.prefWidthProperty().bind(dragTarget.widthProperty())
         draggingNodeProperty.onChange { draggingNode ->
             clear()
             draggingNode?.let { add(draggingNode) }


### PR DESCRIPTION
"Currently, resource take cards on the right side of the record resource fragment are spilling past the edge of the available space, causing a horizontal scroll bar to appear at the bottom. This PR allows the take card to be smaller than its maximum width. Effectively, on small screens, the selected take area is now smaller than the cards in the alternate takes list on the right side. This PR does ensure that the take being dragged is the same size as the selected take (/drag target) area.

More work needs to be done to ensure that the width of the selected take is the same as the width of the content text. Additonally, more work would need to be done to ensure that the selected take area and the alternate takes are the same size as eachother but still resizable.

Corresponds to OT-23" -Kevin Joslyn

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/otter/8)
<!-- Reviewable:end -->
