### PR TITLE
Add a total frames field to WavFile

### DIFF
--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/io/wav/WavFile.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/io/wav/WavFile.kt
@@ -41,6 +41,9 @@ class WavFile private constructor() {
         private set
     val frameSizeInBytes = channels * (bitsPerSample / 8)
 
+    val totalFrames: Int
+        get() = totalAudioLength / frameSizeInBytes
+
     internal var totalAudioLength = 0
     internal var totalDataLength = 0
 


### PR DESCRIPTION
Adds a field to return the total frames in the audio file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/otter/132)
<!-- Reviewable:end -->
