### PR TITLE
Bugfix: Duplicating workbooks

### DIFF
--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/data/workbook/Book.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/data/workbook/Book.kt
@@ -24,8 +24,9 @@ import org.wycliffeassociates.otter.common.data.primitives.Language
 import org.wycliffeassociates.otter.common.data.primitives.ResourceMetadata
 import org.wycliffeassociates.otter.common.data.primitives.Collection
 import java.time.LocalDateTime
+import java.util.*
 
-data class Book(
+class Book(
     val collectionId: Int,
     val sort: Int,
     val slug: String,
@@ -53,4 +54,26 @@ data class Book(
         modifiedTs,
         collectionId
     )
+
+    override fun hashCode(): Int {
+        return Objects.hash(
+            collectionId,
+            sort,
+            slug,
+            title,
+            label
+        )
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as Book
+
+        if (slug != other.slug) return false
+        if (collectionId != other.collectionId) return false
+
+        return true
+    }
 }

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/persistence/repositories/WorkbookRepository.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/persistence/repositories/WorkbookRepository.kt
@@ -94,6 +94,13 @@ class WorkbookRepository(
     private val connections = mutableMapOf<Workbook, CompositeDisposable>()
 
     override fun get(source: Collection, target: Collection): Workbook {
+        logger.info("Opening workbook with source $source and target $target")
+
+        val existing = getExistingWorkbookIfExists(source, target)
+        if (existing != null) {
+            return existing
+        }
+
         // Clear database connections and dispose observables for the
         // previous Workbook if a new one was requested.
         val disposables = mutableListOf<Disposable>()
@@ -113,6 +120,10 @@ class WorkbookRepository(
         )
         connections[workbook] = CompositeDisposable(disposables)
         return workbook
+    }
+
+    private fun getExistingWorkbookIfExists(source: Collection, target: Collection): Workbook? {
+        return connections.keys.find { it.source.collectionId == source.id && it.target.collectionId == target.id }
     }
 
     override fun closeWorkbook(workbook: Workbook) {


### PR DESCRIPTION
Workbooks are retrieved multiple times, resulting in extra subscribers which probably won't get cleaned up.

This change checks to see if a workbook exists in the connection map, and returns it if one is found.

Additionally, equals and hashcode are added to Book, as non-primitives are part of the constructor and thus cannot be a data-class.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/orature/550)
<!-- Reviewable:end -->
