### PR TITLE
Adds Deleting Project dialog, fixes import dialog

### DIFF
--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/menu/viewmodel/MainMenuViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/menu/viewmodel/MainMenuViewModel.kt
@@ -69,6 +69,7 @@ class MainMenuViewModel : ViewModel() {
             directoryProvider,
             injector.zipEntryTreeBuilder
         ).import(fileOrDir)
+            .subscribeOn(Schedulers.io())
             .observeOnFx()
             .subscribe { result: ImportResult ->
                 if (result == ImportResult.SUCCESS) {

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/projectgrid/view/ProjectGridFragment.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/projectgrid/view/ProjectGridFragment.kt
@@ -3,6 +3,7 @@ package org.wycliffeassociates.otter.jvm.workbookapp.ui.projectgrid.view
 import com.jfoenix.controls.JFXButton
 import de.jensd.fx.glyphs.materialicons.MaterialIcon
 import de.jensd.fx.glyphs.materialicons.MaterialIconView
+import javafx.application.Platform
 import javafx.beans.property.*
 import javafx.geometry.Pos
 import javafx.scene.layout.Priority
@@ -13,6 +14,8 @@ import org.wycliffeassociates.otter.jvm.utils.images.SVGImage
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.projectgrid.viewmodel.ProjectGridViewModel
 import org.wycliffeassociates.otter.jvm.controls.card.DefaultStyles
 import org.wycliffeassociates.otter.jvm.controls.card.projectcard
+import org.wycliffeassociates.otter.jvm.controls.progressdialog.progressdialog
+import org.wycliffeassociates.otter.jvm.workbookapp.theme.AppStyles
 import tornadofx.*
 
 class ProjectGridFragment : Fragment() {
@@ -29,6 +32,7 @@ class ProjectGridFragment : Fragment() {
         val listProperty = SimpleListProperty<Collection>()
         listProperty.bind(SimpleObjectProperty(viewModel.projects))
         noProjectsProperty = listProperty.emptyProperty()
+        initializeProgressDialogs()
     }
 
     override val root = anchorpane {
@@ -132,5 +136,16 @@ class ProjectGridFragment : Fragment() {
     override fun onDock() {
         viewModel.loadProjects()
         viewModel.clearSelectedProject()
+    }
+
+    private fun initializeProgressDialogs() {
+        val deletingProjectDialog = progressdialog {
+            text = messages["deleteingProject"]
+            graphic = ProjectGridStyles.deleteIcon("60px")
+            root.addClass(AppStyles.progressDialog)
+        }
+        viewModel.showDeleteDialogProperty.onChange {
+            Platform.runLater { if (it) deletingProjectDialog.open() else deletingProjectDialog.close() }
+        }
     }
 }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/projectgrid/view/ProjectGridFragment.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/projectgrid/view/ProjectGridFragment.kt
@@ -140,7 +140,7 @@ class ProjectGridFragment : Fragment() {
 
     private fun initializeProgressDialogs() {
         val deletingProjectDialog = progressdialog {
-            text = messages["deleteingProject"]
+            text = messages["deletingProject"]
             graphic = ProjectGridStyles.deleteIcon("60px")
             root.addClass(AppStyles.progressDialog)
         }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/projectgrid/view/ProjectGridStyles.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/projectgrid/view/ProjectGridStyles.kt
@@ -1,5 +1,7 @@
 package org.wycliffeassociates.otter.jvm.workbookapp.ui.projectgrid.view
 
+import de.jensd.fx.glyphs.materialicons.MaterialIcon
+import de.jensd.fx.glyphs.materialicons.MaterialIconView
 import javafx.geometry.Pos
 import javafx.scene.Cursor
 import javafx.scene.text.FontWeight
@@ -8,6 +10,7 @@ import tornadofx.*
 
 class ProjectGridStyles : Stylesheet() {
     companion object {
+        fun deleteIcon(size: String) = MaterialIconView(MaterialIcon.DELETE, size)
         val projectsGrid by cssclass()
         val noProjectsLabel by cssclass()
         val tryCreatingLabel by cssclass()

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/projectgrid/viewmodel/ProjectGridViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/projectgrid/viewmodel/ProjectGridViewModel.kt
@@ -9,7 +9,6 @@ import org.wycliffeassociates.otter.common.data.model.Collection
 import org.wycliffeassociates.otter.common.data.model.ContainerType
 import org.wycliffeassociates.otter.common.domain.collections.DeleteProject
 import org.wycliffeassociates.otter.common.navigation.TabGroupType
-import org.wycliffeassociates.otter.jvm.controls.progressdialog.progressdialog
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.chromeablestage.ChromeableStage
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.inject.Injector
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.projectwizard.view.ProjectWizard

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/projectgrid/viewmodel/ProjectGridViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/projectgrid/viewmodel/ProjectGridViewModel.kt
@@ -2,12 +2,14 @@ package org.wycliffeassociates.otter.jvm.workbookapp.ui.projectgrid.viewmodel
 
 import com.github.thomasnield.rxkotlinfx.observeOnFx
 import javafx.application.Platform
+import javafx.beans.property.SimpleBooleanProperty
 import javafx.collections.FXCollections
 import javafx.collections.ObservableList
 import org.wycliffeassociates.otter.common.data.model.Collection
 import org.wycliffeassociates.otter.common.data.model.ContainerType
 import org.wycliffeassociates.otter.common.domain.collections.DeleteProject
 import org.wycliffeassociates.otter.common.navigation.TabGroupType
+import org.wycliffeassociates.otter.jvm.controls.progressdialog.progressdialog
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.chromeablestage.ChromeableStage
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.inject.Injector
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.projectwizard.view.ProjectWizard
@@ -22,6 +24,7 @@ class ProjectGridViewModel : ViewModel() {
 
     private val navigator: ChromeableStage by inject()
     private val workbookViewModel: WorkbookViewModel by inject()
+    val showDeleteDialogProperty = SimpleBooleanProperty(false)
 
     val projects: ObservableList<Collection> = FXCollections.observableArrayList<Collection>()
 
@@ -47,10 +50,12 @@ class ProjectGridViewModel : ViewModel() {
     }
 
     fun deleteProject(project: Collection) {
+        showDeleteDialogProperty.set(true)
         DeleteProject(collectionRepo, directoryProvider)
             .delete(project, true)
             .observeOnFx()
             .subscribe {
+                showDeleteDialogProperty.set(false)
                 Platform.runLater { loadProjects() }
             }
     }

--- a/jvm/workbookapp/src/main/resources/Messages_en.properties
+++ b/jvm/workbookapp/src/main/resources/Messages_en.properties
@@ -63,6 +63,7 @@ noPlugins=No Audio Plugins
 deleteTakePrompt = Delete Take?
 deleteProjectPrompt = Delete Project?
 deleteProjectDetails = This action cannot be undone. This will NOT delete project audio.
+deletingProject = Deleting Project
 cannotBeUndone = This action cannot be undone.
 nightMode = Night Mode
 noRecorder = No audio recording plugin found.


### PR DESCRIPTION
Import's progress dialog was not running off the main thread for some reason and as such the onChange listener was not firing until after the import had completed.

Adds a similar dialog for delete.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/otter/67)
<!-- Reviewable:end -->
