### PR TITLE
Return result when no plugin found

### DIFF
--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/takemanagement/viewmodel/RecordableViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/takemanagement/viewmodel/RecordableViewModel.kt
@@ -111,6 +111,7 @@ open class RecordableViewModel(
                 .doOnError { e ->
                     logger.error("Error in recording a new take", e)
                 }
+                .onErrorReturn { RecordTake.Result.NO_RECORDER }
                 .subscribe { result: RecordTake.Result ->
                     showPluginActive = false
                     when (result) {
@@ -135,6 +136,7 @@ open class RecordableViewModel(
             .doOnError { e ->
                 logger.error("Error in editing take", e)
             }
+            .onErrorReturn { EditTake.Result.NO_EDITOR }
             .subscribe { result: EditTake.Result ->
                 showPluginActive = false
                 currentTakeNumberProperty.set(null)


### PR DESCRIPTION
Returns the result of no editor or recorder if a plugin is launched that doesn't exist which then triggers a snackbar to request adding a plugin

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/otter/176)
<!-- Reviewable:end -->
