### PR TITLE
Fix crash in Record Scripture Page

### DIFF
--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/RecordScripturePage.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/RecordScripturePage.kt
@@ -324,7 +324,6 @@ class RecordScripturePage : View() {
 
                         minHeightProperty().bind(Bindings.size(items).multiply(TAKES_ROW_HEIGHT))
                         placeholder = ListViewPlaceHolder()
-                        selectionModelProperty().set(null)
                     }
                 }
             }


### PR DESCRIPTION
Clicking on empty card inside Record Scripture Page (View Takes) causes a crash  #555 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/orature/557)
<!-- Reviewable:end -->
