### PR TITLE
Fix shortcuts text color in dark theme

### DIFF
--- a/jvm/workbookapp/src/main/resources/css/app-drawer.css
+++ b/jvm/workbookapp/src/main/resources/css/app-drawer.css
@@ -167,4 +167,9 @@
     -fx-border-color: -wa-text-field-border;
     -fx-border-radius: 6px;
     -fx-padding: 10px;
+    -fx-text-fill: -wa-regular-text;
+}
+
+.app-drawer__shortcut .ikonli-font-icon {
+    -fx-fill: -wa-regular-text;
 }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/orature/531)
<!-- Reviewable:end -->
