### PR TITLE
Prevent unselect plugin

### DIFF
--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/button/SelectButton.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/button/SelectButton.kt
@@ -32,4 +32,11 @@ class SelectButton : ToggleButton() {
     override fun createDefaultSkin(): Skin<*> {
         return SelectButtonSkin(this)
     }
+
+    override fun fire() {
+        // we don't toggle from selected to not selected if part of a group
+        if (toggleGroup == null || !isSelected) {
+            super.fire()
+        }
+    }
 }

--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/skins/button/SelectButtonSkin.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/skins/button/SelectButtonSkin.kt
@@ -18,7 +18,7 @@
  */
 package org.wycliffeassociates.otter.jvm.controls.skins.button
 
-import com.sun.javafx.scene.control.behavior.ToggleButtonBehavior
+import com.sun.javafx.scene.control.behavior.ButtonBehavior
 import javafx.fxml.FXML
 import javafx.fxml.FXMLLoader
 import javafx.scene.Node
@@ -31,7 +31,7 @@ import org.wycliffeassociates.otter.jvm.controls.button.SelectButton
 import tornadofx.*
 
 class SelectButtonSkin(private val button: SelectButton) : SkinBase<SelectButton>(button) {
-    private val behavior = ToggleButtonBehavior(button)
+    private val behavior = ButtonBehavior(button)
 
     @FXML
     lateinit var root: HBox
@@ -54,7 +54,8 @@ class SelectButtonSkin(private val button: SelectButton) : SkinBase<SelectButton
     }
 
     private fun initializeControl() {
-        btnRadio.selectedProperty().bindBidirectional(button.selectedProperty())
+        btnRadio.isMouseTransparent = true
+        btnRadio.selectedProperty().bind(button.selectedProperty())
 
         btnLabel.apply {
             textProperty().bind(button.textProperty())

--- a/jvm/controls/src/main/resources/css/select-button.css
+++ b/jvm/controls/src/main/resources/css/select-button.css
@@ -30,10 +30,6 @@
     -fx-cursor: hand;
 }
 
-.select-button .wa-radio .radio {
-    -fx-background-color: -wa-checkbox-button-background;
-}
-
 .select-button:disabled {
     -fx-border-width: 0px;
 }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/drawer/SettingsView.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/drawer/SettingsView.kt
@@ -231,31 +231,37 @@ class SettingsView : View() {
 
                                 region { hgrow = Priority.ALWAYS }
 
-                                add(
-                                    SelectButton().apply {
-                                        isDisable = !pluginData.canRecord
-                                        viewModel.selectedRecorderProperty.onChangeAndDoNow { selectedData ->
-                                            isSelected = selectedData == pluginData
+                                hbox {
+                                    addClass("app-drawer__plugin__radio-btn-wrapper")
+                                    add(
+                                        SelectButton().apply {
+                                            isDisable = !pluginData.canRecord
+                                            viewModel.selectedRecorderProperty.onChangeAndDoNow { selectedData ->
+                                                isSelected = selectedData == pluginData
+                                            }
+                                            selectedProperty().onChange { selected ->
+                                                if (selected) viewModel.selectRecorder(pluginData)
+                                            }
+                                            toggleGroup = recorderToggleGroup
                                         }
-                                        selectedProperty().onChange { selected ->
-                                            if (selected) viewModel.selectRecorder(pluginData)
-                                        }
-                                        toggleGroup = recorderToggleGroup
-                                    }
-                                )
+                                    )
+                                }
 
-                                add(
-                                    SelectButton().apply {
-                                        isDisable = !pluginData.canEdit
-                                        viewModel.selectedEditorProperty.onChangeAndDoNow { selectedData ->
-                                            isSelected = selectedData == pluginData
+                                hbox {
+                                    addClass("app-drawer__plugin__radio-btn-wrapper")
+                                    add(
+                                        SelectButton().apply {
+                                            isDisable = !pluginData.canEdit
+                                            viewModel.selectedEditorProperty.onChangeAndDoNow { selectedData ->
+                                                isSelected = selectedData == pluginData
+                                            }
+                                            selectedProperty().onChange { selected ->
+                                                if (selected) viewModel.selectEditor(pluginData)
+                                            }
+                                            toggleGroup = editorToggleGroup
                                         }
-                                        selectedProperty().onChange { selected ->
-                                            if (selected) viewModel.selectEditor(pluginData)
-                                        }
-                                        toggleGroup = editorToggleGroup
-                                    }
-                                )
+                                    )
+                                }
                             }
                         }
                     }

--- a/jvm/workbookapp/src/main/resources/css/app-drawer.css
+++ b/jvm/workbookapp/src/main/resources/css/app-drawer.css
@@ -141,6 +141,15 @@
     -fx-font-size: 24px;
 }
 
+.app-drawer__plugin__radio-btn-wrapper {
+    -fx-pref-width: 50px;
+    -fx-alignment: center;
+}
+
+.app-drawer__plugin .select-button {
+    -fx-background-color: transparent;
+}
+
 .app-drawer__drag-drop-area {
     -fx-alignment: center;
     -fx-border-width: 2px;


### PR DESCRIPTION
It is complicated and messy to have the toggle buttons listened to both the view model changes and user selection by selectedProperty(). 
The PR separates model changes and user event by using setOnAction() instead of binding to selectedProperty() which already coupled with the view model property

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/orature/529)
<!-- Reviewable:end -->
