### PR TITLE
Fixes the path to resource audio for exporting

### DIFF
--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/persistence/DirectoryProvider.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/persistence/DirectoryProvider.kt
@@ -1,6 +1,7 @@
 package org.wycliffeassociates.otter.jvm.workbookapp.persistence
 
 import org.wycliffeassociates.otter.common.data.model.Collection
+import org.wycliffeassociates.otter.common.data.model.ContainerType
 import org.wycliffeassociates.otter.common.data.model.ResourceMetadata
 import org.wycliffeassociates.otter.common.persistence.IDirectoryProvider
 import org.wycliffeassociates.otter.jvm.workbookapp.io.zip.NioZipFileReader
@@ -72,8 +73,14 @@ class DirectoryProvider(
         target: ResourceMetadata?,
         bookSlug: String
     ): File {
+        // Audio is being stored in the source creator directory for resources
+        val targetCreator = when {
+            target?.type == ContainerType.Help -> source.creator
+            target?.creator != null -> target.creator
+            else -> "."
+        }
         val appendedPath = listOf(
-            target?.creator ?: ".",
+            targetCreator,
             source.creator,
             "${source.language.slug}_${source.identifier}",
             "v${target?.version ?: "-none"}",


### PR DESCRIPTION
Resource audio is stored in the source creator directory, and as such export was looking in the wrong folder

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/otter/62)
<!-- Reviewable:end -->
