### PR TITLE
Update isDraggingProperty

### DIFF
--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/takemanagement/view/RecordScriptureFragment.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/takemanagement/view/RecordScriptureFragment.kt
@@ -83,7 +83,7 @@ class RecordScriptureFragment : RecordableFragment(
                 recordableViewModel.selectTake(db.string)
                 success = true
             }
-            (it.source as? ScriptureTakeCard)?.let {
+            (it.gestureSource as? ScriptureTakeCard)?.let {
                 it.isDraggingProperty().value = false
             }
             it.setDropCompleted(success)
@@ -98,9 +98,18 @@ class RecordScriptureFragment : RecordableFragment(
         }
 
         mainContainer.apply {
-
-            addEventHandler(DragEvent.DRAG_ENTERED, { isDraggingProperty.value = true })
-            addEventHandler(DragEvent.DRAG_EXITED, { isDraggingProperty.value = false })
+            addEventHandler(DragEvent.DRAG_ENTERED) {
+                (it.gestureSource as? ScriptureTakeCard)?.let { card ->
+                    card.isDraggingProperty().value = true
+                }
+                isDraggingProperty.value = true
+            }
+            addEventHandler(DragEvent.DRAG_EXITED) {
+                (it.gestureSource as? ScriptureTakeCard)?.let { card ->
+                    card.isDraggingProperty().value = false
+                }
+                isDraggingProperty.value = false
+            }
 
             addClass(RecordScriptureStyles.background)
 


### PR DESCRIPTION
it.source is not the scripture take card, but it.gestureSource is, so this is updated.

Also, the drag handlers are not functioning on the card, and onMouseReleased is only caught on MacOS. The event handlers on the fragment are handled properly everywhere, so the dragging property is set there. When the card is dragged outside of that container though (off screen, or to the chrome for example) the DRAG_EXITED handler is executed, effectively making the card visible on the grid afterwards while still dragging. As such the value is set to true in the DRAG_ENTERED handler, because that will fire once the user drags the card back into the fragment region.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/otter/192)
<!-- Reviewable:end -->
