### PR TITLE
Ignore space outside of the waveform min/max for slider

### DIFF
--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/skins/waveform/WaveformSliderSkin.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/skins/waveform/WaveformSliderSkin.kt
@@ -37,7 +37,7 @@ class WaveformSliderSkin(val control: AudioSlider) : SkinBase<Slider>(control) {
                 player.getAudioReader()?.let { reader ->
                     reader.seek(0)
                     waveformImage
-                        .build(reader, 0)
+                        .build(reader, fitToAudioMax = true)
                         .doOnError { e ->
                             logger.error("Error in building waveform image", e)
                         }


### PR DESCRIPTION
For the slider, this fits the waveform image to the actual highest and lowest peak so most waveforms in low-height views won't seem mostly flat (quiet)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/otter/196)
<!-- Reviewable:end -->
