### PR TITLE
Bug fix: placing 10th marker pauses the audio playback

### DIFF
--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/skins/waveform/WaveformSliderSkin.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/skins/waveform/WaveformSliderSkin.kt
@@ -116,15 +116,13 @@ class WaveformSliderSkin(val control: AudioSlider) : SkinBase<Slider>(control) {
     }
 
     private fun resizeThumbWidth(): Double {
-        return control.player.value?.getAudioReader()?.let { reader ->
-            reader?.let {
-                val secondsToHighlight = control.secondsToHighlightProperty.value
-                val framesInHighlight = it.sampleRate * secondsToHighlight
-                val framesPerPixel = it.totalFrames / max(control.widthProperty().value, 1.0)
-                val pixelsInHighlight = max(framesInHighlight / framesPerPixel, 1.0)
-                thumb.width = min(pixelsInHighlight, control.width)
-                return pixelsInHighlight
-            }
+        return control.reader?.let { it ->
+            val secondsToHighlight = control.secondsToHighlightProperty.value
+            val framesInHighlight = it.sampleRate * secondsToHighlight
+            val framesPerPixel = it.totalFrames / max(control.widthProperty().value, 1.0)
+            val pixelsInHighlight = max(framesInHighlight / framesPerPixel, 1.0)
+            thumb.width = min(pixelsInHighlight, control.width)
+            return pixelsInHighlight
         } ?: 0.0
     }
 }

--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/waveform/AudioSlider.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/waveform/AudioSlider.kt
@@ -26,6 +26,7 @@ import javafx.scene.control.Slider
 import javafx.scene.image.Image
 import javafx.scene.paint.Color
 import javafx.scene.paint.Paint
+import org.wycliffeassociates.otter.common.audio.AudioFileReader
 import org.wycliffeassociates.otter.common.device.IAudioPlayer
 import org.wycliffeassociates.otter.jvm.controls.skins.waveform.WaveformSliderSkin
 import org.wycliffeassociates.otter.jvm.utils.onChangeAndDoNow
@@ -43,6 +44,7 @@ class AudioSlider(
     var waveformMinimapListener: ChangeListener<Image>? = null
 
     val player = SimpleObjectProperty<IAudioPlayer>()
+    var reader: AudioFileReader? = null
 
     init {
         // initial height/width to prevent the control from otherwise growing indefinitely
@@ -51,6 +53,7 @@ class AudioSlider(
 
         player.onChangeAndDoNow { player ->
             player?.let {
+                reader = it.getAudioReader()
                 setMax(it.getDurationInFrames().toDouble())
                 it.seek(0)
             }


### PR DESCRIPTION
In verse marker app, the width of the mini-map area is bound to the region/parent container. When the width of the counter changes from 9 to 10 (see photo), it also changes the surrounding UI elements and thus triggers the resizeThumbWidth() on the mini-map slider. This method calls player.getAudioReader() and as a result, it pauses the playback.

![image](https://user-images.githubusercontent.com/34975907/148576838-5b6aa17d-78a8-4049-b6da-b83864c1a0a1.png)


This PR refactors such method call to have it invoked once when the player changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/orature/472)
<!-- Reviewable:end -->
