### PR TITLE
Fix: Timestamp is not fully visible in takes list view - chapter page

### DIFF
--- a/jvm/controls/src/main/resources/css/resourcetakecard.css
+++ b/jvm/controls/src/main/resources/css/resourcetakecard.css
@@ -75,12 +75,12 @@
 }
 
 .card--left-region-container {
-    -fx-padding: 30px 0 0 0;
+    -fx-padding: 50px 0 0 0;
     -fx-background-color: -wa-background;
 }
 
 .card__right-region {
-    -fx-padding: 30px 70px 30px 30px;
+    -fx-padding: 50px 70px 50px 30px;
     -fx-background-color: -wa-background;
     -fx-border-width: 0 0 0 1px;
     -fx-border-color: -wa-border-light;

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/ChunkItem.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/ChunkItem.kt
@@ -176,6 +176,8 @@ class ChunkItem : VBox() {
         clip.heightProperty().bind(lv.heightProperty().plus(offset))
         clip.layoutY = -offset
         // traverse to ClippedContainer and update it
-        lv.getChildList()?.firstOrNull()?.getChildList()?.firstOrNull()?.clip = clip
+        lv.getChildList()?.firstOrNull { it.hasClass("virtual-flow") }
+            ?.getChildList()?.firstOrNull { it.hasClass("clipped-container") }
+            ?.clip = clip
     }
 }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/ChunkItem.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/ChunkItem.kt
@@ -170,14 +170,9 @@ class ChunkItem : VBox() {
      * Call this method after the list view children have rendered.
      */
     private fun setClipOffsetListView(lv: ListView<TakeItem>) {
-        val offset = TAKE_CELL_HEIGHT
-        val clip = Rectangle(0.0, 0.0)
-        clip.widthProperty().bind(lv.widthProperty())
-        clip.heightProperty().bind(lv.heightProperty().plus(offset))
-        clip.layoutY = -offset
         // traverse to ClippedContainer and update it
         lv.getChildList()?.firstOrNull { it.hasClass("virtual-flow") }
             ?.getChildList()?.firstOrNull { it.hasClass("clipped-container") }
-            ?.clip = clip
+            ?.clip = null
     }
 }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/ChunkItem.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/ChunkItem.kt
@@ -28,7 +28,6 @@ import javafx.event.EventHandler
 import javafx.scene.control.ListView
 import javafx.scene.layout.Priority
 import javafx.scene.layout.VBox
-import javafx.scene.shape.Rectangle
 import org.kordamp.ikonli.javafx.FontIcon
 import org.kordamp.ikonli.materialdesign.MaterialDesign
 import org.wycliffeassociates.otter.jvm.controls.ListAnimationMediator

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/ChunkItem.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/ChunkItem.kt
@@ -25,8 +25,10 @@ import javafx.beans.property.SimpleObjectProperty
 import javafx.beans.property.SimpleStringProperty
 import javafx.event.ActionEvent
 import javafx.event.EventHandler
+import javafx.scene.control.ListView
 import javafx.scene.layout.Priority
 import javafx.scene.layout.VBox
+import javafx.scene.shape.Rectangle
 import org.kordamp.ikonli.javafx.FontIcon
 import org.kordamp.ikonli.materialdesign.MaterialDesign
 import org.wycliffeassociates.otter.jvm.controls.ListAnimationMediator
@@ -113,6 +115,8 @@ class ChunkItem : VBox() {
                     addClass("wa-list-view")
                     setCellFactory { TakeCell() }
                     prefHeightProperty().bind(Bindings.size(takes).multiply(TAKE_CELL_HEIGHT))
+
+                    this.childrenUnmodifiable.onChange { setClipOffsetListView(this) }
                 }
             }
         }
@@ -155,5 +159,23 @@ class ChunkItem : VBox() {
                 }
             }
         )
+    }
+
+    /**
+     * The built-in clipped container from the ListView
+     * overlays the timestamp tooltip of the audio player.
+     * This function extends the clipped region towards the
+     * top boundary, allowing the tooltip to be fully visible.
+     *
+     * Call this method after the list view children have rendered.
+     */
+    private fun setClipOffsetListView(lv: ListView<TakeItem>) {
+        val offset = TAKE_CELL_HEIGHT
+        val clip = Rectangle(0.0, 0.0)
+        clip.widthProperty().bind(lv.widthProperty())
+        clip.heightProperty().bind(lv.heightProperty().plus(offset))
+        clip.layoutY = -offset
+        // traverse to ClippedContainer and update it
+        lv.getChildList()?.firstOrNull()?.getChildList()?.firstOrNull()?.clip = clip
     }
 }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/ChunkItem.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/ChunkItem.kt
@@ -32,6 +32,7 @@ import org.kordamp.ikonli.javafx.FontIcon
 import org.kordamp.ikonli.materialdesign.MaterialDesign
 import org.wycliffeassociates.otter.jvm.controls.ListAnimationMediator
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.model.TakeModel
+import org.wycliffeassociates.otter.jvm.workbookapp.ui.screens.removeListViewClip
 import tornadofx.*
 
 private const val TAKE_CELL_HEIGHT = 80.0
@@ -115,7 +116,7 @@ class ChunkItem : VBox() {
                     setCellFactory { TakeCell() }
                     prefHeightProperty().bind(Bindings.size(takes).multiply(TAKE_CELL_HEIGHT))
 
-                    this.childrenUnmodifiable.onChange { setClipOffsetListView(this) }
+                    this.childrenUnmodifiable.onChange { removeListViewClip(this as ListView<Any>) }
                 }
             }
         }
@@ -158,20 +159,5 @@ class ChunkItem : VBox() {
                 }
             }
         )
-    }
-
-    /**
-     * The built-in clipped container from the ListView
-     * overlays the timestamp tooltip of the audio player.
-     * This function extends the clipped region towards the
-     * top boundary, allowing the tooltip to be fully visible.
-     *
-     * Call this method after the list view children have rendered.
-     */
-    private fun setClipOffsetListView(lv: ListView<TakeItem>) {
-        // traverse to ClippedContainer and update it
-        lv.getChildList()?.firstOrNull { it.hasClass("virtual-flow") }
-            ?.getChildList()?.firstOrNull { it.hasClass("clipped-container") }
-            ?.clip = null
     }
 }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/TakesListView.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/TakesListView.kt
@@ -42,5 +42,22 @@ class TakesListView(
         vgrow = Priority.ALWAYS
         isFocusTraversable = false
         addClass("card__takes-list")
+
+        childrenUnmodifiable.onChange { removeListViewClip(this as ListView<Any>) }
     }
+}
+
+/**
+ * The built-in clipped container from the ListView
+ * overlays the timestamp tooltip of the audio player.
+ * This function extends the clipped region towards the
+ * top boundary, allowing the tooltip to be fully visible.
+ *
+ * Call this method after the list view children have rendered.
+ */
+fun removeListViewClip(lv: ListView<Any>) {
+    // traverse to ClippedContainer and update it
+    lv.getChildList()?.firstOrNull { it.hasClass("virtual-flow") }
+        ?.getChildList()?.firstOrNull { it.hasClass("clipped-container") }
+        ?.clip = null
 }


### PR DESCRIPTION
Timestamp tooltip is overlaid with ClippedContainer in ListView (javafx generated).

![image](https://user-images.githubusercontent.com/34975907/148802460-fc5467e7-9485-4273-89a6-22310fdc2906.png)

Solution: no clip

![MicrosoftTeams-image](https://user-images.githubusercontent.com/34975907/148807490-324de530-b3c7-43c1-894f-ba71057c3aa6.png)


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/orature/475)
<!-- Reviewable:end -->
