### PR TITLE
Change default project card colors

### DIFF
--- a/jvm/controls/src/main/resources/org/wycliffeassociates/otter/jvm/controls/skins/cards/ProjectCard.fxml
+++ b/jvm/controls/src/main/resources/org/wycliffeassociates/otter/jvm/controls/skins/cards/ProjectCard.fxml
@@ -31,10 +31,10 @@
             <Insets bottom="8.0" left="8.0" right="8.0" top="8.0" />
          </VBox.margin>
       </HBox>
-      <StackPane prefHeight="128.0" prefWidth="176.0" style="-fx-background-color: ffc0cb;">
+      <StackPane prefHeight="128.0" prefWidth="176.0" style="-fx-background-color: #015ad932;">
          <children>
             <ImageView fx:id="coverArt" pickOnBounds="true" preserveRatio="true" />
-            <Text fx:id="bookSlug" fill="#8d1919" strokeType="OUTSIDE" strokeWidth="0.0" text="Slug">
+            <Text fx:id="bookSlug" fill="#0a3373" strokeType="OUTSIDE" strokeWidth="0.0" text="Slug">
                <font>
                   <Font size="72.0" />
                </font>


### PR DESCRIPTION
Matches the blue in the new UI as opposed to the red from before

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/otter/182)
<!-- Reviewable:end -->
