### PR TITLE
Fix numbering markers when placed

### DIFF
--- a/jvm/markerapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/markerapp/app/model/VerseMarkers.kt
+++ b/jvm/markerapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/markerapp/app/model/VerseMarkers.kt
@@ -31,10 +31,15 @@ class VerseMarkers(private val audio: WavFile, private val markerTotal: Int) {
         var index = 0
         for ((i, c) in cues.withIndex()) {
             if (c.location < location) {
-                index = i
+                index = i + 1
             }
         }
-        cues.add(index, WavCue(location, "${index+1}"))
+        cues.add(index, WavCue(location, "${index + 1}"))
+        cues.replaceAll {
+            if (it.location > location) {
+                WavCue(it.location, "${it.label.toInt() + 1}")
+            } else it
+        }
         markerCountProperty.value = cues.size
     }
 
@@ -52,7 +57,7 @@ class VerseMarkers(private val audio: WavFile, private val markerTotal: Int) {
         cues.sortBy { it.location }
         for ((i, cue) in cues.reversed().withIndex()) {
             if (location > cue.location) {
-                return cues.reversed().get(min(cues.size-1, i+1)).location
+                return cues.reversed().get(min(cues.size - 1, i + 1)).location
             }
         }
         return 0


### PR DESCRIPTION
Off by one on the index of the marker to insert.

Also adds adding one to markers after the marker being placed so that the order is correct if adding markers preceding placed markers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/otter/159)
<!-- Reviewable:end -->
