### PR TITLE
Fix deleting the old rc properly during import-update

### DIFF
--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/DeleteResourceContainer.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/DeleteResourceContainer.kt
@@ -23,6 +23,7 @@ import org.slf4j.LoggerFactory
 import org.wycliffeassociates.otter.common.persistence.IDirectoryProvider
 import org.wycliffeassociates.otter.common.persistence.repositories.IResourceContainerRepository
 import org.wycliffeassociates.resourcecontainer.ResourceContainer
+import java.io.File
 import javax.inject.Inject
 
 class DeleteResourceContainer @Inject constructor(
@@ -42,11 +43,17 @@ class DeleteResourceContainer @Inject constructor(
                     val file = directoryProvider.getSourceContainerDirectory(resourceContainer)
                     logger.info("Deleting RC: $file")
                     if (file.deleteRecursively()) {
-                        logger.error("RC partially deleted: $file")
-                    } else {
                         logger.info("RC deleted successfully!")
+                    } else {
+                        logger.error("RC partially deleted: $file")
                     }
                 }
             }
+    }
+
+    fun delete(rcFile: File): Single<DeleteResult> {
+        ResourceContainer.load(rcFile).use {
+            return delete(it)
+        }
     }
 }

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/ImportResourceContainer.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/ImportResourceContainer.kt
@@ -169,9 +169,9 @@ class ImportResourceContainer @Inject constructor(
      * importing the new one if they have different versions.
      * Returns false if it could not delete the existing RC.
      */
-    private fun tryUpdateExistingRC(rcFile: File): Boolean {
-        ResourceContainer.load(rcFile).use { rc ->
-            val dublinCore = rc.manifest.dublinCore
+    private fun tryUpdateExistingRC(newFile: File): Boolean {
+        ResourceContainer.load(newFile).use { newRc ->
+            val dublinCore = newRc.manifest.dublinCore
             resourceMetadataRepository.getAllSources().blockingGet()
                 .find {
                     it.language.slug == dublinCore.language.identifier &&
@@ -180,9 +180,10 @@ class ImportResourceContainer @Inject constructor(
                     var isDeleted = false
 
                     // delete if matching rc has different version
-                    if (existingRc.version != rc.manifest.dublinCore.version) {
+                    if (existingRc.version != newRc.manifest.dublinCore.version) {
                         logger.info("Existing RC has different version, updating...")
-                        val result = deleteProvider.get().delete(rc).blockingGet()
+
+                        val result = deleteProvider.get().delete(existingRc.path).blockingGet()
                         if (result == DeleteResult.SUCCESS) {
                             isDeleted = true
                             logger.info("Removed old RC successfully!")

--- a/jvm/workbookapp/src/integration-test/kotlin/integrationtest/projects/TestRcImport.kt
+++ b/jvm/workbookapp/src/integration-test/kotlin/integrationtest/projects/TestRcImport.kt
@@ -24,6 +24,8 @@ import com.fasterxml.jackson.dataformat.csv.CsvSchema
 import com.fasterxml.jackson.module.kotlin.KotlinModule
 import integrationtest.di.DaggerTestPersistenceComponent
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import javax.inject.Inject
 import javax.inject.Provider
 import org.junit.Test
@@ -32,6 +34,7 @@ import org.wycliffeassociates.otter.common.data.primitives.ContentType.META
 import org.wycliffeassociates.otter.common.data.primitives.ContentType.TEXT
 import org.wycliffeassociates.otter.common.data.primitives.ContentType.TITLE
 import org.wycliffeassociates.resourcecontainer.ResourceContainer
+import java.io.File
 
 class TestRcImport {
 
@@ -203,6 +206,7 @@ class TestRcImport {
     fun `import override when existing rc has different version`() {
         val oldRCVer = "12"
         val newRCVer = "999"
+        var oldRCFile: File? = null
 
         dbEnvProvider.get()
             .import("en_ulb.zip")
@@ -220,6 +224,8 @@ class TestRcImport {
                     oldRCVer,
                     db.resourceMetadataDao.fetchAll().single().version
                 )
+                oldRCFile = File(db.resourceMetadataDao.fetchAll().single().path)
+                assertTrue(oldRCFile!!.exists())
             }
             .import("en_ulb_newer_ver.zip")
             .assertRowCounts(
@@ -233,6 +239,10 @@ class TestRcImport {
                 assertEquals(
                     newRCVer,
                     db.resourceMetadataDao.fetchAll().single().version
+                )
+                assertFalse(
+                    "Old rc should no longer exist after overwrite import.",
+                    oldRCFile!!.exists()
                 )
             }
     }


### PR DESCRIPTION
Original bug found in #491. The old rc was not properly deleted from the internal directory.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/orature/504)
<!-- Reviewable:end -->
