### PR TITLE
Restrict export source to only source containers used

### DIFF
--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/projectimportexport/ProjectExporter.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/projectimportexport/ProjectExporter.kt
@@ -71,7 +71,7 @@ class ProjectExporter(
         sequenceOf(bookSource, projectSourceMetadata)
             .map { it.path }
             .distinct()
-            .forEach { zipWriter.copyDirectory(it, RcConstants.SOURCE_DIR) }
+            .forEach { zipWriter.copyFile(it, RcConstants.SOURCE_DIR) }
     }
 
     private fun copyTakeFiles(zipWriter: IZipFileWriter) {

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/projectimportexport/ProjectExporter.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/projectimportexport/ProjectExporter.kt
@@ -69,7 +69,7 @@ class ProjectExporter(
         val bookSource = workbook.source.resourceMetadata
 
         sequenceOf(bookSource, projectSourceMetadata)
-            .map(directoryProvider::getSourceContainerDirectory)
+            .map { it.path }
             .distinct()
             .forEach { zipWriter.copyDirectory(it, RcConstants.SOURCE_DIR) }
     }

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/io/zip/IZipFileWriter.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/io/zip/IZipFileWriter.kt
@@ -6,4 +6,5 @@ import java.io.File
 interface IZipFileWriter : AutoCloseable {
     fun bufferedWriter(filepath: String): BufferedWriter
     fun copyDirectory(source: File, destination: String, filter: (String) -> Boolean = { _ -> true })
+    fun copyFile(source: File, destination: String)
 }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/io/zip/NioFileUtils.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/io/zip/NioFileUtils.kt
@@ -57,4 +57,3 @@ internal fun Path.copyFileTo(dest: Path): Observable<String> {
     }
     return pairsOfFilesToCopy.map { (_, toFile) -> toFile.toString() }
 }
-

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/io/zip/NioFileUtils.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/io/zip/NioFileUtils.kt
@@ -44,7 +44,7 @@ internal fun Path.copyDirectoryTo(dest: Path, filter: (String) -> Boolean): Obse
 }
 
 /** Copy a File, possibly to another [java.nio.file.FileSystem] */
-internal fun Path.copyFile(dest: Path): Observable<String> {
+internal fun Path.copyFileTo(dest: Path): Observable<String> {
     val sourceRoot = toAbsolutePath().parent
     val fromFile = this
     val relativePath = sourceRoot.relativize(fromFile).toString()

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/io/zip/NioFileUtils.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/io/zip/NioFileUtils.kt
@@ -7,6 +7,7 @@ import java.io.File
 import java.net.URI
 import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.StandardCopyOption
 import kotlin.streams.asSequence
 
 /**
@@ -41,3 +42,19 @@ internal fun Path.copyDirectoryTo(dest: Path, filter: (String) -> Boolean): Obse
 
     return pairsOfFilesToCopy.map { (_, toFile) -> toFile.toString() }
 }
+
+/** Copy a File, possibly to another [java.nio.file.FileSystem] */
+internal fun Path.copyFile(dest: Path): Observable<String> {
+    val sourceRoot = toAbsolutePath().parent
+    val fromFile = this
+    val relativePath = sourceRoot.relativize(fromFile).toString()
+    val toFile = dest.resolve(relativePath)
+    toFile.createParentDirectories()
+    val pairsOfFilesToCopy = Observable.just(Pair(fromFile, toFile)).cache()
+    pairsOfFilesToCopy.forEach { (fromFile, toFile) ->
+        toFile.createParentDirectories()
+        Files.copy(fromFile, toFile, StandardCopyOption.REPLACE_EXISTING)
+    }
+    return pairsOfFilesToCopy.map { (_, toFile) -> toFile.toString() }
+}
+

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/io/zip/NioZipFileWriter.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/io/zip/NioZipFileWriter.kt
@@ -30,7 +30,7 @@ class NioZipFileWriter(
         val sourcePath = source.toPath()
         val destPath = fileSystem.getPath(destination)
         if (Files.isRegularFile(sourcePath)) {
-            sourcePath.copyFile(destPath)
+            sourcePath.copyFileTo(destPath)
         }
     }
 }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/io/zip/NioZipFileWriter.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/io/zip/NioZipFileWriter.kt
@@ -25,4 +25,12 @@ class NioZipFileWriter(
         val destPath = fileSystem.getPath(destination)
         sourcePath.copyDirectoryTo(destPath, filter)
     }
+
+    override fun copyFile(source: File, destination: String) {
+        val sourcePath = source.toPath()
+        val destPath = fileSystem.getPath(destination)
+        if (Files.isRegularFile(sourcePath)) {
+            sourcePath.copyFile(destPath)
+        }
+    }
 }


### PR DESCRIPTION
Previously export pulled all RCs in the directory to be used as source. If other RCs had the same originator and version number, you could get multiple RCs in that directory (like tn and tq, for example). This grabs just the file pointed to specifically by the metadata of the project and book being exported.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/otter/68)
<!-- Reviewable:end -->
