### PR TITLE
Replace MappedByteBuffer with RandomAccessFile in WavFileReader

### DIFF
--- a/common/audio/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/WavFileReader.kt
+++ b/common/audio/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/WavFileReader.kt
@@ -21,15 +21,15 @@ package org.wycliffeassociates.otter.common.audio.wav
 import org.slf4j.LoggerFactory
 import org.wycliffeassociates.otter.common.audio.AudioFileReader
 import java.io.RandomAccessFile
-import java.lang.Exception
 import java.lang.IllegalStateException
 import java.lang.Integer.max
 import java.lang.Integer.min
-import java.nio.ByteBuffer
-import java.nio.MappedByteBuffer
-import java.nio.channels.FileChannel
 
-internal class WavFileReader(val wav: WavFile, val start: Int? = null, val end: Int? = null) : AudioFileReader {
+internal class WavFileReader(
+    val wav: WavFile,
+    val playbackSectionBegin: Int? = null,
+    val playbackSectionEnd: Int? = null
+) : AudioFileReader {
 
     private val logger = LoggerFactory.getLogger(WavFileReader::class.java)
 
@@ -38,23 +38,20 @@ internal class WavFileReader(val wav: WavFile, val start: Int? = null, val end: 
     override val channels: Int = wav.channels
     override val sampleSize: Int = wav.bitsPerSample
     override val framePosition: Int
-        get() = (mappedFile?.position() ?: 0) / wav.frameSizeInBytes
+        get() = pos / wav.frameSizeInBytes
 
-    private var mappedFile: MappedByteBuffer? = null
-    private var channel: FileChannel? = null
+    private var raf: RandomAccessFile? = null
+
+    private var start = 0
+    private var stop = 0
+    private var pos = playbackSectionBegin ?: 44
 
     override fun open() {
-        mappedFile?.let { release() }
         val (begin, end) = computeBounds(wav)
-        mappedFile =
-            RandomAccessFile(wav.file, "r").use {
-                channel = it.channel
-                channel!!.map(
-                    FileChannel.MapMode.READ_ONLY,
-                    begin.toLong(),
-                    (end - begin).toLong()
-                )
-            }
+        start = begin
+        stop = end
+        pos = start
+        raf = RandomAccessFile(wav.file, "r")
     }
 
     fun computeBounds(wav: WavFile): Pair<Int, Int> {
@@ -64,8 +61,8 @@ internal class WavFileReader(val wav: WavFile, val start: Int? = null, val end: 
         }
 
         val totalFrames = wav.totalFrames
-        var begin = if (start != null) min(max(0, start), totalFrames) else 0
-        var end = if (end != null) min(max(begin, end), totalFrames) else totalFrames
+        var begin = if (playbackSectionBegin != null) min(max(0, playbackSectionBegin), totalFrames) else 0
+        var end = if (playbackSectionEnd != null) min(max(begin, playbackSectionEnd), totalFrames) else totalFrames
 
         // Convert from frames to array index
         begin *= wav.frameSizeInBytes
@@ -87,47 +84,39 @@ internal class WavFileReader(val wav: WavFile, val start: Int? = null, val end: 
     }
 
     override fun getPcmBuffer(bytes: ByteArray): Int {
-        mappedFile?.let { _mappedFile ->
-            val written = _mappedFile.remaining().coerceAtMost(bytes.size)
-            _mappedFile.get(bytes, 0, written)
+        raf?.let { raf ->
+            val written = remaining().coerceAtMost(bytes.size)
+            raf.read(bytes, 0, written)
+            pos += written
             return written
         } ?: run {
             throw IllegalStateException("Tried to get pcm buffer before opening file")
         }
     }
 
+    private fun remaining(): Int {
+        return stop - pos
+    }
+
     @Throws(ArrayIndexOutOfBoundsException::class)
     override fun seek(sample: Int) {
-        mappedFile?.let { _mappedFile ->
-            val index = min(wav.sampleIndex(sample), _mappedFile.limit())
-            _mappedFile.position(index)
+        raf?.let { raf ->
+            val index = min(wav.sampleIndex(sample) + WAV_HEADER_SIZE, stop)
+            pos = index
+            raf.seek(index.toLong())
         } ?: run {
             throw IllegalStateException("Tried to seek before opening file")
         }
     }
 
     override fun hasRemaining(): Boolean {
-        return mappedFile?.hasRemaining() ?: throw IllegalStateException("hasRemaining called before opening file")
+        if (raf != null) return remaining() > 0 else throw IllegalStateException("hasRemaining called before opening file")
     }
 
     override fun release() {
-        if (mappedFile != null) {
-            try {
-                // https://stackoverflow.com/questions/25238110/how-to-properly-close-mappedbytebuffer/25239834#25239834
-                // TODO: Replace with https://docs.oracle.com/en/java/javase/14/docs/api/jdk.incubator.foreign/jdk/incubator/foreign/MemorySegment.html#ofByteBuffer(java.nio.ByteBuffer)
-                val unsafeClass = Class.forName("sun.misc.Unsafe")
-                val unsafeField = unsafeClass.getDeclaredField("theUnsafe")
-                unsafeField.isAccessible = true
-                val unsafe: Any = unsafeField.get(null)
-                val invokeCleaner = unsafeClass.getMethod("invokeCleaner", ByteBuffer::class.java)
-                invokeCleaner.invoke(unsafe, mappedFile)
-            } catch (e: Exception) {
-                logger.error("Error releasing memory mapped file: ${wav.file.name}", e)
-            }
-            channel?.close()
-            mappedFile = null
-            channel = null
-            System.gc()
+        raf?.let {
+            it.close()
+            pos = 0
         }
     }
 }


### PR DESCRIPTION
Switch implementation from mappedbytebuffer to randomaccess file to avoid issues with releasing resources.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/orature/517)
<!-- Reviewable:end -->
