### PR TITLE
Fixes refreshing source languages on wizard open

### DIFF
--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/projectwizard/viewmodel/ProjectWizardViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/projectwizard/viewmodel/ProjectWizardViewModel.kt
@@ -51,9 +51,9 @@ class ProjectWizardViewModel : ViewModel() {
     val resourceCompletedText = SimpleStringProperty()
     val bookCompletedText = SimpleStringProperty()
 
-    init {
-        initializeTargetLanguages()
-        initializeSourceLanguages()
+    fun loadLanguages() {
+        loadTargetLanguages()
+        loadSourceLanguages()
         loadProjects()
         selectedTargetLanguage
             .toObservable()
@@ -66,7 +66,8 @@ class ProjectWizardViewModel : ViewModel() {
             }
     }
 
-    private fun initializeTargetLanguages() {
+    private fun loadTargetLanguages() {
+        targetLanguages.clear()
         languageRepo
             .getAll()
             .observeOnFx()
@@ -78,7 +79,8 @@ class ProjectWizardViewModel : ViewModel() {
             }
     }
 
-    private fun initializeSourceLanguages() {
+    private fun loadSourceLanguages() {
+        sourceLanguages.clear()
         collectionRepo
             .getRootSources()
             .observeOnFx()
@@ -97,6 +99,7 @@ class ProjectWizardViewModel : ViewModel() {
     }
 
     private fun loadProjects() {
+        projects.clear()
         collectionRepo
             .getDerivedProjects()
             .doOnError { e ->
@@ -207,9 +210,9 @@ class ProjectWizardViewModel : ViewModel() {
         collectionHierarchy.clear()
         existingProjects.clear()
         creationCompletedProperty.value = false
-        loadProjects()
         languageCompletedText.set(null)
         resourceCompletedText.set(null)
+        loadLanguages()
     }
 
     fun filterLanguages(query: String?, language: Language): Boolean {


### PR DESCRIPTION
refresh is called on dock and undock, but only cleared state and refreshed projects, not languages.

This loads languages which in turn loads projects. Init is removed as it would duplicate items in the list on dock.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/otter/190)
<!-- Reviewable:end -->
