### PR TITLE
Reduce memory usage of exporting a large project

### DIFF
--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/io/zip/NioZipFileWriter.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/io/zip/NioZipFileWriter.kt
@@ -10,7 +10,12 @@ import java.nio.file.Files
 class NioZipFileWriter(
     zipFile: File
 ) : IZipFileWriter {
-    private val fileSystem: FileSystem = FileSystems.newFileSystem(zipFile.jarUri(), mapOf("create" to "true"))
+
+    // useTempFile set to true to reduce memory usage when writing large zip files
+    private val fileSystem: FileSystem = FileSystems.newFileSystem(
+        zipFile.jarUri(),
+        mapOf("create" to "true", "useTempFile" to true)
+    )
 
     override fun close() = fileSystem.close()
 


### PR DESCRIPTION
When exporting, OutOfMemory exceptions were being thrown due to ZipFileSystem:

https://stackoverflow.com/questions/23858706/zipping-a-huge-folder-by-using-a-zipfilesystem-results-in-outofmemoryerror

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/otter/61)
<!-- Reviewable:end -->
