### PR TITLE
Remove onError for logging

### DIFF
--- a/assets/src/main/kotlin/org/wycliffeassociates/otter/assets/initialization/InitializeUlb.kt
+++ b/assets/src/main/kotlin/org/wycliffeassociates/otter/assets/initialization/InitializeUlb.kt
@@ -51,19 +51,17 @@ class InitializeUlb(
                         ClassLoader.getSystemResourceAsStream(EN_ULB_PATH)
                     )
                         .toObservable()
-                        .blockingSubscribe(
-                            { result ->
-                                if (result == ImportResult.SUCCESS) {
-                                    installedEntityRepo.install(this)
-                                    log.info("$name version: $version installed!")
-                                } else {
-                                    throw ImportException(result)
-                                }
-                            },
-                            { e ->
-                                log.error("Error importing $EN_ULB_FILENAME.", e)
+                        .doOnError { e ->
+                            log.error("Error importing $EN_ULB_FILENAME.", e)
+                        }
+                        .blockingSubscribe { result ->
+                            if (result == ImportResult.SUCCESS) {
+                                installedEntityRepo.install(this)
+                                log.info("$name version: $version installed!")
+                            } else {
+                                throw ImportException(result)
                             }
-                        )
+                        }
                 } else {
                     log.info("$name up to date with version: $version")
                 }

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/projectimportexport/ProjectExporter.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/projectimportexport/ProjectExporter.kt
@@ -93,14 +93,12 @@ class ProjectExporter(
         zipWriter.bufferedWriter(RcConstants.SELECTED_TAKES_FILE).use { fileWriter ->
             fetchSelectedTakes()
                 .map(::relativeTakePath)
-                .blockingSubscribe(
-                    {
+                .doOnError { e ->
+                    log.error("Error in writeSelectedTakesFile", e)
+                }
+                .blockingSubscribe{
                         fileWriter.appendln(it)
-                    },
-                    { e ->
-                        log.error("Error in writeSelectedTakesFile", e)
-                    }
-                )
+                }
         }
     }
 

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/projectimportexport/ProjectImporter.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/projectimportexport/ProjectImporter.kt
@@ -133,16 +133,14 @@ class ProjectImporter(
             .flatMap { audioDirInRc ->
                 zipFileReader.copyDirectory(audioDirInRc, audioDir, this::isAudioFile)
             }
-            .subscribe(
-                { newTakeFile ->
-                    insertTake(newTakeFile, audioDir, collectionForTakes, selectedTakes)
-                },
-                { e ->
-                    log.error("Error in importTakes, project: $project, manifestProject: $manifestProject")
-                    log.error("metadata: $metadata, sourceMetadata: $sourceMetadata")
-                    log.error("sourceCollection: $sourceCollection", e)
-                }
-            )
+            .doOnError { e ->
+                log.error("Error in importTakes, project: $project, manifestProject: $manifestProject")
+                log.error("metadata: $metadata, sourceMetadata: $sourceMetadata")
+                log.error("sourceCollection: $sourceCollection", e)
+            }
+            .subscribe { newTakeFile ->
+                insertTake(newTakeFile, audioDir, collectionForTakes, selectedTakes)
+            }
     }
 
     private fun insertTake(

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/recorder/WavFileWriter.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/recorder/WavFileWriter.kt
@@ -48,5 +48,6 @@ class WavFileWriter(
             }
         )
         .subscribeOn(Schedulers.io())
-        .subscribe({}, { e -> logger.error("Error in WavFileWriter", e) })
+        .doOnError { e -> logger.error("Error in WavFileWriter", e) }
+        .subscribe()
 }

--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/SimpleAudioPlayer.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/SimpleAudioPlayer.kt
@@ -89,16 +89,15 @@ class SimpleAudioPlayer(private val audioFile: File, private val player: IAudioP
         return Observable
             .interval(16, TimeUnit.MILLISECONDS)
             .observeOnFx()
-            .subscribe(
-                {
-                    val location = player
-                        .getAbsoluteLocationInFrames()
-                        .toDouble()
-                    progressBar.progress = location / player.getAbsoluteDurationInFrames()
-                }, { e ->
-                    logger.error("Error in starting progress update", e)
-                }
-            )
+            .doOnError { e ->
+                logger.error("Error in starting progress update", e)
+            }
+            .subscribe {
+                val location = player
+                    .getAbsoluteLocationInFrames()
+                    .toDouble()
+                progressBar.progress = location / player.getAbsoluteDurationInFrames()
+            }
     }
 }
 

--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/controllers/AudioPlayerController.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/controllers/AudioPlayerController.kt
@@ -99,16 +99,14 @@ class AudioPlayerController(
         return Observable
             .interval(ANIMATION_REFRESH_MS, TimeUnit.MILLISECONDS)
             .observeOnFx()
-            .subscribe(
-                {
-                    if (player?.isPlaying() == true && !audioSlider.isValueChanging && !dragging) {
-                        audioSlider.value = playbackPosition().toDouble()
-                    }
-                } ,
-                { e ->
-                    logger.error("Error in startProgressUpdate", e)
+            .doOnError { e ->
+                logger.error("Error in startProgressUpdate", e)
+            }
+            .subscribe {
+                if (player?.isPlaying() == true && !audioSlider.isValueChanging && !dragging) {
+                    audioSlider.value = playbackPosition().toDouble()
                 }
-            )
+            }
     }
 
     private fun play() {

--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/progressdialog/ProgressDialog.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/progressdialog/ProgressDialog.kt
@@ -32,15 +32,16 @@ class ProgressDialog : Fragment() {
                 progressindicator()
                 hbox {
                     alignment = Pos.CENTER
-                    graphicProperty.toObservable().subscribe(
-                        {
+                    graphicProperty
+                        .toObservable()
+                        .doOnError { e ->
+                            logger.error("Error in ProgressDialog", e)
+                        }
+                        .subscribe {
                             clear()
                             it.addClass(ProgressDialogStyles.progressGraphic)
                             add(it)
-                        }, { e ->
-                            logger.error("Error in ProgressDialog", e)
                         }
-                    )
                 }
             }
         }

--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/skins/waveform/WaveformSliderSkin.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/skins/waveform/WaveformSliderSkin.kt
@@ -36,8 +36,12 @@ class WaveformSliderSkin(val control: AudioSlider) : SkinBase<Slider>(control) {
             _player?.let { player ->
                 player.getAudioReader()?.let { reader ->
                     reader.seek(0)
-                    waveformImage.build(reader, 0).subscribe(
-                        { image: Image ->
+                    waveformImage
+                        .build(reader, 0)
+                        .doOnError { e ->
+                            logger.error("Error in building waveform image", e)
+                        }
+                        .subscribe { image: Image ->
                             val imageView = ImageView(image).apply {
                                 fitHeightProperty().bind(root.heightProperty())
                                 fitWidthProperty().bind(root.widthProperty())
@@ -46,11 +50,7 @@ class WaveformSliderSkin(val control: AudioSlider) : SkinBase<Slider>(control) {
                             root.getChildList()?.clear()
                             root.add(imageView)
                             root.add(thumb)
-                        },
-                        { e ->
-                            logger.error("Error in building waveform image", e)
                         }
-                    )
                 }
             }
         }

--- a/jvm/device/src/main/kotlin/org/wycliffeassociates/otter/jvm/device/audio/AudioRecorder.kt
+++ b/jvm/device/src/main/kotlin/org/wycliffeassociates/otter/jvm/device/audio/AudioRecorder.kt
@@ -54,9 +54,10 @@ class AudioRecorder : IAudioRecorder {
                 }
             }
             .subscribeOn(Schedulers.io())
-            .subscribe({}, { e ->
+            .doOnError { e ->
                 logger.error("Error while recording audio", e)
-            })
+            }
+            .subscribe()
     }
 
     override fun stop() {

--- a/jvm/markerapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/markerapp/app/view/PlaybackControlsFragment.kt
+++ b/jvm/markerapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/markerapp/app/view/PlaybackControlsFragment.kt
@@ -59,13 +59,14 @@ class PlaybackControlsFragment : Fragment() {
         styleClass.add("vm-continue-button")
         setOnAction {
             (scope as ParameterizedScope).let {
-                viewModel.writeMarkers().subscribe(
-                    {
-                        it.navigateBack()
-                    }, { e ->
+                viewModel
+                    .writeMarkers()
+                    .doOnError { e ->
                         logger.error("Error in closing the maker app", e)
                     }
-                )
+                    .subscribe {
+                        it.navigateBack()
+                    }
             }
         }
     }

--- a/jvm/recorderapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/recorder/app/view/drawables/VolumeBar.kt
+++ b/jvm/recorderapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/recorder/app/view/drawables/VolumeBar.kt
@@ -40,21 +40,20 @@ class VolumeBar(stream: Observable<ByteArray>) : Drawable {
         val bb = ByteBuffer.allocate(20480)
         bb.order(ByteOrder.LITTLE_ENDIAN)
         stream.subscribeOn(Schedulers.io())
-            .subscribe(
-                {
-                    bb.put(it)
-                    bb.position(0)
-                    var max = 0
-                    while (bb.hasRemaining()) {
-                        val db = bb.short.toInt().absoluteValue
-                        max = max(db, max)
-                    }
-                    decibleAtom = max
-                    bb.clear()
-                }, { e ->
-                    logger.error("Error in the volume bar", e)
+            .doOnError { e ->
+                logger.error("Error in the volume bar", e)
+            }
+            .subscribe {
+                bb.put(it)
+                bb.position(0)
+                var max = 0
+                while (bb.hasRemaining()) {
+                    val db = bb.short.toInt().absoluteValue
+                    max = max(db, max)
                 }
-            )
+                decibleAtom = max
+                bb.clear()
+            }
     }
 
     override fun draw(context: GraphicsContext, canvas: Canvas) {

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/controls/resourcecard/model/ResourceCardItem.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/controls/resourcecard/model/ResourceCardItem.kt
@@ -34,13 +34,12 @@ data class ResourceCardItem(val resource: Resource, val onSelect: () -> Unit) {
     private fun AssociatedAudio.progressProperty(): DoubleProperty {
         val progressProperty = SimpleDoubleProperty(0.0)
         val sub = this.selected
-            .subscribe(
-                {
-                    progressProperty.set(if (it.value != null) 1.0 else 0.0)
-                }, { e ->
-                    logger.error("Error in updating resource card progress", e)
-                }
-            )
+            .doOnError { e ->
+                logger.error("Error in updating resource card progress", e)
+            }
+            .subscribe {
+                progressProperty.set(if (it.value != null) 1.0 else 0.0)
+            }
         disposables.add(sub)
         return progressProperty
     }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/controls/resourcecard/view/ResourceGroupCard.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/controls/resourcecard/view/ResourceGroupCard.kt
@@ -24,8 +24,12 @@ class ResourceGroupCard(
         addClass(ResourceGroupCardStyles.resourceGroupCard)
         label(group.title)
 
-        group.resources.buffer(RENDER_BATCH_SIZE).subscribe(
-            { items ->
+        group.resources
+            .buffer(RENDER_BATCH_SIZE)
+            .doOnError { e ->
+                logger.error("Error in rendering resource groups", e)
+            }
+            .subscribe { items ->
                 Platform.runLater {
                     items.forEach {
                         add(
@@ -33,10 +37,7 @@ class ResourceGroupCard(
                         )
                     }
                 }
-            }, { e ->
-                logger.error("Error in rendering resource groups", e)
             }
-        )
     }
 }
 

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/controls/takecard/TakeCard.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/controls/takecard/TakeCard.kt
@@ -74,13 +74,12 @@ class TakeCard(
         val sub = playOrPauseEventObservable
             .filter { it is PlayEvent }
             .filter { it.target != this }
-            .subscribe(
-                {
-                    firePauseEvent()
-                }, { e ->
-                    logger.error("Error in take card playback event listener", e)
-                }
-            )
+            .doOnError { e ->
+                logger.error("Error in take card playback event listener", e)
+            }
+            .subscribe {
+                firePauseEvent()
+            }
         disposables.add(sub)
     }
 

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/OtterExceptionHandler.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/OtterExceptionHandler.kt
@@ -83,7 +83,8 @@ class OtterExceptionHandler : Thread.UncaughtExceptionHandler {
                                 Platform.exit()
                             }
                             .subscribeOn(Schedulers.computation())
-                            .subscribe({}, { e -> log.error("Error in showErrorDialog", e)})
+                            .doOnError { e -> log.error("Error in showErrorDialog", e)}
+                            .subscribe()
                     } else {
                         Platform.exit()
                     }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/addplugin/viewmodel/AddPluginViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/addplugin/viewmodel/AddPluginViewModel.kt
@@ -36,13 +36,12 @@ class AddPluginViewModel : ViewModel() {
         pluginRepository
             .getAll()
             .observeOnFx()
-            .subscribe(
-                { retrieved ->
-                    plugins.addAll(retrieved)
-                }, { e ->
-                    logger.error("Error in getting all plugins", e)
-                }
-            )
+            .doOnError { e ->
+                logger.error("Error in getting all plugins", e)
+            }
+            .subscribe { retrieved ->
+                plugins.addAll(retrieved)
+            }
     }
 
     fun validateName(): ValidationMessage? {
@@ -89,13 +88,12 @@ class AddPluginViewModel : ViewModel() {
                     mainMenuViewModel.selectEditor(pluginData)
                     mainMenuViewModel.refreshPlugins()
                 }
+                .doOnError { e ->
+                    logger.error("Error creating a plugin:")
+                    logger.error("Plugin name: $name, path: $path, record: $canRecord, edit: $canEdit", e)
+                }
                 .onErrorComplete()
-                .subscribe(
-                    {}, { e ->
-                        logger.error("Error creating a plugin:")
-                        logger.error("Plugin name: $name, path: $path, record: $canRecord, edit: $canEdit", e)
-                    }
-                )
+                .subscribe()
         }
     }
 }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/cardgrid/view/CardGridFragment.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/cardgrid/view/CardGridFragment.kt
@@ -62,15 +62,14 @@ class CardGridFragment : Fragment() {
                                 it.contentType == ContentType.TEXT
                             }
                             .count()
-                            .subscribe(
-                                { count ->
-                                    Platform.runLater {
-                                        chapterBanner.chunkCount.text = count.toString()
-                                    }
-                                }, { e ->
-                                    logger.error("Error in setting chapter banner chunk count", e)
+                            .doOnError { e ->
+                                logger.error("Error in setting chapter banner chunk count", e)
+                            }
+                            .subscribe { count ->
+                                Platform.runLater {
+                                    chapterBanner.chunkCount.text = count.toString()
                                 }
-                            )
+                            }
                         openButton.setOnMouseClicked {
                             viewModel.onCardSelection(CardData(chapter))
                             navigator.navigateTo(TabGroupType.RECORD_SCRIPTURE)

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/projectwizard/view/fragments/SelectLanguage.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/projectwizard/view/fragments/SelectLanguage.kt
@@ -58,14 +58,15 @@ class SelectLanguage : Fragment() {
             }
             searchField.promptText = messages["languageSearchPrompt"]
             autoSelect = true
-            viewModel.clearLanguages.subscribe(
-                {
-                    searchField.clear()
-                    listView.selectionModel.clearSelection()
-                }, { e ->
+            viewModel
+                .clearLanguages
+                .doOnError { e ->
                     logger.error("Error in clear languages", e)
                 }
-            )
+                .subscribe {
+                    searchField.clear()
+                    listView.selectionModel.clearSelection()
+                }
             selectedLanguage.addValidator(searchField) {
                 if (it == null) error(errorMessage) else null
             }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/removeplugins/viewmodel/RemovePluginsViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/removeplugins/viewmodel/RemovePluginsViewModel.kt
@@ -30,13 +30,12 @@ class RemovePluginsViewModel : ViewModel() {
         pluginRepository
             .getAll()
             .observeOnFx()
-            .subscribe(
-                { pluginData ->
-                    plugins.addAll(pluginData)
-                }, { e ->
-                    logger.error("Error in refreshing plugins", e)
-                }
-            )
+            .doOnError { e ->
+                logger.error("Error in refreshing plugins", e)
+            }
+            .subscribe { pluginData ->
+                plugins.addAll(pluginData)
+            }
     }
 
     fun remove(plugin: AudioPluginData) {

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/resourcetakes/viewmodel/RecordResourceViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/resourcetakes/viewmodel/RecordResourceViewModel.kt
@@ -169,13 +169,14 @@ class RecordResourceViewModel : ViewModel() {
                     resourceListViewModel.setActiveChunkAndRecordables(activeChunk, it)
                 } ?: run {
                     nextGroupCardItem()?.let { nextItem ->
-                        nextItem.resources.firstElement().subscribe(
-                            {
-                                resourceListViewModel.setActiveChunkAndRecordables(nextItem.bookElement, it.resource)
-                            }, { e ->
+                        nextItem.resources
+                            .firstElement()
+                            .doOnError { e ->
                                 logger.error("Error in step to chunk, direction: $direction", e)
                             }
-                        )
+                            .subscribe {
+                                resourceListViewModel.setActiveChunkAndRecordables(nextItem.bookElement, it.resource)
+                            }
                     }
                 }
             }
@@ -184,16 +185,17 @@ class RecordResourceViewModel : ViewModel() {
                     resourceListViewModel.setActiveChunkAndRecordables(activeChunk, it)
                 } ?: run {
                     previousGroupCardItem()?.let { previousItem ->
-                        previousItem.resources.lastElement().subscribe(
-                            {
-                                resourceListViewModel.setActiveChunkAndRecordables(
-                                    previousItem.bookElement,
-                                    it.resource
-                                )
-                            }, { e ->
+                        previousItem.resources
+                            .lastElement()
+                            .doOnError { e ->
                                 logger.error("Error in step to chunk, direction, $direction", e)
                             }
-                        )
+                            .subscribe {
+                            resourceListViewModel.setActiveChunkAndRecordables(
+                                previousItem.bookElement,
+                                it.resource
+                            )
+                        }
                     }
                 }
             }
@@ -211,15 +213,14 @@ class RecordResourceViewModel : ViewModel() {
         activeResourceSubscription = resources
             .toList()
             .observeOnFx()
-            .subscribe(
-                { list ->
-                    list.forEach {
-                        resourceList.add(it.resource)
-                    }
-                }, { e ->
-                    logger.error("Error in get resource list", e)
+            .doOnError { e ->
+                logger.error("Error in get resource list", e)
+            }
+            .subscribe { list ->
+                list.forEach {
+                    resourceList.add(it.resource)
                 }
-            )
+            }
     }
 
     private fun nextResource(): Resource? {

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/resourcetakes/viewmodel/RecordResourceViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/resourcetakes/viewmodel/RecordResourceViewModel.kt
@@ -191,11 +191,11 @@ class RecordResourceViewModel : ViewModel() {
                                 logger.error("Error in step to chunk, direction, $direction", e)
                             }
                             .subscribe {
-                            resourceListViewModel.setActiveChunkAndRecordables(
-                                previousItem.bookElement,
-                                it.resource
-                            )
-                        }
+                                resourceListViewModel.setActiveChunkAndRecordables(
+                                    previousItem.bookElement,
+                                    it.resource
+                                )
+                            }
                     }
                 }
             }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/takemanagement/view/RecordableFragment.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/takemanagement/view/RecordableFragment.kt
@@ -117,8 +117,12 @@ abstract class RecordableFragment(
         // TODO: This doesn't actually handle anything correctly. Need to know whether the user
         // TODO... hasn't selected an editor or recorder and respond appropriately.
         val snackBar = JFXSnackbar(pane)
-        recordableViewModel.snackBarObservable.subscribe(
-            {
+        recordableViewModel
+            .snackBarObservable
+            .doOnError { e ->
+                logger.error("Error in creating no plugin snackbar", e)
+            }
+            .subscribe {
                 snackBar.enqueue(
                     JFXSnackbar.SnackbarEvent(
                         JFXSnackbarLayout(
@@ -132,10 +136,7 @@ abstract class RecordableFragment(
                         null
                     )
                 )
-            }, { e ->
-                logger.error("Error in creating no plugin snackbar", e)
             }
-        )
     }
 
     private fun createAudioPluginProgressDialog() {

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/takemanagement/viewmodel/RecordScriptureViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/takemanagement/viewmodel/RecordScriptureViewModel.kt
@@ -109,13 +109,12 @@ class RecordScriptureViewModel : ViewModel() {
             .toList()
             .map { it.sortedBy { chunk -> chunk.start } }
             .observeOnFx()
-            .subscribe(
-                { list ->
-                    chunkList.setAll(list)
-                }, { e ->
-                    logger.error("Error in getting the chunk list", e)
-                }
-            )
+            .doOnError { e ->
+                logger.error("Error in getting the chunk list", e)
+            }
+            .subscribe { list ->
+                chunkList.setAll(list)
+            }
     }
 
     private fun stepToChunk(direction: StepDirection) {


### PR DESCRIPTION
onError closes the stream and does catches the exception, which could cause unintended bugs, as onerror should be handled specific to each case.

Replaces them with onError for logging

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/otter/175)
<!-- Reviewable:end -->
