### PR TITLE
Scale waveform image to height on creation

### DIFF
--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/waveform/WaveformImageBuilder.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/waveform/WaveformImageBuilder.kt
@@ -16,30 +16,35 @@ import kotlin.math.max
 
 const val SIGNED_SHORT_MAX = 32767
 
-class WaveformImageBuilder {
+class WaveformImageBuilder(
+    private val wavColor: Color = Color.BLACK,
+    private val background: Color = Color.TRANSPARENT,
+    private val paddingColor: Color = background
+) {
     private val logger = LoggerFactory.getLogger(WaveformImageBuilder::class.java)
 
     fun build(
         reader: AudioFileReader,
-        padding: Int,
+        padding: Int = 0,
+        fitToAudioMax: Boolean = true,
         width: Int = Screen.getMainScreen().platformWidth,
-        height: Int = Screen.getMainScreen().platformHeight,
-        wavColor: Color = Color.BLACK,
-        background: Color = Color.TRANSPARENT
+        height: Int = Screen.getMainScreen().platformHeight
     ): Single<Image> {
         return Single
             .fromCallable {
                 if (width > 0) {
                     val img = WritableImage(width + (2 * padding), height)
-                    val (globalMin, globalMax) = drawWaveform(img, reader, width, height, background, wavColor)
+                    val (globalMin, globalMax) = drawWaveform(img, reader, width, height, padding)
                     val newHeight = globalMax - globalMin
-                    val image2 = WritableImage(
-                        img.pixelReader,
-                        0,
-                        globalMin - newHeight,
-                        width, (newHeight) * 2
-                    )
-                    image2 as Image
+                    if (fitToAudioMax) {
+                        val image2 = WritableImage(
+                            img.pixelReader,
+                            0,
+                            globalMin - newHeight,
+                            width + (padding * 2), (newHeight) * 2
+                        )
+                        image2 as Image
+                    } else img as Image
                 } else {
                     WritableImage(1, 1) as Image
                 }
@@ -56,8 +61,7 @@ class WaveformImageBuilder {
         reader: AudioFileReader,
         width: Int,
         height: Int,
-        background: Color,
-        wavColor: Color
+        padding: Int
     ): Pair<Int, Int> {
         val framesPerPixel = reader.totalFrames / width
 
@@ -65,7 +69,8 @@ class WaveformImageBuilder {
         val bytes = ByteArray(framesPerPixel * 2)
         var globalMax = 1
         var globalMin = 0
-        for (i in 0 until width) {
+        addPadding(img, 0, padding, height)
+        for (i in padding until width) {
             reader.getPcmBuffer(bytes)
             val bb = ByteBuffer.wrap(bytes)
             bb.rewind()
@@ -87,7 +92,16 @@ class WaveformImageBuilder {
                 }
             }
         }
+        addPadding(img, (width + padding), (width + (padding * 2)), height)
         return Pair(scaleToHeight(globalMin, height), scaleToHeight(globalMax, height))
+    }
+
+    private fun addPadding(img: WritableImage, startX: Int, endX: Int, height: Int) {
+        for (i in startX until endX) {
+            for (j in 0 until height) {
+                img.pixelWriter.setColor(i, j, paddingColor)
+            }
+        }
     }
 
     private fun scaleToHeight(value: Int, height: Int): Int {


### PR DESCRIPTION
Rather than use the full range as a height, this scales the audio samples to a provided height;

A default is provided of the screen size

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/otter/183)
<!-- Reviewable:end -->
