### PR TITLE
Fix: null locale language selection when switching between app bar buttons

### DIFF
--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/drawer/SettingsView.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/drawer/SettingsView.kt
@@ -91,12 +91,6 @@ class SettingsView : View() {
                         }
 
                         buttonCell = LanguageComboboxCell()
-
-                        selectionModel.selectedItemProperty().addListener { observable, oldValue, newValue ->
-                            if (oldValue != null) {
-                                newValue?.let { viewModel.updateLanguage(it) }
-                            }
-                        }
                     }
                 }
 

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/SettingsViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/SettingsViewModel.kt
@@ -77,6 +77,11 @@ class SettingsViewModel : ViewModel() {
         audioPluginViewModel.selectedEditorProperty.bind(selectedEditorProperty)
         audioPluginViewModel.selectedRecorderProperty.bind(selectedRecorderProperty)
         audioPluginViewModel.selectedMarkerProperty.bind(selectedMarkerProperty)
+        selectedLocaleLanguageProperty.addListener { observable, oldValue, newValue ->
+            if (oldValue != null) {
+                newValue?.let { updateLanguage(it) }
+            }
+        }
     }
 
     fun bind() {


### PR DESCRIPTION
Instead of listening to the selection property of the combobox, we listen to the property of the view model which is already bound with the combobox (see below). This avoid conflicting changes when dock/undock the settings drawer, which may nullify the combobox selection.

` combobox(viewModel.selectedLocaleLanguageProperty, ... `

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/orature/400)
<!-- Reviewable:end -->
