### PR TITLE
Fixed bug when navigation from a resource group with single resource …

### DIFF
--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/chromeablestage/tabgroups/RecordResourceTabGroup.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/chromeablestage/tabgroups/RecordResourceTabGroup.kt
@@ -4,6 +4,7 @@ import org.wycliffeassociates.otter.common.data.model.ContentType
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.resourcetakes.view.RecordableTab
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.resourcetakes.viewmodel.RecordResourceViewModel
 import org.wycliffeassociates.otter.jvm.utils.getNotNull
+import org.wycliffeassociates.otter.jvm.utils.onChangeAndDoNow
 
 class RecordResourceTabGroup : TabGroup() {
     private val viewModel: RecordResourceViewModel by inject()
@@ -22,9 +23,18 @@ class RecordResourceTabGroup : TabGroup() {
 
     override fun activate() {
         tabs.forEach { recordableTab ->
-            if (recordableTab.hasRecordable()) {
-                tabPane.tabs.add(recordableTab)
+            recordableTab.bindProperties()
+            recordableTab.recordableProperty.onChangeAndDoNow { rec ->
+                rec?.let {
+                    if (!tabPane.tabs.contains(recordableTab)) tabPane.tabs.add(recordableTab)
+                } ?: tabPane.tabs.remove(recordableTab)
             }
+        }
+    }
+
+    override fun deactivate() {
+        tabs.forEach { recordableTab ->
+            recordableTab.unbindProperties()
         }
     }
 }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/resourcetakes/view/RecordableTab.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/resourcetakes/view/RecordableTab.kt
@@ -1,5 +1,6 @@
 package org.wycliffeassociates.otter.jvm.workbookapp.ui.resourcetakes.view
 
+import javafx.beans.property.SimpleObjectProperty
 import javafx.scene.control.Tab
 import javafx.scene.paint.Color
 import org.wycliffeassociates.otter.common.domain.content.Recordable
@@ -13,9 +14,9 @@ class RecordableTab(
     private val onTabSelect: (Recordable) -> Unit
 ) : Tab() {
 
-    init {
-        textProperty().bind(viewModel.labelProperty)
+    val recordableProperty = SimpleObjectProperty<Recordable?>()
 
+    init {
         graphic = statusindicator {
             initForRecordableTab()
             progressProperty.bind(viewModel.getProgressBinding())
@@ -33,7 +34,15 @@ class RecordableTab(
         }
     }
 
-    fun hasRecordable(): Boolean = viewModel.recordable != null
+    fun bindProperties() {
+        textProperty().bind(viewModel.labelProperty)
+        recordableProperty.bind(viewModel.recordableProperty)
+    }
+
+    fun unbindProperties() {
+        textProperty().unbind()
+        recordableProperty.unbind()
+    }
 
     private fun callOnTabSelect() {
         viewModel.recordable?.let { onTabSelect(it) }


### PR DESCRIPTION
…to the resource group with two resources didn't render tabs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/otter/105)
<!-- Reviewable:end -->
