### PR TITLE
Add text/usfm3 to mimetype list

### DIFF
--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/data/model/MimeType.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/data/model/MimeType.kt
@@ -3,7 +3,7 @@ package org.wycliffeassociates.otter.common.data.model
 import java.lang.IllegalArgumentException
 
 enum class MimeType(vararg types: String) {
-    USFM("text/usfm", "text/x-usfm", "usfm"),
+    USFM("text/usfm", "text/x-usfm", "text/usfm3", "usfm"),
     MARKDOWN("text/markdown", "text/x-markdown", "markdown"),
     WAV("audio/wav", "audio/wave", "audio/x-wave", "audio/vnd.wave");
 

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/ImportResourceContainer.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/ImportResourceContainer.kt
@@ -224,11 +224,15 @@ class ImportResourceContainer(
 
     /** @throws ImportException */
     private fun constructContainerTree(container: ResourceContainer): OtterTree<CollectionOrContent> {
-        val projectReader = IProjectReader.build(
-            format = container.manifest.dublinCore.format,
-            isHelp = ContainerType.of(container.manifest.dublinCore.type) == ContainerType.Help
-        )
-            ?: throw ImportException(ImportResult.UNSUPPORTED_CONTENT)
+        val projectReader = try {
+            IProjectReader.build(
+                format = container.manifest.dublinCore.format,
+                isHelp = ContainerType.of(container.manifest.dublinCore.type) == ContainerType.Help
+            )
+        } catch (e: IllegalArgumentException) {
+            logger.error("Error Importing project of type: ${container.manifest.dublinCore.format}", e)
+            null
+        } ?: throw ImportException(ImportResult.UNSUPPORTED_CONTENT)
 
         val root = OtterTree<CollectionOrContent>(container.toCollection())
         val categoryInfo = container.otterConfigCategories()


### PR DESCRIPTION
French Louis Segond 1910 Bible was causing crashes on import due to the listed mimetype being usfm3 (which the parser should be able to handle).

This adds text/usfm3 to the supported mimetype list and also catches the exception to throw an Import Exception rather than crashing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/otter/178)
<!-- Reviewable:end -->
