### PR TITLE
Configure log4j2 to write to a file

### DIFF
--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/persistence/IDirectoryProvider.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/persistence/IDirectoryProvider.kt
@@ -33,4 +33,5 @@ interface IDirectoryProvider {
     val userProfileImageDirectory: File
     val userProfileAudioDirectory: File
     val audioPluginDirectory: File
+    val logsDirectory: File
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -32,6 +32,7 @@ ext {
     chromeabletabpaneVer = '0.1.0'
     jdenticonKoltinVer = '1.0'
     slf4jApiVer = '2.0.0-alpha1'
+    log4j2Ver = '2.12.1'
     fontawesomeCommonsVer = '11.0'
     fontawesomeMaterialIconsVer = "2.2.0-11"
     fontawesomeIcons525Ver = '3.0.0-11'

--- a/jvm/workbookapp/build.gradle
+++ b/jvm/workbookapp/build.gradle
@@ -144,7 +144,10 @@ dependencies {
     // jar loader
     implementation "org.clapper:javautil:$clapperJavaUtilVer"
 
-    implementation "org.slf4j:slf4j-simple:$slf4jApiVer"
+    // Logging
+    implementation "org.slf4j:slf4j-api:$slf4jApiVer"
+    implementation "org.apache.logging.log4j:log4j-core:$log4j2Ver"
+    implementation "org.apache.logging.log4j:log4j-slf4j18-impl:$log4j2Ver"
 }
 
 // tell gradle what to put in the jar

--- a/jvm/workbookapp/src/main/java/org/wycliffeassociates/otter/jvm/workbookapp/logging/ConfigureLogger.java
+++ b/jvm/workbookapp/src/main/java/org/wycliffeassociates/otter/jvm/workbookapp/logging/ConfigureLogger.java
@@ -1,0 +1,79 @@
+package org.wycliffeassociates.otter.jvm.workbookapp.logging;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
+import org.apache.logging.log4j.core.config.builder.api.*;
+import org.apache.logging.log4j.core.config.builder.impl.BuiltConfiguration;
+import java.io.File;
+
+
+public class ConfigureLogger {
+
+    private final String FILE_LOGGER_REF = "logfile";
+    private final String CONSOLE_LOGGER_REF = "stdout";
+    private final String LOG_FILE_NAME = "orature";
+    private final String LOG_EXT = ".log";
+
+    private File logDir;
+    private ConfigurationBuilder<BuiltConfiguration> builder = ConfigurationBuilderFactory.newConfigurationBuilder();
+    private LayoutComponentBuilder layout = builder.newLayout("PatternLayout");
+
+    public ConfigureLogger(File logDir) {
+        this.logDir = logDir;
+    }
+
+    private void configureConsoleAppender() {
+        AppenderComponentBuilder appender = builder.newAppender(CONSOLE_LOGGER_REF, "Console");
+        appender.add(layout);
+        builder.add(appender);
+    }
+
+    private void configureFileAppender() {
+        AppenderComponentBuilder fileAppender = builder.newAppender(FILE_LOGGER_REF, "RollingFile");
+        ComponentBuilder triggeringPolicy = builder.newComponent("Policies")
+                .addComponent(builder.newComponent("SizeBasedTriggeringPolicy")
+                .addAttribute("size", "128K"));
+
+        String filename = new StringBuilder()
+                .append(logDir.getAbsolutePath())
+                .append("/")
+                .append(LOG_FILE_NAME)
+                .append(LOG_EXT)
+                .toString();
+
+        String rolloverPattern = new StringBuilder()
+                .append(logDir.getAbsolutePath())
+                .append("/")
+                .append(LOG_FILE_NAME)
+                .append("-%i.zip")
+                .toString();
+
+        fileAppender.addAttribute("fileName", filename);
+        fileAppender.addAttribute("filePattern", rolloverPattern);
+        fileAppender.addAttribute("append", true);
+        fileAppender.addAttribute("bufferedIO", true);
+        fileAppender.addAttribute("immediateFlush", true);
+        fileAppender.add(layout);
+        fileAppender.addComponent(triggeringPolicy);
+        builder.add(fileAppender);
+    }
+
+    private void configureRootLogger() {
+        RootLoggerComponentBuilder root = builder.newRootLogger(Level.INFO);
+        root.add(builder.newAppenderRef(CONSOLE_LOGGER_REF));
+        root.add(builder.newAppenderRef(FILE_LOGGER_REF));
+        builder.add(root);
+    }
+
+    private void configurePatternLayout() {
+        layout.addAttribute("pattern", "%highlight{[%p] %d %c{4}: %msg%n%throwable}");
+    }
+
+    public void configure() {
+        configurePatternLayout();
+        configureConsoleAppender();
+        configureFileAppender();
+        configureRootLogger();
+        Configurator.initialize(builder.build());
+    }
+}

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/Main.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/Main.kt
@@ -2,6 +2,8 @@ package org.wycliffeassociates.otter.jvm.workbookapp
 
 import javafx.stage.Stage
 import javafx.stage.StageStyle
+import org.wycliffeassociates.otter.jvm.workbookapp.di.persistence.DaggerPersistenceComponent
+import org.wycliffeassociates.otter.jvm.workbookapp.logging.ConfigureLogger
 import org.wycliffeassociates.otter.jvm.workbookapp.theme.AppStyles
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.splash.view.SplashScreen
 import tornadofx.*
@@ -19,5 +21,12 @@ class MyApp : App(SplashScreen::class) {
 
 // launch the org.wycliffeassociates.otter.jvm.workbookapp
 fun main(args: Array<String>) {
+    initializeLogger()
     launch<MyApp>(args)
+}
+
+fun initializeLogger() {
+    val persistenceComponent = DaggerPersistenceComponent.builder().build()
+    val directoryProvider = persistenceComponent.injectDirectoryProvider()
+    ConfigureLogger(directoryProvider.logsDirectory).configure()
 }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/persistence/DirectoryProvider.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/persistence/DirectoryProvider.kt
@@ -128,4 +128,7 @@ class DirectoryProvider(
 
     override val audioPluginDirectory: File
         get() = getAppDataDirectory("plugins")
+
+    override val logsDirectory: File
+        get() = getAppDataDirectory("logs")
 }


### PR DESCRIPTION
Writes logs to a file.
When logs reach 128KB they will move to an autoincremented file that gets Zipped. Uses the default rollover of deleting the oldest of 4.

The configuration class is written in Java due to the log4j2 API using recursive generics that Kotlin isn't able to type infer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/otter/19)
<!-- Reviewable:end -->
