### PR TITLE
Create prerelease workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,6 +63,7 @@ jobs:
         run: echo "CURRENT_S3_DESTINATION=$CI_REPOSITORY_OWNER/$CI_REPOSITORY_NAME/$UPDATE_PATH" >> $GITHUB_ENV
       - name: Upload file to bucket
         uses: shallwefootball/s3-upload-action@v1.1.3
+        if: github.event_name != 'pull_request'
         with:
           aws_key_id: ${{ secrets.AWS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
         uses: booxmedialtd/ws-action-parse-semver@v1.4.2
         with:
           input_string: ${{ env.CI_REF_NAME }}
-          version_extractor_regex: '\/v(.*)$' 
+          version_extractor_regex: 'v(.*)$' 
         if: contains( github.ref, 'refs/tags/v' )
       - name: set version var for tags and update path for releases
         id: tagged

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: FranzDiebold/github-env-vars-action@v2.1.0
       - name: Parse SemVer if tagged build
         id: semver_parser 
-        uses: booxmedialtd/ws-action-parse-semver@v1
+        uses: booxmedialtd/ws-action-parse-semver@v1.4.2
         with:
           input_string: ${{ env.CI_REF_NAME }}
           version_extractor_regex: '\/v(.*)$' 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,8 +17,7 @@ jobs:
         id: tagged
         run: |
           echo "ORG_GRADLE_PROJECT_gradlewCommandVersionProp=${{ steps.semver_parser.outputs.fullversion }}+$GITHUB_RUN_NUMBER" >> $GITHUB_ENV && \
-          echo "UPDATE_PATH=release" >> $GITHUB_ENV && \
-          echo "${{ steps.semver_parser.outputs.fullversion }}" > VERSION
+          echo "UPDATE_PATH=release" >> $GITHUB_ENV
         if: contains( github.ref, 'refs/tags/v' )
       - name: If this is a tagged pre-release build set pre-release label and update path
         id: prerelease

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,8 @@ jobs:
         id: tagged
         run: |
           echo "ORG_GRADLE_PROJECT_gradlewCommandVersionProp=${{ steps.semver_parser.outputs.fullversion }}+$GITHUB_RUN_NUMBER" >> $GITHUB_ENV && \
-          echo "UPDATE_PATH=release" >> $GITHUB_ENV
+          echo "UPDATE_PATH=release" >> $GITHUB_ENV && \
+          echo "${{ steps.semver_parser.outputs.fullversion }}" > VERSION
         if: contains( github.ref, 'refs/tags/v' )
       - name: If this is a tagged pre-release build set pre-release label and update path
         id: prerelease
@@ -27,7 +28,7 @@ jobs:
         if: ${{ steps.semver_parser.outputs.prerelease }}
       - name: set version var for not-tags and upload dir for branches
         run: |
-          echo "ORG_GRADLE_PROJECT_gradlewCommandVersionProp=$(git describe --abbrev=0 --tags)+$GITHUB_RUN_NUMBER" >> $GITHUB_ENV && \
+          echo "ORG_GRADLE_PROJECT_gradlewCommandVersionProp=$(cat VERSION)+$GITHUB_RUN_NUMBER" >> $GITHUB_ENV && \
           echo "UPDATE_PATH=$CI_REF_NAME_SLUG" >> $GITHUB_ENV
         if: ${{ steps.tagged.outcome == 'skipped' }}
       - name: Decrypt secret file

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       - name: set s3 destination_dir
-        if: ${{ env.CI_REF_NAME_SLUG == 'pre-release' }}
         run: echo "CURRENT_S3_DESTINATION=$CI_REPOSITORY_OWNER/$CI_REPOSITORY_NAME/$UPDATE_PATH" >> $GITHUB_ENV
       - name: Upload file to bucket
         uses: shallwefootball/s3-upload-action@v1.1.3


### PR DESCRIPTION
Tagging now releases to github releases if tagged with a semver.org compatible version starting with a v. E.G. `v1.0.0`

If tagged with a semver compatible pre-release it will tag the release as a github pre-release and upload the artifcacts to a pre-release update bucket for that particular pre-release. EG 1.1.0-alpha will got to the alpha bucket and when 1.1.1-alpha is released it will go to the alpha bucket and show as an update available when updates are checked in app.

Any pre-release name is OK for the pre-release and will allow updates.

Any branch will now also allow in-app updates for multiple builds within the same branch when installed from the nightly builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/orature/503)
<!-- Reviewable:end -->
