### PR TITLE
Filter source collection by project id

### DIFF
--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/projectimportexport/ProjectImporter.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/projectimportexport/ProjectImporter.kt
@@ -90,7 +90,7 @@ class ProjectImporter(
     ) {
         importSources(zipFileReader)
 
-        val sourceCollection = findSourceCollection(manifestSources)
+        val sourceCollection = findSourceCollection(manifestSources, manifestProject)
 
         val derivedProject = createDerivedProject(metadata, sourceCollection)
 
@@ -148,7 +148,7 @@ class ProjectImporter(
             .blockingGet()
     }
 
-    private fun findSourceCollection(manifestSources: Set<Source>): Collection {
+    private fun findSourceCollection(manifestSources: Set<Source>, manifestProject: Project): Collection {
         val allSourceProjects = collectionRepository.getSourceProjects().blockingGet()
         val sourceCollection: Collection? = allSourceProjects
             .asSequence()
@@ -157,6 +157,9 @@ class ProjectImporter(
                     ?.run { Source(identifier, language.slug, version) }
                     ?.let { it in manifestSources }
                     ?: false
+            }
+            .filter {
+                it.slug == manifestProject.identifier
             }
             .firstOrNull()
 


### PR DESCRIPTION
Currently, the findSourceCollection method finds all collections that match a particular resource container source. The RC source just contains the RC id, version, and language. As a result, this returns all project collections associated with that resource container, which in the case of the ULB is 66. This then does a first or null, resulting in always returning Genesis.

This fix adds the project as a parameter to the method, so that the projects can then be filtered further by the project slug.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/otter/30)
<!-- Reviewable:end -->
