### PR TITLE
Use the mimetype of the source, not always USFM

### DIFF
--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/persistence/repositories/CollectionRepository.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/persistence/repositories/CollectionRepository.kt
@@ -429,7 +429,7 @@ class CollectionRepository(
             }
             creator = dublinCoreCreator
             version = source.version
-            format = MimeType.USFM.norm
+            format = MimeType.of(source.format).norm
             subject = source.subject
             type = derivedContainerType.slug
             title = source.title


### PR DESCRIPTION
Previously all derived RCs were created as text/usfm, which was incorrect for resources like tq which is text/markdown. As such, importing an exported project would throw a parse error due to using the incorrect parser.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/otter/64)
<!-- Reviewable:end -->
