### PR TITLE
Fix crash with mp3 - "zero size tag"

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -49,5 +49,5 @@ ext {
     jump3rVer='1.0.5'
     systemThemeDectectorVer='3.7'
     tarsosDspVer = '2.4.1'
-    mp3TagVer = '0.9.1'
+    mp3TagVer = '0.9.3'
 }


### PR DESCRIPTION
Uses a fork to avoid throwing exception when loading an mp3 file which has never been tagged.
` 0.9.3 ` is hosted from our private maven repo

See changes: https://github.com/mpatric/mp3agic/pull/191

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/orature/533)
<!-- Reviewable:end -->
