### PR TITLE
Faster merging of resource containers

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -29,7 +29,7 @@ ext {
     mockitoKotlinVer = '2.1.0'
     commonmarkVer = '0.12.1'
     clapperJavaUtilVer = '3.2.0'
-    kotlinresourcecontainerVer = '0.4.0'
+    kotlinresourcecontainerVer = '0.5.0'
     chromeabletabpaneVer = '0.1.0'
     jdenticonKoltinVer = '1.0'
     slf4jApiVer = '2.0.0-alpha1'


### PR DESCRIPTION
Gathers all media to write out across all projects in the resource container and writes once at the end. This is important as each write requires a rewrite of the entire zip file.

Note: this will not build until the update to the kotlin-resource-container library has been published. Do not merge this request until the build passes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/otter/96)
<!-- Reviewable:end -->
