### PR TITLE
Namespace verse markers

### DIFF
--- a/common/audio/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/CueChunk.kt
+++ b/common/audio/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/CueChunk.kt
@@ -222,14 +222,18 @@ internal class CueChunk : RiffChunk {
     }
 
     private fun separateOratureCues(allCues: List<AudioCue>) {
-        val oratureCues = allCues.filter { it.label.matches(Regex("^orature-vm-(\\d+)$")) }
+        val oratureRegex = Regex("^orature-vm-(\\d+)$")
+        val loneDigitRegex = Regex("^\\d+$")
+        val numberRegex = Regex(".*(\\d+).*")
+
+        val oratureCues = allCues.filter { it.label.matches(oratureRegex) }
         val leftoverCues = allCues.filter { !oratureCues.contains(it) }
-        val loneDigits = leftoverCues.filter { it.label.matches(Regex("^\\d+$")) }
+        val loneDigits = leftoverCues.filter { it.label.matches(loneDigitRegex) }
         val potentialCues = leftoverCues
             .filter { !loneDigits.contains(it) }
-            .filter { it.label.matches(Regex(".*(\\d+).*")) }
+            .filter { it.label.matches(numberRegex) }
             .map {
-                val match = Regex(".*(\\d+).*").find(it.label)
+                val match = numberRegex.find(it.label)
                 val label = match!!.groupValues.first()!!
                 AudioCue(it.location, label)
             }
@@ -237,7 +241,7 @@ internal class CueChunk : RiffChunk {
         if (oratureCues.isNotEmpty()) {
             cues as MutableList
             val mapped = oratureCues.map {
-                val match = Regex("^orature-vm-(\\d+)$").find(it.label)
+                val match = oratureRegex.find(it.label)
                 val label = match!!.groupValues.get(1)!!
                 AudioCue(it.location, label)
             }
@@ -247,7 +251,7 @@ internal class CueChunk : RiffChunk {
         } else if (loneDigits.isNotEmpty()) {
             cues as MutableList
             cues.addAll(loneDigits.map {
-                val match = Regex("^\\d+$").find(it.label)
+                val match = loneDigitRegex.find(it.label)
                 val label = match!!.groupValues.first()
                 AudioCue(it.location, label)
             })
@@ -256,7 +260,7 @@ internal class CueChunk : RiffChunk {
         } else if(potentialCues.isNotEmpty()){
             cues as MutableList
             cues.addAll(potentialCues.map {
-                val match = Regex(".*(\\d+).*").find(it.label)
+                val match = numberRegex.find(it.label)
                 val label = match!!.groupValues.get(1)!!
                 AudioCue(it.location, label)
             })

--- a/common/audio/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/CueChunk.kt
+++ b/common/audio/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/CueChunk.kt
@@ -207,6 +207,10 @@ internal open class CueChunk : RiffChunk {
             // move on to the next chunk
             chunk.seek(wordAlign(subchunkSize))
         }
+        addParsedCues(cueListBuilder)
+    }
+
+    open protected fun addParsedCues(cueListBuilder: CueListBuilder) {
         cues as MutableList
         cues.clear()
         cues.addAll(cueListBuilder.build())
@@ -287,7 +291,7 @@ internal open class CueChunk : RiffChunk {
     }
 }
 
-private class CueListBuilder {
+internal class CueListBuilder {
 
     private data class TempCue(var location: Int?, var label: String?)
 

--- a/common/audio/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/CueChunk.kt
+++ b/common/audio/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/CueChunk.kt
@@ -239,37 +239,29 @@ internal class CueChunk : RiffChunk {
             }
 
         if (oratureCues.isNotEmpty()) {
-            cues as MutableList
-            val mapped = oratureCues.map {
-                val match = oratureRegex.find(it.label)
-                val label = match!!.groupValues.get(1)!!
-                AudioCue(it.location, label)
-            }
-            cues.addAll(mapped)
-            extraCues as MutableList
-            extraCues.addAll(leftoverCues)
+            addMatchingCues(oratureCues, oratureRegex)
         } else if (loneDigits.isNotEmpty()) {
-            cues as MutableList
-            cues.addAll(loneDigits.map {
-                val match = loneDigitRegex.find(it.label)
-                val label = match!!.groupValues.first()
-                AudioCue(it.location, label)
-            })
-            extraCues as MutableList
-            extraCues.addAll(leftoverCues)
-        } else if(potentialCues.isNotEmpty()){
-            cues as MutableList
-            cues.addAll(potentialCues.map {
-                val match = numberRegex.find(it.label)
-                val label = match!!.groupValues.get(1)!!
-                AudioCue(it.location, label)
-            })
-            extraCues as MutableList
-            extraCues.addAll(leftoverCues)
-        } else {
-            extraCues as MutableList
-            extraCues.addAll(leftoverCues)
+            addMatchingCues(loneDigits, loneDigitRegex)
+        } else if (potentialCues.isNotEmpty()) {
+            addMatchingCues(potentialCues, numberRegex)
         }
+        extraCues as MutableList
+        extraCues.addAll(leftoverCues)
+    }
+
+    fun addMatchingCues(baseCueList: List<AudioCue>, regex: Regex) {
+        cues as MutableList
+        val mapped = baseCueList.map {
+            val match = regex.find(it.label)
+            val groups = match!!.groupValues
+            val label = if (groups.size > 1) {
+                match!!.groupValues.get(1)!!
+            } else {
+                match!!.groupValues.first()!!
+            }
+            AudioCue(it.location, label)
+        }
+        cues.addAll(mapped)
     }
 
     /**

--- a/common/audio/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/VerseMarkerChunk.kt
+++ b/common/audio/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/VerseMarkerChunk.kt
@@ -7,6 +7,11 @@ import org.wycliffeassociates.otter.common.audio.AudioCue
 internal class VerseMarkerChunk : CueChunk() {
     private val extraCues: List<AudioCue> = mutableListOf()
 
+   override fun addParsedCues(cueListBuilder: CueListBuilder) {
+       val allCues = cueListBuilder.build()
+       separateOratureCues(allCues)
+   }
+
     override fun toByteArray(): ByteArray {
         if (cues.isEmpty()) {
             return ByteArray(0)

--- a/common/audio/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/VerseMarkerChunk.kt
+++ b/common/audio/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/VerseMarkerChunk.kt
@@ -1,0 +1,81 @@
+package org.wycliffeassociates.otter.common.audio.wav
+
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import org.wycliffeassociates.otter.common.audio.AudioCue
+
+internal class VerseMarkerChunk : CueChunk() {
+    private val extraCues: List<AudioCue> = mutableListOf()
+
+    override fun toByteArray(): ByteArray {
+        if (cues.isEmpty()) {
+            return ByteArray(0)
+        }
+
+        val outputCues = mutableListOf<AudioCue>()
+        outputCues.addAll(cues.map { AudioCue(it.location, "orature-vm-${it.label}") })
+        outputCues.addAll(extraCues)
+        outputCues.sortBy { it.location }
+
+        val cueChunkBuffer = ByteBuffer.allocate(CHUNK_HEADER_SIZE + getCueChunkSize(outputCues))
+        cueChunkBuffer.order(ByteOrder.LITTLE_ENDIAN)
+        cueChunkBuffer.put(CUE_LABEL.toByteArray(Charsets.US_ASCII))
+        cueChunkBuffer.putInt(CUE_DATA_SIZE * outputCues.size + CUE_COUNT_SIZE)
+        cueChunkBuffer.putInt(outputCues.size)
+        for (i in outputCues.indices) {
+            cueChunkBuffer.put(createCueData(i, outputCues[i]))
+        }
+        val labelChunkArray = createLabelChunk(outputCues)
+        val combinedBuffer = ByteBuffer.allocate(cueChunkBuffer.capacity() + labelChunkArray.size)
+        combinedBuffer.put(cueChunkBuffer.array())
+        combinedBuffer.put(labelChunkArray)
+        return combinedBuffer.array()
+    }
+
+    private fun getCueChunkSize(cues: List<AudioCue>): Int {
+        return CUE_HEADER_SIZE + (CUE_DATA_SIZE * cues.size)
+    }
+
+    private fun separateOratureCues(allCues: List<AudioCue>) {
+        val oratureRegex = Regex("^orature-vm-(\\d+)$")
+        val loneDigitRegex = Regex("^\\d+$")
+        val numberRegex = Regex(".*(\\d+).*")
+
+        val oratureCues = allCues.filter { it.label.matches(oratureRegex) }
+        val leftoverCues = allCues.filter { !oratureCues.contains(it) }
+        val loneDigits = leftoverCues.filter { it.label.matches(loneDigitRegex) }
+        val potentialCues = leftoverCues
+            .filter { !loneDigits.contains(it) }
+            .filter { it.label.matches(numberRegex) }
+            .map {
+                val match = numberRegex.find(it.label)
+                val label = match!!.groupValues.first()!!
+                AudioCue(it.location, label)
+            }
+
+        if (oratureCues.isNotEmpty()) {
+            addMatchingCues(oratureCues, oratureRegex)
+        } else if (loneDigits.isNotEmpty()) {
+            addMatchingCues(loneDigits, loneDigitRegex)
+        } else if (potentialCues.isNotEmpty()) {
+            addMatchingCues(potentialCues, numberRegex)
+        }
+        extraCues as MutableList
+        extraCues.addAll(leftoverCues)
+    }
+
+    fun addMatchingCues(baseCueList: List<AudioCue>, regex: Regex) {
+        cues as MutableList
+        val mapped = baseCueList.map {
+            val match = regex.find(it.label)
+            val groups = match!!.groupValues
+            val label = if (groups.size > 1) {
+                match!!.groupValues.get(1)!!
+            } else {
+                match!!.groupValues.first()!!
+            }
+            AudioCue(it.location, label)
+        }
+        cues.addAll(mapped)
+    }
+}

--- a/common/audio/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/WavFile.kt
+++ b/common/audio/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/WavFile.kt
@@ -218,7 +218,7 @@ internal class WavFile private constructor() : AudioFormatStrategy {
                 }
                 metadata.parseMetadata(ByteBuffer.wrap(bytes))
             } catch (e: Exception) {
-                logger.error("Error parsing metadata for file: ${file.name}")
+                logger.error("Error parsing metadata for file: ${file.name}", e)
             }
         }
     }

--- a/common/audio/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/WavMetadata.kt
+++ b/common/audio/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/WavMetadata.kt
@@ -40,7 +40,7 @@ internal class WavMetadata(parsableChunks: List<RiffChunk>? = null) : AudioMetad
         if (cue != null) {
             cueChunk = cue as CueChunk
         } else {
-            cueChunk = CueChunk()
+            cueChunk = VerseMarkerChunk()
             chunks.add(cueChunk)
         }
     }

--- a/common/audio/src/test/kotlin/org/wycliffeassociates/otter/common/audio/wav/CueChunkTest.kt
+++ b/common/audio/src/test/kotlin/org/wycliffeassociates/otter/common/audio/wav/CueChunkTest.kt
@@ -91,7 +91,7 @@ class CueChunkTest {
                 os.use {
                     os.write(ByteArray(writeSize))
                 }
-                val validator = WavFile(file)
+                val validator = WavFile(file, WavMetadata(listOf(CueChunk())))
                 val resultMetadata = validator.metadata
                 assertEquals(cues.size, resultMetadata.getCues().size)
                 for (cue in cues) {

--- a/common/audio/src/test/kotlin/org/wycliffeassociates/otter/common/audio/wav/CueChunkTest.kt
+++ b/common/audio/src/test/kotlin/org/wycliffeassociates/otter/common/audio/wav/CueChunkTest.kt
@@ -83,7 +83,7 @@ class CueChunkTest {
             for (cues in testEnv) {
                 val file = File.createTempFile("test", "wav")
                 file.deleteOnExit()
-                val wav = WavFile(file, 1, 44100, 16)
+                val wav = WavFile(file, 1, 44100, 16, WavMetadata(listOf(CueChunk())))
                 for (cue in cues) {
                     wav.metadata.addCue(cue.location, cue.label)
                 }

--- a/common/audio/src/test/kotlin/org/wycliffeassociates/otter/common/audio/wav/VerseMarkerChunkTest.kt
+++ b/common/audio/src/test/kotlin/org/wycliffeassociates/otter/common/audio/wav/VerseMarkerChunkTest.kt
@@ -1,0 +1,173 @@
+/**
+ * Copyright (C) 2020, 2021 Wycliffe Associates
+ *
+ * This file is part of Orature.
+ *
+ * Orature is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Orature is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Orature.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package org.wycliffeassociates.otter.common.audio.wav
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+import org.wycliffeassociates.otter.common.audio.AudioCue
+
+class TestData(val initial: List<AudioCue>, val result: List<AudioCue>)
+
+class VerseMarkerChunkTest {
+
+    val testEnv = listOf(
+        TestData(
+            listOf(
+                AudioCue(1, "1"),
+                AudioCue(2, "2"),
+                AudioCue(3, "3")
+            ),
+            listOf(
+                AudioCue(1, "1"),
+                AudioCue(2, "2"),
+                AudioCue(3, "3"),
+                AudioCue(1, "orature-vm-1"),
+                AudioCue(2, "orature-vm-2"),
+                AudioCue(3, "orature-vm-3")
+            )
+        ),
+        // locations out of order
+        TestData(
+            listOf(
+                AudioCue(2, "2"),
+                AudioCue(1, "1"),
+                AudioCue(3, "3")
+            ),
+            listOf(
+                AudioCue(2, "2"),
+                AudioCue(1, "1"),
+                AudioCue(3, "3"),
+                AudioCue(2, "orature-vm-2"),
+                AudioCue(1, "orature-vm-1"),
+                AudioCue(3, "orature-vm-3")
+            )
+        ),
+        // requiring padding to get to double word aligned
+        TestData(
+            listOf(
+                AudioCue(2, "1"),
+                AudioCue(1, "12"),
+                AudioCue(3, "123"),
+                AudioCue(4, "1234")
+            ),
+            listOf(
+                AudioCue(2, "1"),
+                AudioCue(1, "12"),
+                AudioCue(3, "123"),
+                AudioCue(4, "1234"),
+                AudioCue(2, "orature-vm-1"),
+                AudioCue(1, "orature-vm-12"),
+                AudioCue(3, "orature-vm-123"),
+                AudioCue(4, "orature-vm-1234")
+            )
+        ),
+        TestData(
+            listOf(
+                AudioCue(0, "    "),
+                AudioCue(2, "Verse 2"),
+                AudioCue(3, "Marker 3   "),
+                AudioCue(4, "   Verse 4"),
+                AudioCue(Int.MAX_VALUE, " stuff5 ")
+            ),
+            listOf(
+                AudioCue(0, "    "),
+                AudioCue(2, "Verse 2"),
+                AudioCue(3, "Marker 3   "),
+                AudioCue(4, "   Verse 4"),
+                AudioCue(Int.MAX_VALUE, " stuff5 "),
+                AudioCue(2, "orature-vm-2"),
+                AudioCue(3, "orature-vm-3"),
+                AudioCue(4, "orature-vm-4"),
+                AudioCue(Int.MAX_VALUE, "orature-vm-5")
+            )
+        ),
+        // Test that only orature-vm markers are interpreted as verse markers
+        TestData(
+            listOf(
+                AudioCue(0, "orature-vm-1"),
+                AudioCue(2, "Verse 2"),
+                AudioCue(3, "Marker 3   "),
+                AudioCue(4, "   Verse 4"),
+                AudioCue(Int.MAX_VALUE, " stuff5 ")
+            ),
+            listOf(
+                AudioCue(0, "orature-vm-1"),
+                AudioCue(2, "Verse 2"),
+                AudioCue(3, "Marker 3   "),
+                AudioCue(4, "   Verse 4"),
+                AudioCue(Int.MAX_VALUE, " stuff5 "),
+            )
+        ),
+        // Test that only lone digits are interpreted as verse markers
+        TestData(
+            listOf(
+                AudioCue(0, "123"),
+                AudioCue(2, "Verse 2"),
+                AudioCue(3, "Marker 3   "),
+                AudioCue(4, "   Verse 4"),
+                AudioCue(Int.MAX_VALUE, " stuff5 ")
+            ),
+            listOf(
+                AudioCue(0, "123"),
+                AudioCue(0, "orature-vm-123"),
+                AudioCue(2, "Verse 2"),
+                AudioCue(3, "Marker 3   "),
+                AudioCue(4, "   Verse 4"),
+                AudioCue(Int.MAX_VALUE, " stuff5 "),
+            )
+        ),
+    )
+
+    @Test
+    fun writeCues() {
+        val wavLengths = listOf(0, 3, 100, 400000)
+        for (writeSize in wavLengths) {
+            for (test in testEnv) {
+                val file = File.createTempFile("test", "wav")
+                file.deleteOnExit()
+
+                // Creates a wav file with cue chunks to write freeform cue markers
+                val wav = WavFile(file, 1, 44100, 16, WavMetadata(listOf(CueChunk())))
+                for (cue in test.initial) {
+                    wav.metadata.addCue(cue.location, cue.label)
+                }
+                val os = WavOutputStream(wav)
+                os.use {
+                    os.write(ByteArray(writeSize))
+                }
+
+                // Open another wav file that uses VerseMarkerChunk rather than CueChunk to find
+                // verse markers from possible cue chunks
+                val updateMetadata = WavFile(file)
+                // write out the interpreted orature-vm markers
+                WavOutputStream(updateMetadata, true).use {}
+
+                // open the file again with CueChunk to verify that the original markers are still there
+                val validator = WavFile(file, WavMetadata(listOf(CueChunk())))
+                val resultMetadata = validator.metadata
+                assertEquals(test.result.size, resultMetadata.getCues().size)
+                for (cue in test.result) {
+                    assertTrue(resultMetadata.getCues().contains(cue))
+                }
+            }
+        }
+    }
+}

--- a/common/audio/src/test/kotlin/org/wycliffeassociates/otter/common/audio/wav/WavIOTest.kt
+++ b/common/audio/src/test/kotlin/org/wycliffeassociates/otter/common/audio/wav/WavIOTest.kt
@@ -39,7 +39,8 @@ class WavIOTest {
             file,
             DEFAULT_CHANNELS,
             DEFAULT_SAMPLE_RATE,
-            DEFAULT_BITS_PER_SAMPLE
+            DEFAULT_BITS_PER_SAMPLE,
+            WavMetadata(listOf(CueChunk()))
         )
         for (cue in cues) {
             wav.metadata.addCue(cue.location, cue.label)
@@ -118,13 +119,15 @@ class WavIOTest {
             temp,
             DEFAULT_CHANNELS,
             DEFAULT_SAMPLE_RATE,
-            DEFAULT_BITS_PER_SAMPLE
+            DEFAULT_BITS_PER_SAMPLE,
+            WavMetadata(listOf(CueChunk()))
         )
         val wav2 = WavFile(
             temp2,
             DEFAULT_CHANNELS,
             DEFAULT_SAMPLE_RATE,
-            DEFAULT_BITS_PER_SAMPLE
+            DEFAULT_BITS_PER_SAMPLE,
+            WavMetadata(listOf(CueChunk()))
         )
 
         val audioSamples = 700_000
@@ -170,13 +173,15 @@ class WavIOTest {
             temp,
             DEFAULT_CHANNELS,
             DEFAULT_SAMPLE_RATE,
-            DEFAULT_BITS_PER_SAMPLE
+            DEFAULT_BITS_PER_SAMPLE,
+            WavMetadata(listOf(CueChunk()))
         )
         val wav2 = WavFile(
             temp2,
             DEFAULT_CHANNELS,
             DEFAULT_SAMPLE_RATE,
-            DEFAULT_BITS_PER_SAMPLE
+            DEFAULT_BITS_PER_SAMPLE,
+            WavMetadata(listOf(CueChunk()))
         )
 
         val audioSamples = 700_000


### PR DESCRIPTION
Namespaces the verse markers placed by Orature.

This is intended to be fault tolerant towards wav files that had markers placed before that are not using this convention- single digits and digits with text like "marker #" can still be imported.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/orature/408)
<!-- Reviewable:end -->
