### PR TITLE
Fix null pointer exceptions on startup

### DIFF
--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/persistence/repositories/AppPreferencesRepository.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/persistence/repositories/AppPreferencesRepository.kt
@@ -80,10 +80,14 @@ class AppPreferencesRepository @Inject constructor(
     override fun localeLanguage(): Maybe<Language> {
         return preferences
             .localeLanguage()
-            .flatMap {
-                languageRepository.getBySlug(it)
-            }.flatMapMaybe {
-                Maybe.just(it)
+            .flatMapMaybe {
+                if (it.isNotEmpty()) {
+                    languageRepository
+                        .getBySlug(it)
+                        .toMaybe()
+                } else {
+                    null
+                }
             }
     }
 

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/OtterApp.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/OtterApp.kt
@@ -32,7 +32,6 @@ import org.wycliffeassociates.otter.jvm.workbookapp.ui.screens.RootView
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.screens.dialogs.SplashScreen
 import tornadofx.*
 import tornadofx.FX.Companion.messages
-import java.util.*
 import javax.inject.Inject
 
 class OtterApp : App(RootView::class), IDependencyGraphProvider {
@@ -47,7 +46,6 @@ class OtterApp : App(RootView::class), IDependencyGraphProvider {
         directoryProvider.cleanTempDirectory()
         Thread.setDefaultUncaughtExceptionHandler(OtterExceptionHandler(directoryProvider))
         initializeLogger(directoryProvider)
-        initializeAppLocale()
 
         importStylesheet<AppStyles>()
     }
@@ -56,12 +54,6 @@ class OtterApp : App(RootView::class), IDependencyGraphProvider {
         ConfigureLogger(
             directoryProvider.logsDirectory
         ).configure()
-    }
-
-    fun initializeAppLocale() {
-        FX.locale = localeLanguage.preferredLanguage?.let {
-            Locale(it.slug)
-        } ?: Locale.getDefault()
     }
 
     override fun start(stage: Stage) {

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/drawer/SettingsView.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/drawer/SettingsView.kt
@@ -92,8 +92,10 @@ class SettingsView : View() {
 
                         buttonCell = LanguageComboboxCell()
 
-                        selectionModel.selectedItemProperty().onChange {
-                            it?.let { viewModel.updateLanguage(it) }
+                        selectionModel.selectedItemProperty().addListener { observable, oldValue, newValue ->
+                            if (oldValue != null) {
+                                newValue?.let { viewModel.updateLanguage(it) }
+                            }
                         }
                     }
                 }
@@ -246,6 +248,7 @@ class SettingsView : View() {
 
     override fun onDock() {
         super.onDock()
+        viewModel.bind()
         viewModel.refreshDevices()
     }
 

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/dialogs/SplashScreen.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/dialogs/SplashScreen.kt
@@ -53,6 +53,7 @@ class SplashScreen : View() {
 
     private fun finish() {
         viewModel.initAudioSystem()
+        viewModel.initializeAppLocale()
         close()
         primaryStage.show()
         navigator.dock<HomePage>()

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/SettingsViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/SettingsViewModel.kt
@@ -77,7 +77,9 @@ class SettingsViewModel : ViewModel() {
         audioPluginViewModel.selectedEditorProperty.bind(selectedEditorProperty)
         audioPluginViewModel.selectedRecorderProperty.bind(selectedRecorderProperty)
         audioPluginViewModel.selectedMarkerProperty.bind(selectedMarkerProperty)
+    }
 
+    fun bind() {
         loadOutputDevices()
         loadInputDevices()
         loadCurrentOutputDevice()

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/SplashScreenViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/SplashScreenViewModel.kt
@@ -20,12 +20,14 @@ package org.wycliffeassociates.otter.jvm.workbookapp.ui.viewmodel
 
 import com.github.thomasnield.rxkotlinfx.observeOnFx
 import io.reactivex.Observable
+import java.util.*
 import javafx.beans.property.SimpleDoubleProperty
 import org.slf4j.LoggerFactory
 import org.wycliffeassociates.otter.assets.initialization.InitializeApp
 import org.wycliffeassociates.otter.jvm.workbookapp.di.IDependencyGraphProvider
 import tornadofx.*
 import javax.inject.Inject
+import org.wycliffeassociates.otter.common.domain.languages.LocaleLanguage
 import org.wycliffeassociates.otter.jvm.device.ConfigureAudioSystem
 
 class SplashScreenViewModel : ViewModel() {
@@ -36,6 +38,9 @@ class SplashScreenViewModel : ViewModel() {
 
     @Inject
     lateinit var configureAudioSystem: ConfigureAudioSystem
+
+    @Inject
+    lateinit var localeLanguage: LocaleLanguage
 
     val progressProperty = SimpleDoubleProperty(0.0)
 
@@ -53,5 +58,11 @@ class SplashScreenViewModel : ViewModel() {
 
     fun initAudioSystem() {
         configureAudioSystem.configure()
+    }
+
+    fun initializeAppLocale() {
+        FX.locale = localeLanguage.preferredLanguage?.let {
+            Locale(it.slug)
+        } ?: Locale.getDefault()
     }
 }


### PR DESCRIPTION
Initialization of the SettingsViewModel is happening on app start up (not when the user opens the SettingsView). As a result, the SettingsViewModel attempts to get the list of languages to configure the app locale and language options before the LanguageRepository is configured. This causes valid language slug lookups (such as "en") to return null on the first time the app is launched because parsing of langnames.json and adding entries to the database is not yet done.

As a result, App Locale initialization has been moved to the SplashScreen where other JVM platform specific initialization is happening (specifically, audio devices).

Moved most initialization of the SettingsViewModel to a bind method which is called when the SettingsView is docked.

Also fixed a Maybe function in the AppPreferencesRepository to filter out empty strings, so that when no language is selected initially, there is not an exception thrown.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/orature/385)
<!-- Reviewable:end -->
