### PR TITLE
Jbs close players

### DIFF
--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/device/IAudioPlayer.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/device/IAudioPlayer.kt
@@ -4,24 +4,15 @@ import io.reactivex.Completable
 import java.io.File
 
 interface IAudioPlayer {
-
     fun addEventListener(listener: IAudioPlayerListener)
-
     fun addEventListener(onEvent: (event: AudioPlayerEvent) -> Unit)
-
     fun load(file: File): Completable
-
     fun play()
-
     fun pause()
-
     fun stop()
-
+    fun close()
     fun getAbsoluteDurationInFrames(): Int
-
     fun getAbsoluteDurationMs(): Int
-
     fun getAbsoluteLocationInFrames(): Int
-
     fun getAbsoluteLocationMs(): Int
 }

--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/SimpleAudioPlayer.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/SimpleAudioPlayer.kt
@@ -63,7 +63,7 @@ class SimpleAudioPlayer(private val audioFile: File, private val player: IAudioP
     }
 
     fun buttonPressed() {
-        if (!isPlaying.value){
+        if (!isPlaying.value) {
             if (!loaded) {
                 player.load(audioFile).andThen {
                     Platform.runLater {

--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/SimpleAudioPlayer.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/SimpleAudioPlayer.kt
@@ -18,9 +18,10 @@ import java.util.concurrent.TimeUnit
 // Named "Simple" since just displays a progress bar and play/pause button
 // No waveform view
 class SimpleAudioPlayer(private val audioFile: File, private val player: IAudioPlayer) : HBox() {
-    val progressBar = JFXProgressBar()
 
+    val progressBar = JFXProgressBar()
     val isPlaying = SimpleBooleanProperty(false)
+    var loaded = false
 
     init {
         style {
@@ -28,12 +29,9 @@ class SimpleAudioPlayer(private val audioFile: File, private val player: IAudioP
         }
         add(progressBar)
 
-        // Set up indefinite loading bar
-        progressBar.progress = -1.0
+        progressBar.progress = 0.0
         progressBar.hgrow = Priority.ALWAYS
         progressBar.maxWidth = Double.MAX_VALUE
-
-        player.load(audioFile).subscribe()
 
         // progress update observable
         var disposable: Disposable? = null
@@ -65,7 +63,22 @@ class SimpleAudioPlayer(private val audioFile: File, private val player: IAudioP
     }
 
     fun buttonPressed() {
-        if (!isPlaying.value) player.play() else player.pause()
+        if (!isPlaying.value){
+            if (!loaded) {
+                player.load(audioFile).andThen {
+                    Platform.runLater {
+                        player.play()
+                        loaded = true
+                    }
+                }.subscribe()
+            }
+            player.play()
+        } else player.pause()
+    }
+
+    fun close() {
+        player.close()
+        loaded = false
     }
 
     private fun startProgressUpdate(): Disposable {

--- a/jvm/device/src/main/kotlin/org/wycliffeassociates/otter/jvm/device/audio/AudioPlayer.kt
+++ b/jvm/device/src/main/kotlin/org/wycliffeassociates/otter/jvm/device/audio/AudioPlayer.kt
@@ -79,6 +79,11 @@ class AudioPlayer : IAudioPlayer {
         clip.framePosition = 0
     }
 
+    override fun close() {
+        stop()
+        clip.close()
+    }
+
     override fun getAbsoluteDurationInFrames(): Int {
         return clip.frameLength
     }

--- a/jvm/device/src/main/kotlin/org/wycliffeassociates/otter/jvm/device/audio/AudioPlayer.kt
+++ b/jvm/device/src/main/kotlin/org/wycliffeassociates/otter/jvm/device/audio/AudioPlayer.kt
@@ -81,6 +81,7 @@ class AudioPlayer : IAudioPlayer {
         stop()
         clip.close()
         audioInputStream?.close()
+        System.gc()
     }
 
     override fun getAbsoluteDurationInFrames(): Int {

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/controls/takecard/TakeCardSkin.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/controls/takecard/TakeCardSkin.kt
@@ -16,7 +16,7 @@ import org.wycliffeassociates.otter.jvm.workbookapp.controls.takecard.events.Sta
 import tornadofx.*
 import tornadofx.FX.Companion.messages
 
-abstract class TakeCardSkin(control: TakeCard) : SkinBase<TakeCard>(control) {
+abstract class TakeCardSkin(val control: TakeCard) : SkinBase<TakeCard>(control) {
 
     private val defaultPlayPauseIconSize = 30
     // These can be overridden
@@ -97,6 +97,7 @@ abstract class TakeCardSkin(control: TakeCard) : SkinBase<TakeCard>(control) {
 
     private fun createEditButton() = JFXButton().apply {
         action {
+            control.simpleAudioPlayer.close()
             skinnable.fireEditTakeEvent()
         }
     }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/resourcetakes/view/RecordResourceFragment.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/resourcetakes/view/RecordResourceFragment.kt
@@ -41,9 +41,7 @@ class RecordResourceFragment(
             maxWidth = 500.0
             text = messages["newTake"]
             action {
-                alternateTakesList.getChildList()?.forEach {
-                    (it as? TakeCard)?.simpleAudioPlayer?.close()
-                }
+                closePlayers()
                 recordableViewModel.recordNewTake()
             }
         }
@@ -123,5 +121,11 @@ class RecordResourceFragment(
         val rc = RowConstraints()
         rc.percentHeight = 100.0
         rowConstraints.addAll(rc)
+    }
+
+    override fun closePlayers() {
+        alternateTakesList.getChildList()?.forEach {
+            (it as? TakeCard)?.simpleAudioPlayer?.close()
+        }
     }
 }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/resourcetakes/view/RecordResourceFragment.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/resourcetakes/view/RecordResourceFragment.kt
@@ -27,6 +27,11 @@ class RecordResourceFragment(
 ) {
     val formattedTextProperty = SimpleStringProperty()
 
+    val alternateTakesList = TakesListView(
+        items = recordableViewModel.alternateTakes,
+        createTakeNode = ::createTakeCard
+    )
+
     private val newTakeButton =
         highlightablebutton {
             highlightColor = Color.ORANGE
@@ -36,6 +41,9 @@ class RecordResourceFragment(
             maxWidth = 500.0
             text = messages["newTake"]
             action {
+                alternateTakesList.getChildList()?.forEach {
+                    (it as? TakeCard)?.simpleAudioPlayer?.close()
+                }
                 recordableViewModel.recordNewTake()
             }
         }
@@ -90,12 +98,7 @@ class RecordResourceFragment(
                     percentWidth = 50.0
                 }
                 addClass(RecordResourceStyles.rightRegion)
-                add(
-                    TakesListView(
-                        items = recordableViewModel.alternateTakes,
-                        createTakeNode = ::createTakeCard
-                    )
-                )
+                add(alternateTakesList)
             }
         }
     }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/takemanagement/view/RecordScriptureFragment.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/takemanagement/view/RecordScriptureFragment.kt
@@ -22,6 +22,13 @@ class RecordScriptureFragment : RecordableFragment(
 ) {
     private val recordScriptureViewModel: RecordScriptureViewModel by inject()
 
+    private val takesList = TakesFlowPane(
+        recordableViewModel.alternateTakes,
+        audioPluginViewModel::audioPlayer,
+        lastPlayOrPauseEvent,
+        recordableViewModel::recordNewTake
+    )
+
     init {
         importStylesheet<RecordScriptureStyles>()
         importStylesheet<TakeCardStyles>()
@@ -69,12 +76,7 @@ class RecordScriptureFragment : RecordableFragment(
                     isFitToWidth = true
                     addClass(RecordScriptureStyles.scrollpane)
                     add(
-                        TakesFlowPane(
-                            recordableViewModel.alternateTakes,
-                            audioPluginViewModel::audioPlayer,
-                            lastPlayOrPauseEvent,
-                            recordableViewModel::recordNewTake
-                        )
+                        takesList
                     )
                 }
             }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/takemanagement/view/RecordScriptureFragment.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/takemanagement/view/RecordScriptureFragment.kt
@@ -83,6 +83,10 @@ class RecordScriptureFragment : RecordableFragment(
         }
     }
 
+    override fun closePlayers() {
+        takesList.closePlayers()
+    }
+
     override fun createTakeCard(take: Take): TakeCard {
         return scripturetakecard(
             take,

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/takemanagement/view/RecordableFragment.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/takemanagement/view/RecordableFragment.kt
@@ -99,9 +99,12 @@ abstract class RecordableFragment(
             recordableViewModel.deleteTake(it.take)
         }
         addEventHandler(EditTakeEvent.EDIT_TAKE) {
+            closePlayers()
             recordableViewModel.editTake(it)
         }
     }
+
+    abstract fun closePlayers()
 
     private fun createSnackBar(pane: Pane) {
         // TODO: This doesn't actually handle anything correctly. Need to know whether the user

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/takemanagement/view/TakesFlowPane.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/takemanagement/view/TakesFlowPane.kt
@@ -59,6 +59,9 @@ class TakesFlowPane(
             label(messages["newTake"])
             button(messages["record"], AppStyles.recordIcon("25px")) {
                 action {
+                    this@TakesFlowPane.children?.forEach {
+                        (it as? TakeCard)?.simpleAudioPlayer?.close()
+                    }
                     recordNewTake()
                 }
             }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/takemanagement/view/TakesFlowPane.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/takemanagement/view/TakesFlowPane.kt
@@ -59,12 +59,16 @@ class TakesFlowPane(
             label(messages["newTake"])
             button(messages["record"], AppStyles.recordIcon("25px")) {
                 action {
-                    this@TakesFlowPane.children?.forEach {
-                        (it as? TakeCard)?.simpleAudioPlayer?.close()
-                    }
+                    closePlayers()
                     recordNewTake()
                 }
             }
+        }
+    }
+
+    fun closePlayers() {
+        this@TakesFlowPane.children?.forEach {
+            (it as? TakeCard)?.simpleAudioPlayer?.close()
         }
     }
 


### PR DESCRIPTION
These pages are architecturally a mess and I'd like to refactor it; but this is enough to only open lines when a play is requested and lines are all closed when moving to begin recording or editing. This allows a file that was just opened for playback to be edited and saved in Ocenaudio.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/otter/25)
<!-- Reviewable:end -->
