### PR TITLE
Use one recording stream for volume and writing

### DIFF
--- a/assets/src/main/kotlin/org/wycliffeassociates/otter/assets/initialization/InitializeRecorder.kt
+++ b/assets/src/main/kotlin/org/wycliffeassociates/otter/assets/initialization/InitializeRecorder.kt
@@ -19,7 +19,7 @@ class InitializeRecorder(
 ) : Installable {
 
     override val name = "RECORDER"
-    override val version = 2
+    override val version = 3
 
     val log = LoggerFactory.getLogger(InitializeRecorder::class.java)
 

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/recorder/WavFileWriter.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/recorder/WavFileWriter.kt
@@ -2,25 +2,44 @@ package org.wycliffeassociates.otter.common.recorder
 
 import io.reactivex.Observable
 import io.reactivex.schedulers.Schedulers
+import io.reactivex.subjects.PublishSubject
 import org.wycliffeassociates.otter.common.audio.wav.WavFile
 import org.wycliffeassociates.otter.common.audio.wav.WavOutputStream
+import java.util.concurrent.atomic.AtomicBoolean
 
 class WavFileWriter(
     private val wav: WavFile,
     private val audioStream: Observable<ByteArray>,
     private val onComplete: () -> Unit
 ) {
+    private var record = AtomicBoolean(false)
+    private val writingSubject = PublishSubject.create<Boolean>()
+    val isWriting = writingSubject.map { it }
+
+    fun start() {
+        record.set(true)
+        writingSubject.onNext(true)
+    }
+
+    fun pause() {
+        record.set(false)
+        writingSubject.onNext(false)
+    }
+
     val writer = Observable.using(
         {
             WavOutputStream(wav, append = false, buffered = true)
         },
         { writer ->
             audioStream.map {
-                writer.write(it)
+                if (record.get()) {
+                    writer.write(it)
+                }
             }
         },
         { writer ->
             writer.close()
+            writingSubject.onComplete()
             onComplete()
         }
     ).subscribeOn(Schedulers.io())


### PR DESCRIPTION
Use of multiple recorders was causing line exceptions due to race conditions.

This uses only one stream for both the volume bar and writing to a file, in which pausing sends a pause signal to the writer and "active" renderer, but the volume bar continues to get the recoding signal.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/otter/169)
<!-- Reviewable:end -->
