### PR TITLE
Remove Deprecations

### DIFF
--- a/common/audio/src/main/kotlin/org/wycliffeassociates/otter/common/audio/AudioFileFormat.kt
+++ b/common/audio/src/main/kotlin/org/wycliffeassociates/otter/common/audio/AudioFileFormat.kt
@@ -23,11 +23,11 @@ enum class AudioFileFormat(val extension: String) {
     MP3("mp3");
 
     companion object {
-        private val map = values().associateBy { it.extension.toLowerCase() }
+        private val map = values().associateBy { it.extension.lowercase() }
 
         /** @throws IllegalArgumentException */
         fun of(extension: String) =
-            map[extension.toLowerCase()]
+            map[extension.lowercase()]
                 ?: throw IllegalArgumentException("Audio extension $extension not supported")
     }
 }

--- a/common/audio/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/CueChunk.kt
+++ b/common/audio/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/CueChunk.kt
@@ -279,7 +279,7 @@ open class CueChunk : RiffChunk {
                     val labelBytes = ByteArray(wordAlignedSubchunkSize - CHUNK_LABEL_SIZE)
                     chunk.get(labelBytes)
                     // trim necessary to strip trailing 0's used to pad to double word align
-                    val label = String(labelBytes, Charsets.US_ASCII).trim { it.toByte() == 0.toByte() }
+                    val label = String(labelBytes, Charsets.US_ASCII).trim { it.code.toByte() == 0.toByte() }
                     cueListBuilder.addLabel(id, label)
                 }
                 else -> {

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/data/OratureFileFormat.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/data/OratureFileFormat.kt
@@ -25,6 +25,6 @@ enum class OratureFileFormat(val extension: String) {
     companion object {
         val extensionList: List<String> = values().map { it.extension }
 
-        fun isSupported(extension: String) = extension.toLowerCase() in extensionList
+        fun isSupported(extension: String) = extension.lowercase() in extensionList
     }
 }

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/data/primitives/ContainerType.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/data/primitives/ContainerType.kt
@@ -31,15 +31,16 @@ enum class ContainerType(val slug: String) {
 
     @Deprecated("Type not supported")
     Dictionary("dict"),
+
     @Deprecated("Type not supported")
     Manual("man");
 
     companion object {
-        private val map = values().associateBy { it.slug.toLowerCase() }
+        private val map = values().associateBy { it.slug.lowercase() }
 
         /** @throws IllegalArgumentException */
         fun of(slug: String) =
-            map[slug.toLowerCase()]
+            map[slug.lowercase()]
                 ?: throw IllegalArgumentException("Container slug $slug not supported")
     }
 }

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/data/primitives/ContentType.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/data/primitives/ContentType.kt
@@ -45,8 +45,8 @@ enum class ContentType {
 
     companion object {
         fun of(s: String): ContentType? {
-            val lower = s.toLowerCase()
-            return values().firstOrNull { lower == it.name.toLowerCase() }
+            val lower = s.lowercase()
+            return values().firstOrNull { lower == it.name.lowercase() }
         }
     }
 }

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/data/primitives/MimeType.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/data/primitives/MimeType.kt
@@ -34,7 +34,7 @@ enum class MimeType(vararg types: String) {
             .associate { it }
 
         /** @throws [IllegalArgumentException] if the format type is not supported **/
-        fun of(type: String) = map[type.toLowerCase()]
+        fun of(type: String) = map[type.lowercase()]
             ?: throw IllegalArgumentException("Mime type $type not supported")
     }
 }

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/content/FileNamer.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/content/FileNamer.kt
@@ -20,7 +20,6 @@ package org.wycliffeassociates.otter.common.domain.content
 
 import org.wycliffeassociates.otter.common.audio.AudioFileFormat
 import org.wycliffeassociates.otter.common.data.primitives.ContentType
-import kotlin.IllegalStateException
 
 class FileNamer(
     val start: Int? = null,

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/content/FileNamer.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/content/FileNamer.kt
@@ -84,7 +84,7 @@ class FileNamer(
     private fun formatContentType(): String? {
         return when (contentType) {
             ContentType.TEXT -> null
-            else -> contentType.toString().toLowerCase()
+            else -> contentType.toString().lowercase()
         }
     }
 

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/project/ProjectFilesAccessor.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/project/ProjectFilesAccessor.kt
@@ -184,7 +184,7 @@ class ProjectFilesAccessor(
                     log.error("Error in writeSelectedTakesFile", e)
                 }
                 .blockingSubscribe {
-                    _fileWriter.appendln(it)
+                    _fileWriter.appendLine(it)
                 }
         }
     }
@@ -331,7 +331,7 @@ class ProjectFilesAccessor(
     private fun isAudioFile(file: String) = isAudioFile(File(file))
 
     private fun isAudioFile(file: File) =
-        file.extension.toLowerCase().let { it == "wav" || it == "mp3" }
+        file.extension.lowercase().let { it == "wav" || it == "mp3" }
 
     companion object {
         val ignoredSourceMediaExtensions = listOf("wav", "mp3", "jpg", "jpeg", "png", "cue")

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/projectimportexport/MediaMerge.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/projectimportexport/MediaMerge.kt
@@ -162,5 +162,5 @@ class MediaMerge(
 
 // This is not exhaustive or sufficient by itself, but a fileExists call is still used after
 private fun String.isURL(): Boolean {
-    return this.toLowerCase().startsWith("http://") || this.toLowerCase().startsWith("https://")
+    return this.lowercase().startsWith("http://") || this.lowercase().startsWith("https://")
 }

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/utils/StringUtils.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/utils/StringUtils.kt
@@ -1,3 +1,21 @@
+/**
+ * Copyright (C) 2020-2022 Wycliffe Associates
+ *
+ * This file is part of Orature.
+ *
+ * Orature is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Orature is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Orature.  If not, see <https://www.gnu.org/licenses/>.
+ */
 package org.wycliffeassociates.otter.common.utils
 
 import java.util.*

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/utils/StringUtils.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/utils/StringUtils.kt
@@ -1,0 +1,7 @@
+package org.wycliffeassociates.otter.common.utils
+
+import java.util.*
+
+fun String.capitalizeString(): String {
+    return this.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() }
+}

--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/skins/media/SourceContentSkin.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/skins/media/SourceContentSkin.kt
@@ -103,12 +103,8 @@ class SourceContentSkin(private val sourceContent: SourceContent) : SkinBase<Sou
     }
 
     private fun initializeControl() {
-        initControllers()
         initAudioControls()
         initTextControls()
-    }
-
-    private fun initControllers() {
     }
 
     private fun initAudioControls() {

--- a/jvm/device/src/main/kotlin/org/wycliffeassociates/otter/jvm/device/ConfigureAudioSystem.kt
+++ b/jvm/device/src/main/kotlin/org/wycliffeassociates/otter/jvm/device/ConfigureAudioSystem.kt
@@ -94,6 +94,7 @@ class ConfigureAudioSystem @Inject constructor(
                     try {
                         line = AudioSystem.getSourceDataLine(DEFAULT_AUDIO_FORMAT, mixer)
                     } catch (e: Exception) {
+                        logger.error("Error in getOutputLine.", e)
                     }
                 }
                 if (line != null) Maybe.just(line) else Maybe.empty()
@@ -118,6 +119,7 @@ class ConfigureAudioSystem @Inject constructor(
                     try {
                         line = AudioSystem.getTargetDataLine(DEFAULT_AUDIO_FORMAT, mixer)
                     } catch (e: Exception) {
+                        logger.error("Error in getInputLine.", e)
                     }
                 }
                 if (line != null) Maybe.just(line) else Maybe.empty()

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/persistence/database/daos/ContentTypeDao.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/persistence/database/daos/ContentTypeDao.kt
@@ -60,12 +60,12 @@ class ContentTypeDao(
         .get(CONTENT_TYPE.ID)
 
     private fun getAll(dsl: DSLContext): List<Pair<ContentType, Int>> {
-        val nameLookup = ContentType.values().associate { it.name.toLowerCase() to it }
+        val nameLookup = ContentType.values().associate { it.name.lowercase() to it }
         return dsl
             .select()
             .from(CONTENT_TYPE)
             .fetch { record ->
-                val name = record.getValue(CONTENT_TYPE.NAME).toLowerCase()
+                val name = record.getValue(CONTENT_TYPE.NAME).lowercase()
                 val id = record.getValue(CONTENT_TYPE.ID)
                 nameLookup[name]?.let { Pair(it, id) }
             }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/persistence/repositories/CollectionRepository.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/persistence/repositories/CollectionRepository.kt
@@ -397,7 +397,7 @@ class CollectionRepository @Inject constructor(
                                 container.manifest.projects = container.manifest.projects.plus(
                                     project {
                                         sort = if (
-                                            mainDerivedMetadata.subject.toLowerCase() == "bible" &&
+                                            mainDerivedMetadata.subject.lowercase() == "bible" &&
                                             projectEntity.sort > 39
                                         ) {
                                             projectEntity.sort + 1

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/persistence/repositories/mapping/LanguageMapper.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/persistence/repositories/mapping/LanguageMapper.kt
@@ -30,7 +30,7 @@ class LanguageMapper @Inject constructor() : Mapper<LanguageEntity, Language> {
             type.slug,
             type.name,
             type.anglicizedName,
-            type.direction.toLowerCase(),
+            type.direction.lowercase(),
             type.gateway == 1,
             type.region,
             type.id
@@ -42,7 +42,7 @@ class LanguageMapper @Inject constructor() : Mapper<LanguageEntity, Language> {
             type.slug,
             type.name,
             type.anglicizedName,
-            type.direction.toLowerCase(),
+            type.direction.lowercase(),
             if (type.isGateway) 1 else 0,
             type.region
         )

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/plugin/AudioPluginRegistrar.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/plugin/AudioPluginRegistrar.kt
@@ -65,7 +65,7 @@ class AudioPluginRegistrar @Inject constructor(
                 // Only load yaml files
                 it
                     .path
-                    .toLowerCase()
+                    .lowercase()
                     .endsWith(".yaml")
             }
             .map {

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/plugin/parser/ParsedAudioPluginDataMapper.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/plugin/parser/ParsedAudioPluginDataMapper.kt
@@ -23,8 +23,7 @@ import java.io.File
 
 /** @param osName optionally overrides the value from System.getProperty("os.name") */
 class ParsedAudioPluginDataMapper(osName: String? = null) {
-    private val osName = (osName ?: System.getProperty("os.name"))
-        .toUpperCase()
+    private val osName = (osName ?: System.getProperty("os.name")).uppercase()
 
     /**
      * Map from Jackson parser class to an AudioPlugin. No need to map the other way.

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/OtterExceptionHandler.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/OtterExceptionHandler.kt
@@ -183,7 +183,7 @@ class OtterExceptionHandler(
     }
 
     private fun getLog(): String? {
-        val logFileName = OratureInfo.SUITE_NAME.toLowerCase()
+        val logFileName = OratureInfo.SUITE_NAME.lowercase()
         val logExt = ".log"
         val logFile = StringBuilder()
             .append(directoryProvider.logsDirectory.absolutePath)

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/ChunkCell.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/ChunkCell.kt
@@ -22,6 +22,7 @@ import javafx.scene.control.ListCell
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.model.CardData
 import tornadofx.*
 import java.text.MessageFormat
+import org.wycliffeassociates.otter.common.utils.capitalizeString
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.model.TakeModel
 
 class ChunkCell(
@@ -44,7 +45,7 @@ class ChunkCell(
             chunkTitleProperty.set(
                 MessageFormat.format(
                     FX.messages["chunkTitle"],
-                    FX.messages[item.item].capitalize(),
+                    FX.messages[item.item].capitalizeString(),
                     item.bodyText
                 )
             )

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/ChapterPage.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/ChapterPage.kt
@@ -47,6 +47,7 @@ import org.wycliffeassociates.otter.jvm.workbookapp.ui.viewmodel.WorkbookDataSto
 import tornadofx.*
 import java.text.MessageFormat
 import java.util.*
+import org.wycliffeassociates.otter.common.utils.capitalizeString
 
 class ChapterPage : View() {
     private val logger = LoggerFactory.getLogger(ChapterPage::class.java)
@@ -143,7 +144,7 @@ class ChapterPage : View() {
                     textProperty().bind(viewModel.chapterCardProperty.stringBinding {
                         MessageFormat.format(
                             FX.messages["chapterTitle"],
-                            FX.messages["chapter"].capitalize(),
+                            FX.messages["chapter"].capitalizeString(),
                             it?.bodyText
                         )
                     })

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/RecordResourceFragment.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/RecordResourceFragment.kt
@@ -20,6 +20,7 @@ package org.wycliffeassociates.otter.jvm.workbookapp.ui.screens
 
 import com.jfoenix.controls.JFXSnackbar
 import com.jfoenix.controls.JFXSnackbarLayout
+import java.util.*
 import javafx.beans.property.SimpleBooleanProperty
 import javafx.beans.property.SimpleObjectProperty
 import javafx.beans.property.SimpleStringProperty
@@ -371,7 +372,7 @@ class RecordResourceFragment(private val recordableViewModel: RecordableViewMode
                     JFXSnackbar.SnackbarEvent(
                         JFXSnackbarLayout(
                             pluginErrorMessage,
-                            messages["addApp"].toUpperCase()
+                            messages["addApp"].uppercase(Locale.getDefault())
                         ) {
                             audioPluginViewModel.addPlugin(true, false)
                         },

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/RecordScriptureViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/RecordScriptureViewModel.kt
@@ -54,6 +54,7 @@ import org.wycliffeassociates.otter.jvm.workbookapp.ui.model.TakeCardModel
 import tornadofx.*
 import java.io.File
 import java.text.MessageFormat
+import org.wycliffeassociates.otter.common.utils.capitalizeString
 import io.reactivex.rxkotlin.toObservable as toRxObservable
 
 class RecordScriptureViewModel : ViewModel() {
@@ -525,11 +526,11 @@ class RecordScriptureViewModel : ViewModel() {
             this,
             selected,
             ap,
-            FX.messages["edit"].capitalize(),
-            FX.messages["delete"].capitalize(),
-            FX.messages["marker"].capitalize(),
-            FX.messages["play"].capitalize(),
-            FX.messages["pause"].capitalize()
+            FX.messages["edit"].capitalizeString(),
+            FX.messages["delete"].capitalizeString(),
+            FX.messages["marker"].capitalizeString(),
+            FX.messages["play"].capitalizeString(),
+            FX.messages["pause"].capitalizeString()
         )
     }
 }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/RecordableViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/RecordableViewModel.kt
@@ -46,6 +46,7 @@ import org.wycliffeassociates.otter.jvm.workbookapp.ui.model.TakeCardModel
 import tornadofx.*
 import java.io.File
 import java.util.concurrent.Callable
+import org.wycliffeassociates.otter.common.utils.capitalizeString
 import io.reactivex.rxkotlin.toObservable as toRxObservable
 
 open class RecordableViewModel(
@@ -398,11 +399,11 @@ open class RecordableViewModel(
             this,
             selected,
             ap,
-            FX.messages["edit"].capitalize(),
-            FX.messages["delete"].capitalize(),
-            FX.messages["marker"].capitalize(),
-            FX.messages["play"].capitalize(),
-            FX.messages["pause"].capitalize()
+            FX.messages["edit"].capitalizeString(),
+            FX.messages["delete"].capitalizeString(),
+            FX.messages["marker"].capitalizeString(),
+            FX.messages["play"].capitalizeString(),
+            FX.messages["pause"].capitalizeString()
         )
     }
 }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/WorkbookDataStore.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/WorkbookDataStore.kt
@@ -40,7 +40,6 @@ import org.wycliffeassociates.otter.common.domain.resourcecontainer.project.Proj
 import org.wycliffeassociates.otter.common.persistence.IDirectoryProvider
 import org.wycliffeassociates.otter.jvm.utils.onChangeAndDoNow
 import org.wycliffeassociates.otter.jvm.workbookapp.di.IDependencyGraphProvider
-import org.wycliffeassociates.otter.jvm.workbookapp.ui.OtterApp
 import tornadofx.*
 import java.io.File
 import java.text.MessageFormat

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/updater/install4j/UpdateLauncher.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/updater/install4j/UpdateLauncher.kt
@@ -28,9 +28,11 @@ class UpdateLauncher(private val listener: UpdateProgressListener? = null) : App
     }
 
     override fun exited(exitValue: Int) {
+        /* no-op */
     }
 
     override fun prepareShutdown() {
+        /* no-op */
     }
 
     override fun createProgressListener(): ApplicationLauncher.ProgressListener? {


### PR DESCRIPTION
Removes deprecated method calls.

toLowerCase is replaced with lowercase. This is chosen over lowercase(Locale.Default) due to the uses being slugs or file extensions, which, could be problematic if lowercase doesn't work as expected on different locales.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/orature/480)
<!-- Reviewable:end -->
