### PR TITLE
return the id of the plugin being updated, not max

### DIFF
--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/persistence/database/daos/AudioPluginDao.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/persistence/database/daos/AudioPluginDao.kt
@@ -31,6 +31,7 @@ class AudioPluginDao(
                 .set(AUDIO_PLUGIN_ENTITY.PATH, entity.path)
                 .where(AUDIO_PLUGIN_ENTITY.ID.eq(id))
                 .execute()
+            return id
         } else {
             // Insert the plugin entity
             dsl


### PR DESCRIPTION
Rather than returning the id of the updated plugin, the function was returning the max id (which works for new inserts, but is wrong for updating existing entries)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/otter/201)
<!-- Reviewable:end -->
