### PR TITLE
Move audio in common

### DIFF
--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/audio/AudioFileReader.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/audio/AudioFileReader.kt
@@ -1,4 +1,4 @@
-package org.wycliffeassociates.otter.common.io
+package org.wycliffeassociates.otter.common.audio
 
 interface AudioFileReader {
     val sampleRate: Int

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/BufferExtensions.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/BufferExtensions.kt
@@ -1,4 +1,4 @@
-package org.wycliffeassociates.otter.common.io.wav
+package org.wycliffeassociates.otter.common.audio.wav
 
 import java.nio.BufferUnderflowException
 import java.nio.ByteBuffer

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/CueChunk.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/CueChunk.kt
@@ -1,4 +1,4 @@
-package org.wycliffeassociates.otter.common.io.wav
+package org.wycliffeassociates.otter.common.audio.wav
 
 import java.nio.ByteBuffer
 import java.nio.ByteOrder

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/CueChunk.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/CueChunk.kt
@@ -172,8 +172,7 @@ class CueChunk : RiffChunk {
             when (subchunkLabel) {
                 LIST_LABEL -> parseLabels(buffer, cueListBuilder)
                 CUE_LABEL -> parseCue(buffer, cueListBuilder)
-                else -> {
-                }
+                else -> Unit
             }
 
             // move on to the next chunk

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/CueChunk.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/CueChunk.kt
@@ -67,7 +67,7 @@ class CueChunk : RiffChunk {
     override val totalSize: Int
         get(): Int {
             return if (cues.isNotEmpty()) {
-                val totalCueChunk = CHUNK_LABEL_SIZE + cueChunkSize
+                val totalCueChunk = CHUNK_HEADER_SIZE + cueChunkSize
                 // adds 1 to cue size for the extra chunk header and label
                 // that the list chunk adds as overhead
                 val totalLabelChunk =

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/IWaveFileCreator.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/IWaveFileCreator.kt
@@ -1,4 +1,4 @@
-package org.wycliffeassociates.otter.common.io.wav
+package org.wycliffeassociates.otter.common.audio.wav
 
 import java.io.File
 

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/RiffChunk.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/RiffChunk.kt
@@ -1,4 +1,4 @@
-package org.wycliffeassociates.otter.common.io.wav
+package org.wycliffeassociates.otter.common.audio.wav
 
 import java.nio.ByteBuffer
 

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/RiffChunk.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/RiffChunk.kt
@@ -2,6 +2,10 @@ package org.wycliffeassociates.otter.common.audio.wav
 
 import java.nio.ByteBuffer
 
+internal const val CHUNK_HEADER_SIZE = 8
+internal const val CHUNK_LABEL_SIZE = 4
+internal const val DWORD_SIZE = 4
+
 interface RiffChunk {
     fun parse(chunk: ByteBuffer)
     fun toByteArray(): ByteArray

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/WavCue.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/WavCue.kt
@@ -1,4 +1,4 @@
-package org.wycliffeassociates.otter.common.io.wav
+package org.wycliffeassociates.otter.common.audio.wav
 
 data class WavCue(
     val location: Int,

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/WavFile.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/WavFile.kt
@@ -19,9 +19,7 @@ const val DEFAULT_SAMPLE_RATE = 44100
 private const val DEFAULT_CHANNELS = 1
 private const val DEFAULT_BITS_PER_SAMPLE = 16
 
-internal const val HEADER_SIZE = 44
-private const val CHUNK_HEADER_SIZE = 8
-private const val CHUNK_LABEL_SIZE = 4
+internal const val WAV_HEADER_SIZE = 44
 private const val AUDIO_LENGTH_LOCATION = 40
 private const val PCM_POSITION = 20
 private const val CHANNEL_POSITION = 22
@@ -103,11 +101,11 @@ class WavFile private constructor() {
     @Throws(IOException::class)
     fun finishWrite(totalAudioLength: Int) {
         this.totalAudioLength = totalAudioLength
-        this.totalDataLength = HEADER_SIZE - CHUNK_HEADER_SIZE + totalAudioLength + metadata.totalSize
+        this.totalDataLength = WAV_HEADER_SIZE - CHUNK_HEADER_SIZE + totalAudioLength + metadata.totalSize
     }
 
     fun initializeWavFile() {
-        totalDataLength = HEADER_SIZE - CHUNK_HEADER_SIZE
+        totalDataLength = WAV_HEADER_SIZE - CHUNK_HEADER_SIZE
         totalAudioLength = 0
 
         FileOutputStream(file, false).use {
@@ -117,7 +115,7 @@ class WavFile private constructor() {
 
     // http://soundfile.sapp.org/doc/WaveFormat/ for equations
     private fun generateHeaderArray(): ByteArray {
-        val header = ByteBuffer.allocate(HEADER_SIZE)
+        val header = ByteBuffer.allocate(WAV_HEADER_SIZE)
         val longSampleRate = sampleRate
         val byteRate = (bitsPerSample * sampleRate * channels) / BITS_IN_BYTE
 
@@ -143,9 +141,9 @@ class WavFile private constructor() {
 
     @Throws(InvalidWavFileException::class)
     private fun parseHeader() {
-        if (file.length() >= HEADER_SIZE) {
+        if (file.length() >= WAV_HEADER_SIZE) {
             RandomAccessFile(file, "r").use {
-                val header = ByteArray(HEADER_SIZE)
+                val header = ByteArray(WAV_HEADER_SIZE)
                 it.read(header)
                 val bb = ByteBuffer.wrap(header)
                 bb.order(ByteOrder.LITTLE_ENDIAN)
@@ -172,11 +170,11 @@ class WavFile private constructor() {
     }
 
     private fun parseMetadata() {
-        if (totalDataLength > totalAudioLength + (HEADER_SIZE - CHUNK_HEADER_SIZE)) {
-            val metadataSize = totalDataLength - totalAudioLength - (HEADER_SIZE - CHUNK_HEADER_SIZE)
+        if (totalDataLength > totalAudioLength + (WAV_HEADER_SIZE - CHUNK_HEADER_SIZE)) {
+            val metadataSize = totalDataLength - totalAudioLength - (WAV_HEADER_SIZE - CHUNK_HEADER_SIZE)
             val bytes = ByteArray(metadataSize)
             file.inputStream().use {
-                val metadataStart = HEADER_SIZE + totalAudioLength
+                val metadataStart = WAV_HEADER_SIZE + totalAudioLength
                 it.skip(metadataStart.toLong())
                 it.read(bytes)
             }

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/WavFile.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/WavFile.kt
@@ -1,4 +1,4 @@
-package org.wycliffeassociates.otter.common.io.wav
+package org.wycliffeassociates.otter.common.audio.wav
 
 import java.io.*
 import java.lang.Exception

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/WavFile.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/WavFile.kt
@@ -1,6 +1,10 @@
 package org.wycliffeassociates.otter.common.audio.wav
 
-import java.io.*
+import java.io.File
+import java.io.OutputStream
+import java.io.FileOutputStream
+import java.io.RandomAccessFile
+import java.io.IOException
 import java.lang.Exception
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
@@ -17,11 +21,13 @@ private const val DEFAULT_BITS_PER_SAMPLE = 16
 
 internal const val HEADER_SIZE = 44
 private const val CHUNK_HEADER_SIZE = 8
+private const val CHUNK_LABEL_SIZE = 4
 private const val AUDIO_LENGTH_LOCATION = 40
 private const val PCM_POSITION = 20
 private const val CHANNEL_POSITION = 22
 private const val SAMPLE_RATE_POSITION = 24
 private const val BITS_PER_SAMPLE_POSITION = 34
+private const val BITS_IN_BYTE = 8
 
 class InvalidWavFileException(message: String? = null) : Exception(message)
 
@@ -39,7 +45,7 @@ class WavFile private constructor() {
         private set
     var bitsPerSample: Int = DEFAULT_BITS_PER_SAMPLE
         private set
-    val frameSizeInBytes = channels * (bitsPerSample / 8)
+    val frameSizeInBytes = channels * (bitsPerSample / BITS_IN_BYTE)
 
     val totalFrames: Int
         get() = totalAudioLength / frameSizeInBytes
@@ -113,7 +119,7 @@ class WavFile private constructor() {
     private fun generateHeaderArray(): ByteArray {
         val header = ByteBuffer.allocate(HEADER_SIZE)
         val longSampleRate = sampleRate
-        val byteRate = (bitsPerSample * sampleRate * channels) / 8
+        val byteRate = (bitsPerSample * sampleRate * channels) / BITS_IN_BYTE
 
         header.order(ByteOrder.LITTLE_ENDIAN)
         header.put(RIFF.toByteArray(Charsets.US_ASCII))
@@ -125,7 +131,7 @@ class WavFile private constructor() {
         header.putShort(channels.toShort()) // number of channels
         header.putInt(longSampleRate)
         header.putInt(byteRate)
-        header.putShort(((channels * bitsPerSample) / 8).toShort()) // block align
+        header.putShort(((channels * bitsPerSample) / BITS_IN_BYTE).toShort()) // block align
         header.putShort(bitsPerSample.toShort()) // bits per sample
         header.put(DATA.toByteArray(Charsets.US_ASCII))
         header.putInt(totalAudioLength) // initial size
@@ -143,10 +149,10 @@ class WavFile private constructor() {
                 it.read(header)
                 val bb = ByteBuffer.wrap(header)
                 bb.order(ByteOrder.LITTLE_ENDIAN)
-                val riff = bb.getText(4)
+                val riff = bb.getText(CHUNK_LABEL_SIZE)
                 this.totalDataLength = bb.int
-                val wave = bb.getText(4)
-                val fmt = bb.getText(4)
+                val wave = bb.getText(CHUNK_LABEL_SIZE)
+                val fmt = bb.getText(CHUNK_LABEL_SIZE)
                 bb.position(PCM_POSITION)
                 val pcm = bb.short
                 channels = bb.short.toInt()
@@ -166,8 +172,8 @@ class WavFile private constructor() {
     }
 
     private fun parseMetadata() {
-        if (totalDataLength > totalAudioLength + 36) {
-            val metadataSize = totalDataLength - totalAudioLength - 36
+        if (totalDataLength > totalAudioLength + (HEADER_SIZE - CHUNK_HEADER_SIZE)) {
+            val metadataSize = totalDataLength - totalAudioLength - (HEADER_SIZE - CHUNK_HEADER_SIZE)
             val bytes = ByteArray(metadataSize)
             file.inputStream().use {
                 val metadataStart = HEADER_SIZE + totalAudioLength

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/WavFileReader.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/WavFileReader.kt
@@ -23,9 +23,9 @@ class WavFileReader(val wav: WavFile, val start: Int? = null, val end: Int? = nu
         var begin = if (start != null) min(max(0, start), totalFrames) else 0
         var end = if (end != null) min(max(begin, end), totalFrames) else totalFrames
         begin *= wav.frameSizeInBytes
-        begin += 44
+        begin += HEADER_SIZE
         end *= wav.frameSizeInBytes
-        end += 44
+        end += HEADER_SIZE
         mappedFile =
             RandomAccessFile(wav.file, "r").use {
                 it.channel.map(

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/WavFileReader.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/WavFileReader.kt
@@ -23,9 +23,9 @@ class WavFileReader(val wav: WavFile, val start: Int? = null, val end: Int? = nu
         var begin = if (start != null) min(max(0, start), totalFrames) else 0
         var end = if (end != null) min(max(begin, end), totalFrames) else totalFrames
         begin *= wav.frameSizeInBytes
-        begin += HEADER_SIZE
+        begin += WAV_HEADER_SIZE
         end *= wav.frameSizeInBytes
-        end += HEADER_SIZE
+        end += WAV_HEADER_SIZE
         mappedFile =
             RandomAccessFile(wav.file, "r").use {
                 it.channel.map(

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/WavFileReader.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/WavFileReader.kt
@@ -1,13 +1,14 @@
-package org.wycliffeassociates.otter.common.io.wav
+package org.wycliffeassociates.otter.common.audio.wav
 
-import org.wycliffeassociates.otter.common.io.AudioFileReader
+import org.wycliffeassociates.otter.common.audio.AudioFileReader
 import java.io.RandomAccessFile
 import java.lang.Integer.max
 import java.lang.Integer.min
 import java.nio.MappedByteBuffer
 import java.nio.channels.FileChannel
 
-class WavFileReader(val wav: WavFile, val start: Int? = null, val end: Int? = null) : AudioFileReader {
+class WavFileReader(val wav: WavFile, val start: Int? = null, val end: Int? = null) :
+    AudioFileReader {
 
     override val sampleRate: Int = wav.sampleRate
     override val channels: Int = wav.channels

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/WavMetadata.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/WavMetadata.kt
@@ -1,4 +1,4 @@
-package org.wycliffeassociates.otter.common.io.wav
+package org.wycliffeassociates.otter.common.audio.wav
 
 import java.io.OutputStream
 import java.nio.ByteBuffer

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/WavOutputStream.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/WavOutputStream.kt
@@ -1,4 +1,4 @@
-package org.wycliffeassociates.otter.common.io.wav
+package org.wycliffeassociates.otter.common.audio.wav
 
 import java.io.BufferedOutputStream
 import java.io.Closeable

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/WavOutputStream.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/WavOutputStream.kt
@@ -36,7 +36,7 @@ class WavOutputStream @Throws(FileNotFoundException::class)
             FileOutputStream(wav.file, true)
                 .channel
                 .truncate(
-                    (whereToTruncate + HEADER_SIZE).toLong()
+                    (whereToTruncate + WAV_HEADER_SIZE).toLong()
                 )
         } catch (e: IOException) {
             e.printStackTrace()
@@ -95,19 +95,19 @@ class WavOutputStream @Throws(FileNotFoundException::class)
     @Throws(IOException::class)
     internal fun updateHeader() {
         // file size minus riff size chunks
-        val totalDataSize = wav.file.length() - 8
-        val bb = ByteBuffer.allocate(4)
+        val totalDataSize = wav.file.length() - CHUNK_HEADER_SIZE
+        val bb = ByteBuffer.allocate(DWORD_SIZE)
         bb.order(ByteOrder.LITTLE_ENDIAN)
         bb.putInt(totalDataSize.toInt())
         RandomAccessFile(wav.file, "rw").use { raf ->
             // move to total file size index
-            raf.seek(4)
+            raf.seek(DWORD_SIZE.toLong())
             raf.write(bb.array())
             bb.clear()
             bb.order(ByteOrder.LITTLE_ENDIAN)
             bb.putInt(audioDataLength)
             // move to audio size index
-            raf.seek(40)
+            raf.seek((WAV_HEADER_SIZE - CHUNK_LABEL_SIZE).toLong())
             raf.write(bb.array())
             raf.close()
         }

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/content/RecordTake.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/content/RecordTake.kt
@@ -5,8 +5,8 @@ import org.wycliffeassociates.otter.common.data.PluginParameters
 import org.wycliffeassociates.otter.common.data.model.MimeType
 import org.wycliffeassociates.otter.common.data.workbook.*
 import org.wycliffeassociates.otter.common.domain.plugins.LaunchPlugin
-import org.wycliffeassociates.otter.common.io.wav.EMPTY_WAVE_FILE_SIZE
-import org.wycliffeassociates.otter.common.io.wav.IWaveFileCreator
+import org.wycliffeassociates.otter.common.audio.wav.EMPTY_WAVE_FILE_SIZE
+import org.wycliffeassociates.otter.common.audio.wav.IWaveFileCreator
 import java.io.File
 import java.time.LocalDate
 

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/SourceAudioAccessor.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/SourceAudioAccessor.kt
@@ -1,7 +1,7 @@
 package org.wycliffeassociates.otter.common.domain.resourcecontainer
 
 import org.wycliffeassociates.otter.common.data.model.ResourceMetadata
-import org.wycliffeassociates.otter.common.io.wav.WavFile
+import org.wycliffeassociates.otter.common.audio.wav.WavFile
 import org.wycliffeassociates.resourcecontainer.ResourceContainer
 import org.wycliffeassociates.resourcecontainer.entity.Media
 import java.io.File

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/recorder/ActiveRecordingRenderer.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/recorder/ActiveRecordingRenderer.kt
@@ -3,7 +3,7 @@ package org.wycliffeassociates.otter.common.recorder
 import io.reactivex.Observable
 import io.reactivex.schedulers.Schedulers
 import org.wycliffeassociates.otter.common.collections.FloatRingBuffer
-import org.wycliffeassociates.otter.common.io.wav.DEFAULT_SAMPLE_RATE
+import org.wycliffeassociates.otter.common.audio.wav.DEFAULT_SAMPLE_RATE
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/recorder/WavFileWriter.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/recorder/WavFileWriter.kt
@@ -2,8 +2,8 @@ package org.wycliffeassociates.otter.common.recorder
 
 import io.reactivex.Observable
 import io.reactivex.schedulers.Schedulers
-import org.wycliffeassociates.otter.common.io.wav.WavFile
-import org.wycliffeassociates.otter.common.io.wav.WavOutputStream
+import org.wycliffeassociates.otter.common.audio.wav.WavFile
+import org.wycliffeassociates.otter.common.audio.wav.WavOutputStream
 
 class WavFileWriter(
     private val wav: WavFile,

--- a/common/src/test/kotlin/org/wycliffeassociates/otter/common/audio/wav/CueChunkTest.kt
+++ b/common/src/test/kotlin/org/wycliffeassociates/otter/common/audio/wav/CueChunkTest.kt
@@ -1,4 +1,4 @@
-package org.wycliffeassociates.otter.common.io.wav
+package org.wycliffeassociates.otter.common.audio.wav
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue

--- a/common/src/test/kotlin/org/wycliffeassociates/otter/common/domain/content/RecordTakeTest.kt
+++ b/common/src/test/kotlin/org/wycliffeassociates/otter/common/domain/content/RecordTakeTest.kt
@@ -6,7 +6,7 @@ import org.wycliffeassociates.otter.common.data.model.MimeType
 import org.wycliffeassociates.otter.common.data.workbook.Take
 import org.wycliffeassociates.otter.common.doAssertEquals
 import org.wycliffeassociates.otter.common.domain.plugins.LaunchPlugin
-import org.wycliffeassociates.otter.common.io.wav.EMPTY_WAVE_FILE_SIZE
+import org.wycliffeassociates.otter.common.audio.wav.EMPTY_WAVE_FILE_SIZE
 import java.io.File
 import java.time.LocalDate
 

--- a/jvm/device/src/main/kotlin/org/wycliffeassociates/otter/jvm/device/audio/AudioBufferPlayer.kt
+++ b/jvm/device/src/main/kotlin/org/wycliffeassociates/otter/jvm/device/audio/AudioBufferPlayer.kt
@@ -3,9 +3,9 @@ package org.wycliffeassociates.otter.jvm.device.audio
 import org.wycliffeassociates.otter.common.device.AudioPlayerEvent
 import org.wycliffeassociates.otter.common.device.IAudioPlayer
 import org.wycliffeassociates.otter.common.device.IAudioPlayerListener
-import org.wycliffeassociates.otter.common.io.AudioFileReader
-import org.wycliffeassociates.otter.common.io.wav.WavFile
-import org.wycliffeassociates.otter.common.io.wav.WavFileReader
+import org.wycliffeassociates.otter.common.audio.AudioFileReader
+import org.wycliffeassociates.otter.common.audio.wav.WavFile
+import org.wycliffeassociates.otter.common.audio.wav.WavFileReader
 import java.io.File
 import javax.sound.sampled.AudioFormat
 import javax.sound.sampled.AudioSystem

--- a/jvm/markerapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/markerapp/app/model/VerseMarkers.kt
+++ b/jvm/markerapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/markerapp/app/model/VerseMarkers.kt
@@ -1,8 +1,8 @@
 package org.wycliffeassociates.otter.jvm.markerapp.app.model
 
 import javafx.beans.property.SimpleIntegerProperty
-import org.wycliffeassociates.otter.common.io.wav.WavCue
-import org.wycliffeassociates.otter.common.io.wav.WavFile
+import org.wycliffeassociates.otter.common.audio.wav.WavCue
+import org.wycliffeassociates.otter.common.audio.wav.WavFile
 import java.lang.Integer.min
 
 class VerseMarkers(private val audio: WavFile, private val markerTotal: Int) {

--- a/jvm/markerapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/markerapp/app/viewmodel/VerseMarkerViewModel.kt
+++ b/jvm/markerapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/markerapp/app/viewmodel/VerseMarkerViewModel.kt
@@ -1,10 +1,9 @@
 package org.wycliffeassociates.otter.jvm.markerapp.app.viewmodel
 
 import javafx.beans.property.SimpleBooleanProperty
-import javafx.beans.property.SimpleIntegerProperty
 import javafx.beans.property.SimpleStringProperty
 import javafx.scene.control.Slider
-import org.wycliffeassociates.otter.common.io.wav.WavFile
+import org.wycliffeassociates.otter.common.audio.wav.WavFile
 import org.wycliffeassociates.otter.jvm.controls.controllers.AudioPlayerController
 import org.wycliffeassociates.otter.jvm.device.audio.AudioBufferPlayer
 import org.wycliffeassociates.otter.jvm.markerapp.app.model.VerseMarkers

--- a/jvm/recorderapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/recorder/app/viewmodel/RecorderViewModel.kt
+++ b/jvm/recorderapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/recorder/app/viewmodel/RecorderViewModel.kt
@@ -4,7 +4,7 @@ import javafx.animation.AnimationTimer
 import javafx.beans.binding.BooleanBinding
 import javafx.beans.property.SimpleBooleanProperty
 import javafx.beans.property.SimpleStringProperty
-import org.wycliffeassociates.otter.common.io.wav.WavFile
+import org.wycliffeassociates.otter.common.audio.wav.WavFile
 import org.wycliffeassociates.otter.common.recorder.ActiveRecordingRenderer
 import org.wycliffeassociates.otter.common.recorder.RecordingTimer
 import org.wycliffeassociates.otter.common.recorder.WavFileWriter

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/io/wav/WaveFileCreator.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/io/wav/WaveFileCreator.kt
@@ -1,6 +1,6 @@
 package org.wycliffeassociates.otter.jvm.workbookapp.io.wav
 
-import org.wycliffeassociates.otter.common.io.wav.IWaveFileCreator
+import org.wycliffeassociates.otter.common.audio.wav.IWaveFileCreator
 import java.io.ByteArrayInputStream
 import java.io.File
 import javax.sound.sampled.AudioFileFormat


### PR DESCRIPTION
Moves the audio/wav package out of IO.

This will be helpful for creating a jar of just this package that can be used as a library for other audio related apps.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/otter/140)
<!-- Reviewable:end -->
