### PR TITLE
Avoid duplicated css imports

### DIFF
--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/breadcrumbs/BreadcrumbBar.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/breadcrumbs/BreadcrumbBar.kt
@@ -21,6 +21,7 @@ package org.wycliffeassociates.otter.jvm.controls.breadcrumbs
 import javafx.beans.binding.Bindings
 import javafx.beans.property.SimpleDoubleProperty
 import javafx.scene.layout.HBox
+import org.wycliffeassociates.otter.jvm.controls.styles.tryImportStylesheet
 import tornadofx.*
 import java.util.concurrent.Callable
 
@@ -31,7 +32,7 @@ class BreadcrumbBar : HBox() {
     val orientationScaleProperty = SimpleDoubleProperty()
 
     init {
-        importStylesheet(javaClass.getResource("/css/breadcrumb-bar.css").toExternalForm())
+        tryImportStylesheet(javaClass.getResource("/css/breadcrumb-bar.css").toExternalForm())
         styleClass.setAll("breadcrumb-bar")
 
         bindChildren(items) { breadcrumb ->

--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/button/AppBarButton.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/button/AppBarButton.kt
@@ -21,12 +21,12 @@ package org.wycliffeassociates.otter.jvm.controls.button
 import javafx.scene.control.Skin
 import javafx.scene.control.ToggleButton
 import org.wycliffeassociates.otter.jvm.controls.skins.button.AppBarButtonSkin
-import tornadofx.*
+import org.wycliffeassociates.otter.jvm.controls.styles.tryImportStylesheet
 
 class AppBarButton : ToggleButton() {
 
     init {
-        importStylesheet(javaClass.getResource("/css/app-bar-button.css").toExternalForm())
+        tryImportStylesheet(javaClass.getResource("/css/app-bar-button.css").toExternalForm())
         styleClass.setAll("app-bar-button")
     }
 

--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/button/SelectButton.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/button/SelectButton.kt
@@ -21,11 +21,11 @@ package org.wycliffeassociates.otter.jvm.controls.button
 import javafx.scene.control.Skin
 import javafx.scene.control.ToggleButton
 import org.wycliffeassociates.otter.jvm.controls.skins.button.SelectButtonSkin
-import tornadofx.*
+import org.wycliffeassociates.otter.jvm.controls.styles.tryImportStylesheet
 
 class SelectButton : ToggleButton() {
     init {
-        importStylesheet(javaClass.getResource("/css/select-button.css").toExternalForm())
+        tryImportStylesheet(javaClass.getResource("/css/select-button.css").toExternalForm())
         styleClass.setAll("select-button")
     }
 

--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/dialog/OtterDialog.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/dialog/OtterDialog.kt
@@ -30,6 +30,7 @@ import javafx.stage.Modality
 import javafx.stage.Stage
 import javafx.stage.StageStyle
 import org.wycliffeassociates.otter.common.data.ColorTheme
+import org.wycliffeassociates.otter.jvm.controls.styles.tryImportStylesheet
 import tornadofx.*
 
 abstract class OtterDialog : Fragment() {
@@ -50,13 +51,13 @@ abstract class OtterDialog : Fragment() {
     }
 
     init {
-        importStylesheet(resources.get("/css/otter-dialog.css"))
+        tryImportStylesheet(resources.get("/css/otter-dialog.css"))
         /*
          * The dialog does not inherit style class from root view;
          * it needs its own theme configuration
          */
-        importStylesheet(resources["/css/theme/light-theme.css"])
-        importStylesheet(resources["/css/theme/dark-theme.css"])
+        tryImportStylesheet(resources["/css/theme/light-theme.css"])
+        tryImportStylesheet(resources["/css/theme/dark-theme.css"])
         bindTheme()
     }
 

--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/dialog/PluginOpenedPage.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/dialog/PluginOpenedPage.kt
@@ -26,6 +26,7 @@ import javafx.geometry.Pos
 import javafx.scene.layout.Priority
 import org.wycliffeassociates.otter.common.device.IAudioPlayer
 import org.wycliffeassociates.otter.jvm.controls.media.SourceContent
+import org.wycliffeassociates.otter.jvm.controls.styles.tryImportStylesheet
 import tornadofx.*
 
 class PluginOpenedPage : Fragment() {
@@ -42,7 +43,7 @@ class PluginOpenedPage : Fragment() {
     val sourceOrientationProperty = SimpleObjectProperty<NodeOrientation>()
 
     init {
-        importStylesheet(resources["/css/plugin-opened-page.css"])
+        tryImportStylesheet(resources["/css/plugin-opened-page.css"])
     }
 
     override val root = vbox {

--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/skins/ChunkMarkerSkin.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/skins/ChunkMarkerSkin.kt
@@ -23,6 +23,7 @@ import javafx.scene.control.SkinBase
 import javafx.scene.layout.HBox
 import org.kordamp.ikonli.javafx.FontIcon
 import org.wycliffeassociates.otter.jvm.controls.ChunkMarker
+import org.wycliffeassociates.otter.jvm.controls.styles.tryImportStylesheet
 import tornadofx.*
 
 class ChunkMarkerSkin(val control: ChunkMarker) : SkinBase<ChunkMarker>(control) {
@@ -39,7 +40,7 @@ class ChunkMarkerSkin(val control: ChunkMarker) : SkinBase<ChunkMarker>(control)
         addBookmarkIcon.visibleProperty().bind(placedBookmarkIcon.visibleProperty().not())
         addBookmarkIcon.managedProperty().bind(placedBookmarkIcon.managedProperty().not())
 
-        importStylesheet(javaClass.getResource("/css/chunk-marker.css").toExternalForm())
+        tryImportStylesheet(javaClass.getResource("/css/chunk-marker.css").toExternalForm())
 
         children.add(
             HBox().apply {

--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/skins/media/ExceptionContentSkin.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/skins/media/ExceptionContentSkin.kt
@@ -30,6 +30,7 @@ import javafx.scene.control.ScrollPane
 import javafx.scene.control.SkinBase
 import org.kordamp.ikonli.javafx.FontIcon
 import org.wycliffeassociates.otter.jvm.controls.media.ExceptionContent
+import org.wycliffeassociates.otter.jvm.controls.styles.tryImportStylesheet
 import tornadofx.*
 
 class ExceptionContentSkin(private var content: ExceptionContent) : SkinBase<ExceptionContent>(content) {
@@ -69,7 +70,7 @@ class ExceptionContentSkin(private var content: ExceptionContent) : SkinBase<Exc
             nodeOrientation = NodeOrientation.LEFT_TO_RIGHT
         }
 
-        importStylesheet(javaClass.getResource("/css/exception-content.css").toExternalForm())
+        tryImportStylesheet(javaClass.getResource("/css/exception-content.css").toExternalForm())
     }
 
     private fun bindText() {

--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/styles/Utils.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/styles/Utils.kt
@@ -16,22 +16,24 @@
  * You should have received a copy of the GNU General Public License
  * along with Orature.  If not, see <https://www.gnu.org/licenses/>.
  */
-package org.wycliffeassociates.otter.jvm.controls.button
+package org.wycliffeassociates.otter.jvm.controls.styles
 
-import javafx.scene.control.CheckBox
-import javafx.scene.control.Skin
-import org.wycliffeassociates.otter.jvm.controls.skins.button.CheckboxButtonSkin
-import org.wycliffeassociates.otter.jvm.controls.styles.tryImportStylesheet
-import tornadofx.*
+import tornadofx.FX
+import tornadofx.importStylesheet
+import java.net.MalformedURLException
+import java.net.URL
 
-class CheckboxButton : CheckBox() {
-
-    init {
-        tryImportStylesheet(javaClass.getResource("/css/checkbox-button.css").toExternalForm())
-        styleClass.setAll("checkbox-button")
+fun tryImportStylesheet(stylesheet: String) : Boolean {
+    try {
+        URL(stylesheet).toExternalForm()
+    } catch (ex: MalformedURLException) {
+        // Fallback to loading classpath resource
+        FX::class.java.getResource(stylesheet)?.toExternalForm()
+    }?.let { resourcePath ->
+        if (!FX.stylesheets.contains(resourcePath)) {
+            importStylesheet(resourcePath)
+            return true
+        }
     }
-
-    override fun createDefaultSkin(): Skin<*> {
-        return CheckboxButtonSkin(this)
-    }
+    return false
 }

--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/styles/Utils.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/styles/Utils.kt
@@ -23,6 +23,10 @@ import tornadofx.importStylesheet
 import java.net.MalformedURLException
 import java.net.URL
 
+/**
+ * Wrapper of FX.importStylesheet(String).
+ * Use this function to prevent duplicated imports.
+ */
 fun tryImportStylesheet(stylesheet: String) : Boolean {
     try {
         URL(stylesheet).toExternalForm()

--- a/jvm/markerapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/markerapp/app/view/MarkerView.kt
+++ b/jvm/markerapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/markerapp/app/view/MarkerView.kt
@@ -19,6 +19,7 @@
 package org.wycliffeassociates.otter.jvm.markerapp.app.view
 
 import javafx.stage.Screen
+import org.wycliffeassociates.otter.jvm.controls.styles.tryImportStylesheet
 import org.wycliffeassociates.otter.jvm.markerapp.app.viewmodel.VerseMarkerViewModel
 import org.wycliffeassociates.otter.jvm.workbookplugin.plugin.PluginEntrypoint
 import tornadofx.*
@@ -40,7 +41,7 @@ class MarkerView : PluginEntrypoint() {
             val css = this@MarkerView.javaClass.getResource("/css/verse-marker-app.css")
                 .toExternalForm()
                 .replace(" ", "%20")
-            importStylesheet(css)
+            tryImportStylesheet(css)
 
             FX.stylesheets.addAll(
                 javaClass.getResource("/css/control.css").toExternalForm(),

--- a/jvm/recorderapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/recorder/app/view/RecorderView.kt
+++ b/jvm/recorderapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/recorder/app/view/RecorderView.kt
@@ -19,6 +19,7 @@
 package org.wycliffeassociates.otter.jvm.recorder.app.view
 
 import javafx.stage.Screen
+import org.wycliffeassociates.otter.jvm.controls.styles.tryImportStylesheet
 import org.wycliffeassociates.otter.jvm.workbookplugin.plugin.PluginEntrypoint
 import org.wycliffeassociates.otter.jvm.recorder.app.viewmodel.RecorderViewModel
 import tornadofx.*
@@ -51,7 +52,7 @@ class RecorderView : PluginEntrypoint() {
             val css = this@RecorderView.javaClass.getResource("/css/recorder.css")
                 .toExternalForm()
                 .replace(" ", "%20")
-            importStylesheet(css)
+            tryImportStylesheet(css)
         }
 
         // notifies viewmodel that views have been inflated and the canvas now has a width

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/AppBar.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/AppBar.kt
@@ -24,6 +24,7 @@ import javafx.scene.layout.VBox
 import org.kordamp.ikonli.javafx.FontIcon
 import org.kordamp.ikonli.materialdesign.MaterialDesign
 import org.wycliffeassociates.otter.jvm.controls.button.AppBarButton
+import org.wycliffeassociates.otter.jvm.controls.styles.tryImportStylesheet
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.components.drawer.AddFilesView
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.components.drawer.DrawerEvent
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.components.drawer.DrawerEventAction
@@ -83,7 +84,7 @@ class AppBar : Fragment() {
     }
 
     init {
-        importStylesheet(resources.get("/css/app-bar.css"))
+        tryImportStylesheet(resources.get("/css/app-bar.css"))
 
         root.apply {
             styleClass.setAll("app-bar")

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/drawer/AddFilesView.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/drawer/AddFilesView.kt
@@ -31,6 +31,7 @@ import org.kordamp.ikonli.javafx.FontIcon
 import org.kordamp.ikonli.materialdesign.MaterialDesign
 import org.slf4j.LoggerFactory
 import org.wycliffeassociates.otter.jvm.controls.dialog.confirmdialog
+import org.wycliffeassociates.otter.jvm.controls.styles.tryImportStylesheet
 import org.wycliffeassociates.otter.jvm.workbookapp.SnackbarHandler
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.viewmodel.AddFilesViewModel
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.viewmodel.SettingsViewModel
@@ -127,8 +128,8 @@ class AddFilesView : View() {
     }
 
     init {
-        importStylesheet(resources.get("/css/app-drawer.css"))
-        importStylesheet(resources.get("/css/confirm-dialog.css"))
+        tryImportStylesheet(resources.get("/css/app-drawer.css"))
+        tryImportStylesheet(resources.get("/css/confirm-dialog.css"))
 
         initImportDialog()
         initSuccessDialog()

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/drawer/InfoView.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/drawer/InfoView.kt
@@ -22,6 +22,7 @@ import com.jfoenix.controls.JFXButton
 import javafx.scene.layout.Priority
 import org.kordamp.ikonli.javafx.FontIcon
 import org.kordamp.ikonli.materialdesign.MaterialDesign
+import org.wycliffeassociates.otter.jvm.controls.styles.tryImportStylesheet
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.system.AppInfo
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.viewmodel.AppInfoViewModel
 import org.wycliffeassociates.otter.jvm.workbookapp.updater.install4j.ui.view.UpdaterView
@@ -150,7 +151,7 @@ class InfoView : View() {
     }
 
     init {
-        importStylesheet(javaClass.getResource("/css/app-drawer.css").toExternalForm())
+        tryImportStylesheet(javaClass.getResource("/css/app-drawer.css").toExternalForm())
     }
 
     private fun collapse() {

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/drawer/SettingsView.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/drawer/SettingsView.kt
@@ -25,6 +25,7 @@ import javafx.scene.layout.Priority
 import org.kordamp.ikonli.javafx.FontIcon
 import org.kordamp.ikonli.materialdesign.MaterialDesign
 import org.wycliffeassociates.otter.jvm.controls.dialog.confirmdialog
+import org.wycliffeassociates.otter.jvm.controls.styles.tryImportStylesheet
 import org.wycliffeassociates.otter.jvm.utils.onChangeAndDoNow
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.components.ComboboxItem
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.components.DeviceComboboxCell
@@ -272,9 +273,9 @@ class SettingsView : View() {
     }
 
     init {
-        importStylesheet(resources.get("/css/app-drawer.css"))
-        importStylesheet(resources.get("/css/add-plugin-dialog.css"))
-        importStylesheet(resources.get("/css/confirm-dialog.css"))
+        tryImportStylesheet(resources.get("/css/app-drawer.css"))
+        tryImportStylesheet(resources.get("/css/add-plugin-dialog.css"))
+        tryImportStylesheet(resources.get("/css/confirm-dialog.css"))
         viewModel.refreshPlugins()
         initChangeLanguageDialog()
 

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/ChapterPage.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/ChapterPage.kt
@@ -48,6 +48,7 @@ import tornadofx.*
 import java.text.MessageFormat
 import java.util.*
 import org.wycliffeassociates.otter.common.utils.capitalizeString
+import org.wycliffeassociates.otter.jvm.controls.styles.tryImportStylesheet
 
 class ChapterPage : View() {
     private val logger = LoggerFactory.getLogger(ChapterPage::class.java)
@@ -106,11 +107,11 @@ class ChapterPage : View() {
     }
 
     init {
-        importStylesheet(resources.get("/css/chapter-page.css"))
-        importStylesheet(resources.get("/css/chunk-item.css"))
-        importStylesheet(resources.get("/css/take-item.css"))
-        importStylesheet(resources.get("/css/add-plugin-dialog.css"))
-        importStylesheet(resources.get("/css/confirm-dialog.css"))
+        tryImportStylesheet(resources.get("/css/chapter-page.css"))
+        tryImportStylesheet(resources.get("/css/chunk-item.css"))
+        tryImportStylesheet(resources.get("/css/take-item.css"))
+        tryImportStylesheet(resources.get("/css/add-plugin-dialog.css"))
+        tryImportStylesheet(resources.get("/css/confirm-dialog.css"))
 
         pluginOpenedPage = createPluginOpenedPage()
         workspace.subscribe<PluginOpenedEvent> { pluginInfo ->

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/HomePage.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/HomePage.kt
@@ -28,6 +28,7 @@ import org.wycliffeassociates.otter.jvm.controls.breadcrumbs.BreadCrumb
 import org.wycliffeassociates.otter.jvm.controls.card.BookCard
 import org.wycliffeassociates.otter.jvm.controls.card.NewTranslationCard
 import org.wycliffeassociates.otter.jvm.controls.card.TranslationCard
+import org.wycliffeassociates.otter.jvm.controls.styles.tryImportStylesheet
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.NavigationMediator
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.viewmodel.HomePageViewModel
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.viewmodel.SettingsViewModel
@@ -48,12 +49,12 @@ class HomePage : View() {
     }
 
     init {
-        importStylesheet(resources.get("/css/control.css"))
-        importStylesheet(resources.get("/css/home-page.css"))
-        importStylesheet(resources.get("/css/resume-book-banner.css"))
-        importStylesheet(resources.get("/css/new-translation-card.css"))
-        importStylesheet(resources.get("/css/translation-card.css"))
-        importStylesheet(resources.get("/css/book-card.css"))
+        tryImportStylesheet(resources.get("/css/control.css"))
+        tryImportStylesheet(resources.get("/css/home-page.css"))
+        tryImportStylesheet(resources.get("/css/resume-book-banner.css"))
+        tryImportStylesheet(resources.get("/css/new-translation-card.css"))
+        tryImportStylesheet(resources.get("/css/translation-card.css"))
+        tryImportStylesheet(resources.get("/css/book-card.css"))
     }
 
     override val root = stackpane {

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/RecordResourceFragment.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/RecordResourceFragment.kt
@@ -48,6 +48,7 @@ import org.wycliffeassociates.otter.jvm.controls.card.events.TakeEvent
 import org.wycliffeassociates.otter.jvm.controls.dialog.PluginOpenedPage
 import org.wycliffeassociates.otter.jvm.controls.dialog.confirmdialog
 import org.wycliffeassociates.otter.jvm.controls.dragtarget.DragTargetBuilder
+import org.wycliffeassociates.otter.jvm.controls.styles.tryImportStylesheet
 import org.wycliffeassociates.otter.jvm.utils.onChangeAndDoNow
 import org.wycliffeassociates.otter.jvm.workbookapp.SnackbarHandler
 import org.wycliffeassociates.otter.jvm.workbookapp.plugin.PluginClosedEvent
@@ -247,9 +248,9 @@ class RecordResourceFragment(private val recordableViewModel: RecordableViewMode
     }
 
     init {
-        importStylesheet(resources.get("/css/takecard.css"))
-        importStylesheet(resources.get("/css/resourcetakecard.css"))
-        importStylesheet(resources.get("/css/add-plugin-dialog.css"))
+        tryImportStylesheet(resources.get("/css/takecard.css"))
+        tryImportStylesheet(resources.get("/css/resourcetakecard.css"))
+        tryImportStylesheet(resources.get("/css/add-plugin-dialog.css"))
 
         isDraggingTakeProperty.onChange {
             if (it) recordableViewModel.stopPlayers()

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/RecordResourcePage.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/RecordResourcePage.kt
@@ -23,6 +23,7 @@ import org.kordamp.ikonli.javafx.FontIcon
 import org.kordamp.ikonli.materialdesign.MaterialDesign
 import org.wycliffeassociates.otter.common.data.primitives.ContentType
 import org.wycliffeassociates.otter.jvm.controls.breadcrumbs.BreadCrumb
+import org.wycliffeassociates.otter.jvm.controls.styles.tryImportStylesheet
 import org.wycliffeassociates.otter.jvm.utils.getNotNull
 import org.wycliffeassociates.otter.jvm.utils.onChangeAndDoNow
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.NavigationMediator
@@ -37,7 +38,7 @@ class RecordResourcePage : View() {
     private val workbookDataStore: WorkbookDataStore by inject()
 
     val tabPane = JFXTabPane().apply {
-        importStylesheet(resources.get("/css/tab-pane.css"))
+        tryImportStylesheet(resources.get("/css/tab-pane.css"))
     }
 
     override val root = tabPane

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/RecordScripturePage.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/RecordScripturePage.kt
@@ -48,6 +48,7 @@ import org.wycliffeassociates.otter.jvm.controls.card.events.TakeEvent
 import org.wycliffeassociates.otter.jvm.controls.dialog.PluginOpenedPage
 import org.wycliffeassociates.otter.jvm.controls.dialog.confirmdialog
 import org.wycliffeassociates.otter.jvm.controls.media.SourceContent
+import org.wycliffeassociates.otter.jvm.controls.styles.tryImportStylesheet
 import org.wycliffeassociates.otter.jvm.workbookapp.SnackbarHandler
 import org.wycliffeassociates.otter.jvm.workbookapp.plugin.PluginClosedEvent
 import org.wycliffeassociates.otter.jvm.workbookapp.plugin.PluginOpenedEvent
@@ -143,10 +144,10 @@ class RecordScripturePage : View() {
     }
 
     init {
-        importStylesheet(resources.get("/css/record-scripture.css"))
-        importStylesheet(resources.get("/css/takecard.css"))
-        importStylesheet(resources.get("/css/scripturetakecard.css"))
-        importStylesheet(resources.get("/css/add-plugin-dialog.css"))
+        tryImportStylesheet(resources.get("/css/record-scripture.css"))
+        tryImportStylesheet(resources.get("/css/takecard.css"))
+        tryImportStylesheet(resources.get("/css/scripturetakecard.css"))
+        tryImportStylesheet(resources.get("/css/add-plugin-dialog.css"))
 
         isDraggingFileProperty.onChange {
             if (it) recordScriptureViewModel.stopPlayers()

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/ResourcePage.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/ResourcePage.kt
@@ -21,6 +21,7 @@ package org.wycliffeassociates.otter.jvm.workbookapp.ui.screens
 import org.kordamp.ikonli.javafx.FontIcon
 import org.kordamp.ikonli.materialdesign.MaterialDesign
 import org.wycliffeassociates.otter.jvm.controls.breadcrumbs.BreadCrumb
+import org.wycliffeassociates.otter.jvm.controls.styles.tryImportStylesheet
 import org.wycliffeassociates.otter.jvm.controls.workbookheader.workbookheader
 import org.wycliffeassociates.otter.jvm.workbookapp.controls.resourcecard.view.ResourceListView
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.NavigationMediator
@@ -55,7 +56,7 @@ class ResourcePage : View() {
     }
 
     init {
-        importStylesheet(resources.get("/css/resource-page.css"))
+        tryImportStylesheet(resources.get("/css/resource-page.css"))
     }
 
     override val root = vbox {

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/RootView.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/RootView.kt
@@ -21,6 +21,7 @@ package org.wycliffeassociates.otter.jvm.workbookapp.ui.screens
 import javafx.application.Platform
 import javafx.scene.layout.Priority
 import org.wycliffeassociates.otter.common.data.ColorTheme
+import org.wycliffeassociates.otter.jvm.controls.styles.tryImportStylesheet
 import org.wycliffeassociates.otter.jvm.utils.onChangeAndDoNow
 import org.wycliffeassociates.otter.jvm.workbookapp.plugin.PluginClosedEvent
 import org.wycliffeassociates.otter.jvm.workbookapp.plugin.PluginOpenedEvent
@@ -52,7 +53,7 @@ class RootView : View() {
         workspace.header.removeFromParent()
         workspace.root.vgrow = Priority.ALWAYS
 
-        importStylesheet(resources.get("/css/audio-error-dialog.css"))
+        tryImportStylesheet(resources.get("/css/audio-error-dialog.css"))
         initThemeStylesheets()
         bindThemeClassToRoot()
 
@@ -72,8 +73,8 @@ class RootView : View() {
     }
 
     private fun initThemeStylesheets() {
-        importStylesheet(resources["/css/theme/light-theme.css"])
-        importStylesheet(resources["/css/theme/dark-theme.css"])
+        tryImportStylesheet(resources["/css/theme/light-theme.css"])
+        tryImportStylesheet(resources["/css/theme/dark-theme.css"])
     }
 
     private fun initAudioErrorDialog() {

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/WorkbookPage.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/WorkbookPage.kt
@@ -33,6 +33,7 @@ import org.wycliffeassociates.otter.common.data.primitives.ResourceMetadata
 import org.wycliffeassociates.otter.jvm.controls.breadcrumbs.BreadCrumb
 import org.wycliffeassociates.otter.jvm.controls.card.DefaultStyles
 import org.wycliffeassociates.otter.jvm.controls.dialog.confirmdialog
+import org.wycliffeassociates.otter.jvm.controls.styles.tryImportStylesheet
 import org.wycliffeassociates.otter.jvm.utils.onChangeAndDoNow
 import org.wycliffeassociates.otter.jvm.workbookapp.theme.AppStyles
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.NavigationMediator
@@ -85,10 +86,10 @@ class WorkbookPage : View() {
     }
 
     init {
-        importStylesheet(resources.get("/css/workbook-page.css"))
-        importStylesheet(resources.get("/css/chapter-card.css"))
-        importStylesheet(resources.get("/css/workbook-banner.css"))
-        importStylesheet(resources.get("/css/confirm-dialog.css"))
+        tryImportStylesheet(resources.get("/css/workbook-page.css"))
+        tryImportStylesheet(resources.get("/css/chapter-card.css"))
+        tryImportStylesheet(resources.get("/css/workbook-banner.css"))
+        tryImportStylesheet(resources.get("/css/confirm-dialog.css"))
     }
 
     /**
@@ -142,7 +143,7 @@ class WorkbookPage : View() {
     override val root = JFXTabPane().apply {
         importStylesheet<CardGridStyles>()
         importStylesheet<DefaultStyles>()
-        importStylesheet(resources.get("/css/tab-pane.css"))
+        tryImportStylesheet(resources.get("/css/tab-pane.css"))
         addClass(Stylesheet.tabPane)
 
         tabs.onChange {

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/book/BookSelection.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/book/BookSelection.kt
@@ -27,6 +27,7 @@ import org.kordamp.ikonli.materialdesign.MaterialDesign
 import org.wycliffeassociates.otter.jvm.controls.bar.FilteredSearchBar
 import org.wycliffeassociates.otter.jvm.controls.breadcrumbs.BreadCrumb
 import org.wycliffeassociates.otter.jvm.controls.dialog.confirmdialog
+import org.wycliffeassociates.otter.jvm.controls.styles.tryImportStylesheet
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.NavigationMediator
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.components.BookCell
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.viewmodel.BookWizardViewModel
@@ -106,10 +107,10 @@ class BookSelection : Fragment() {
     }
 
     init {
-        importStylesheet(resources.get("/css/book-wizard.css"))
-        importStylesheet(resources.get("/css/filtered-search-bar.css"))
-        importStylesheet(resources.get("/css/book-card-cell.css"))
-        importStylesheet(resources.get("/css/confirm-dialog.css"))
+        tryImportStylesheet(resources.get("/css/book-wizard.css"))
+        tryImportStylesheet(resources.get("/css/filtered-search-bar.css"))
+        tryImportStylesheet(resources.get("/css/book-card-cell.css"))
+        tryImportStylesheet(resources.get("/css/confirm-dialog.css"))
 
         createProgressDialog()
     }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/SourceLanguageSelection.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/SourceLanguageSelection.kt
@@ -24,6 +24,7 @@ import org.kordamp.ikonli.javafx.FontIcon
 import org.kordamp.ikonli.material.Material
 import org.wycliffeassociates.otter.jvm.controls.bar.FilteredSearchBar
 import org.wycliffeassociates.otter.jvm.controls.breadcrumbs.BreadCrumb
+import org.wycliffeassociates.otter.jvm.controls.styles.tryImportStylesheet
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.NavigationMediator
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.components.LanguageCell
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.components.LanguageType
@@ -82,9 +83,9 @@ class SourceLanguageSelection : Fragment() {
     }
 
     init {
-        importStylesheet(resources.get("/css/translation-wizard.css"))
-        importStylesheet(resources.get("/css/language-card-cell.css"))
-        importStylesheet(resources.get("/css/filtered-search-bar.css"))
+        tryImportStylesheet(resources.get("/css/translation-wizard.css"))
+        tryImportStylesheet(resources.get("/css/language-card-cell.css"))
+        tryImportStylesheet(resources.get("/css/filtered-search-bar.css"))
 
         translationViewModel.sourceLanguages.onChange {
             viewModel.regions.setAll(

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/TargetLanguageSelection.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/TargetLanguageSelection.kt
@@ -26,6 +26,7 @@ import org.kordamp.ikonli.materialdesign.MaterialDesign
 import org.wycliffeassociates.otter.jvm.controls.bar.FilteredSearchBar
 import org.wycliffeassociates.otter.jvm.controls.breadcrumbs.BreadCrumb
 import org.wycliffeassociates.otter.jvm.controls.dialog.confirmdialog
+import org.wycliffeassociates.otter.jvm.controls.styles.tryImportStylesheet
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.NavigationMediator
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.components.LanguageCell
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.components.LanguageType
@@ -81,10 +82,10 @@ class TargetLanguageSelection : Fragment() {
     }
 
     init {
-        importStylesheet(resources.get("/css/translation-wizard.css"))
-        importStylesheet(resources.get("/css/language-card-cell.css"))
-        importStylesheet(resources.get("/css/filtered-search-bar.css"))
-        importStylesheet(resources.get("/css/confirm-dialog.css"))
+        tryImportStylesheet(resources.get("/css/translation-wizard.css"))
+        tryImportStylesheet(resources.get("/css/language-card-cell.css"))
+        tryImportStylesheet(resources.get("/css/filtered-search-bar.css"))
+        tryImportStylesheet(resources.get("/css/confirm-dialog.css"))
 
         translationViewModel.targetLanguages.onChange {
             viewModel.regions.setAll(


### PR DESCRIPTION
importStylesheet() will just flood the stylesheet list without concern about duplicated entries. This PR adds a new wrapper function which prevents adding if a stylesheet has already imported.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/orature/485)
<!-- Reviewable:end -->
