### PR TITLE
Exclude log4j 1 dependency

### DIFF
--- a/jvm/workbookapp/build.gradle
+++ b/jvm/workbookapp/build.gradle
@@ -93,7 +93,9 @@ dependencies {
     runtimeOnly "org.openjfx:javafx-graphics:$javafxVer:mac"
 
     // SVG Loader
-    implementation "com.github.afester.javafx:FranzXaver:$franzXaverVer"
+    implementation("com.github.afester.javafx:FranzXaver:$franzXaverVer") {
+        exclude group: 'log4j', module: 'log4j'
+    }
 
     // JFoenix
     implementation "com.jfoenix:jfoenix:$jfoenixVer"


### PR DESCRIPTION
Svg Loader library was declaring the log4j1 api without providing the implementation (runtime was excluded). This was conflicting with log4j2 used in Orature. Fix provided by https://logging.apache.org/log4j/2.x/faq.html#exclusions

Caused by: java.lang.UnsupportedOperationException: No class provided, and an appropriate one cannot be found.
    at org.apache.logging.log4j.LogManager.callerClass(LogManager.java:555)
    at org.apache.logging.log4j.LogManager.getLogger(LogManager.java:580)
    at org.apache.logging.log4j.LogManager.getLogger(LogManager.java:567)
    at afester.javafx.svg.SvgLoader.<clinit>(SvgLoader.java:59)
    ... 29 more

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/otter/20)
<!-- Reviewable:end -->
