### PR TITLE
Fix uninstall

### DIFF
--- a/jvm/workbookapp/otter.install4j
+++ b/jvm/workbookapp/otter.install4j
@@ -307,7 +307,7 @@ return console.askYesNo(message, true);
               <action id="29" beanClass="com.install4j.runtime.beans.actions.UninstallFilesAction" actionElevationType="elevated" rollbackBarrierExitCode="0" />
               <action id="257" beanClass="com.install4j.runtime.beans.actions.files.DeleteFileAction" actionElevationType="elevated" rollbackBarrierExitCode="0">
                 <serializedBean>
-                  <property name="files" type="array" class="java.io.File" length="4">
+                  <property name="files" type="array" class="java.io.File" length="2">
                     <element index="0">
                       <object class="java.io.File">
                         <string>${installer:sys.appdataDir}${installer:sys.fileSeparator}Orature</string>
@@ -315,17 +315,7 @@ return console.askYesNo(message, true);
                     </element>
                     <element index="1">
                       <object class="java.io.File">
-                        <string>${installer:sys.userHome}/.config/Orature</string>
-                      </object>
-                    </element>
-                    <element index="2">
-                      <object class="java.io.File">
                         <string>${installer:sys.userHome}${installer:sys.fileSeparator}Orature</string>
-                      </object>
-                    </element>
-                    <element index="3">
-                      <object class="java.io.File">
-                        <string>/home/${installer:sys.userName}/.config/Orature</string>
                       </object>
                     </element>
                   </property>
@@ -574,7 +564,8 @@ return console.askYesNo(message, true);
     </windows>
     <linuxDeb name="Linux Deb Archive" id="158">
       <jreBundle jreBundleSource="preCreated" includedJre="linux-amd64-11.0.4.tar.gz" manualJreEntry="true" />
-      <postInstallScript>cp /opt/${compiler:sys.shortName}/${compiler:sys.shortName}.desktop ~/Desktop/</postInstallScript>
+      <postInstallScript>for i in $(ls -d -1 /home/**); do cp /opt/${compiler:sys.shortName}/${compiler:sys.shortName}.desktop $i/Desktop/; done</postInstallScript>
+      <postUninstallScript>for i in $(ls -d -1 /home/**); do rm -rf $i/orature; done</postUninstallScript>
     </linuxDeb>
     <macosFolder name="macOS Folder" id="166">
       <jreBundle jreBundleSource="preCreated" includedJre="macosx-amd64-11.0.3.tar.gz" manualJreEntry="true" />

--- a/jvm/workbookapp/otter.install4j
+++ b/jvm/workbookapp/otter.install4j
@@ -564,8 +564,7 @@ return console.askYesNo(message, true);
     </windows>
     <linuxDeb name="Linux Deb Archive" id="158">
       <jreBundle jreBundleSource="preCreated" includedJre="linux-amd64-11.0.4.tar.gz" manualJreEntry="true" />
-      <postInstallScript>for i in $(ls -d -1 /home/**); do cp /opt/${compiler:sys.shortName}/${compiler:sys.shortName}.desktop $i/Desktop/; done</postInstallScript>
-      <postUninstallScript>for i in $(ls -d -1 /home/**); do rm -rf $i/orature; done</postUninstallScript>
+      <postUninstallScript>for i in $(ls -d -1 /home/**); do rm -rf $i/.config/Orature; done</postUninstallScript>
     </linuxDeb>
     <macosFolder name="macOS Folder" id="166">
       <jreBundle jreBundleSource="preCreated" includedJre="macosx-amd64-11.0.3.tar.gz" manualJreEntry="true" />

--- a/jvm/workbookapp/otter.install4j
+++ b/jvm/workbookapp/otter.install4j
@@ -307,15 +307,10 @@ return console.askYesNo(message, true);
               <action id="29" beanClass="com.install4j.runtime.beans.actions.UninstallFilesAction" actionElevationType="elevated" rollbackBarrierExitCode="0" />
               <action id="257" beanClass="com.install4j.runtime.beans.actions.files.DeleteFileAction" actionElevationType="elevated" rollbackBarrierExitCode="0">
                 <serializedBean>
-                  <property name="files" type="array" class="java.io.File" length="2">
+                  <property name="files" type="array" class="java.io.File" length="1">
                     <element index="0">
                       <object class="java.io.File">
                         <string>${installer:sys.appdataDir}${installer:sys.fileSeparator}Orature</string>
-                      </object>
-                    </element>
-                    <element index="1">
-                      <object class="java.io.File">
-                        <string>${installer:sys.userHome}${installer:sys.fileSeparator}Orature</string>
                       </object>
                     </element>
                   </property>

--- a/jvm/workbookapp/otter.install4j
+++ b/jvm/workbookapp/otter.install4j
@@ -307,7 +307,7 @@ return console.askYesNo(message, true);
               <action id="29" beanClass="com.install4j.runtime.beans.actions.UninstallFilesAction" actionElevationType="elevated" rollbackBarrierExitCode="0" />
               <action id="257" beanClass="com.install4j.runtime.beans.actions.files.DeleteFileAction" actionElevationType="elevated" rollbackBarrierExitCode="0">
                 <serializedBean>
-                  <property name="files" type="array" class="java.io.File" length="2">
+                  <property name="files" type="array" class="java.io.File" length="4">
                     <element index="0">
                       <object class="java.io.File">
                         <string>${installer:sys.appdataDir}${installer:sys.fileSeparator}Orature</string>
@@ -316,6 +316,16 @@ return console.askYesNo(message, true);
                     <element index="1">
                       <object class="java.io.File">
                         <string>${installer:sys.userHome}/.config/Orature</string>
+                      </object>
+                    </element>
+                    <element index="2">
+                      <object class="java.io.File">
+                        <string>${installer:sys.userHome}${installer:sys.fileSeparator}Orature</string>
+                      </object>
+                    </element>
+                    <element index="3">
+                      <object class="java.io.File">
+                        <string>/home/${installer:sys.userName}/.config/Orature</string>
                       </object>
                     </element>
                   </property>


### PR DESCRIPTION
This adds and/or fixes deletion of the user's Orature files on uninstall for Windows and Linux. The linux file deletion is a little hacky because dpkg has to be run as root/sudo and therefore there is no direct access to the current user's home directory. Also, we want to remove all users files on uninstall, so this does that. Open to other methods, this was just what seemed like it would work (and it did).

I also removed a non-working desktop shortcut script from the linux installer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/otter/70)
<!-- Reviewable:end -->
