### PR TITLE
Supresses function naming warning

### DIFF
--- a/assets/src/main/kotlin/org/wycliffeassociates/otter/assets/initialization/InitializeProjects.kt
+++ b/assets/src/main/kotlin/org/wycliffeassociates/otter/assets/initialization/InitializeProjects.kt
@@ -1,3 +1,4 @@
+@file:Suppress("FunctionNaming")
 package org.wycliffeassociates.otter.assets.initialization
 
 import io.reactivex.Completable


### PR DESCRIPTION
allow ` ` naming in migration function names

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/otter/237)
<!-- Reviewable:end -->
