### PR TITLE
Separates main from the app class

### DIFF
--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/Main.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/Main.kt
@@ -1,0 +1,8 @@
+package org.wycliffeassociates.otter.jvm.workbookapp
+
+import org.wycliffeassociates.otter.jvm.workbookapp.ui.OtterApp
+import tornadofx.launch
+
+fun main(args: Array<String>) {
+    launch<OtterApp>(args)
+}

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/OtterApp.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/OtterApp.kt
@@ -1,16 +1,16 @@
-package org.wycliffeassociates.otter.jvm.workbookapp
+package org.wycliffeassociates.otter.jvm.workbookapp.ui
 
 import javafx.scene.layout.Pane
 import javafx.stage.Stage
 import javafx.stage.StageStyle
 import org.wycliffeassociates.otter.common.persistence.IDirectoryProvider
+import org.wycliffeassociates.otter.jvm.workbookapp.SnackbarHandler
 import org.wycliffeassociates.otter.jvm.workbookapp.di.DaggerAppDependencyGraph
 import org.wycliffeassociates.otter.jvm.workbookapp.di.IDependencyGraphProvider
 import org.wycliffeassociates.otter.jvm.workbookapp.logging.ConfigureLogger
 import org.wycliffeassociates.otter.jvm.workbookapp.plugin.PluginClosedEvent
 import org.wycliffeassociates.otter.jvm.workbookapp.plugin.PluginOpenedEvent
 import org.wycliffeassociates.otter.jvm.workbookapp.theme.AppStyles
-import org.wycliffeassociates.otter.jvm.workbookapp.ui.OtterExceptionHandler
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.menu.view.MainMenu
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.screens.MainScreenView
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.screens.SplashScreen
@@ -70,8 +70,4 @@ class OtterApp : App(Workspace::class), IDependencyGraphProvider {
     override fun shouldShowPrimaryStage(): Boolean {
         return false
     }
-}
-
-fun main(args: Array<String>) {
-    launch<OtterApp>(args)
 }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/RecordableViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/RecordableViewModel.kt
@@ -19,7 +19,7 @@ import org.wycliffeassociates.otter.common.domain.content.*
 import org.wycliffeassociates.otter.common.persistence.repositories.PluginType
 import org.wycliffeassociates.otter.jvm.controls.card.events.TakeEvent
 import org.wycliffeassociates.otter.jvm.utils.onChangeAndDoNow
-import org.wycliffeassociates.otter.jvm.workbookapp.OtterApp
+import org.wycliffeassociates.otter.jvm.workbookapp.ui.OtterApp
 import org.wycliffeassociates.otter.jvm.workbookapp.plugin.PluginClosedEvent
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.model.TakeCardModel
 import tornadofx.*


### PR DESCRIPTION
Renaming the file from Main to OtterApp broke install4j launching (as the name wasn't updated in the config).

Rather than update those, Main is now in Main.kt and the OtterApp is its own class in the app package.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/otter/246)
<!-- Reviewable:end -->
