### PR TITLE
Unset text fill for common wa list view

### DIFF
--- a/jvm/controls/src/main/resources/css/control.css
+++ b/jvm/controls/src/main/resources/css/control.css
@@ -550,10 +550,6 @@
     -fx-background-color: -wa-transparent;
 }
 
-.wa-list-view .label {
-    -fx-text-fill: -wa-gray-darker;
-}
-
 /* ------------------- Menu Button --------------- */
 .wa-menu-button {
     -fx-pref-height: 48px;


### PR DESCRIPTION
Bug in dark mode: text color defined in wa-list-view

![image](https://user-images.githubusercontent.com/34975907/157311933-62435bf7-be62-4560-9d4d-fc8cd036db35.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/orature/515)
<!-- Reviewable:end -->
