### PR TITLE
Source text zoom

### DIFF
--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/plugins/PluginParameters.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/plugins/PluginParameters.kt
@@ -39,5 +39,6 @@ data class PluginParameters(
     val direction: String? = null,
     val sourceDirection: String? = null,
     val sourceRate: Double = 1.0,
-    val targetRate: Double = 1.0
+    val targetRate: Double = 1.0,
+    val sourceTextZoom: Int = 100
 )

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/persistence/IAppPreferences.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/persistence/IAppPreferences.kt
@@ -42,4 +42,6 @@ interface IAppPreferences {
     fun setLocaleLanguage(locale: String): Completable
     fun appTheme(): Single<String>
     fun setAppTheme(theme: String): Completable
+    fun sourceTextZoomRate(): Single<Int>
+    fun setSourceTextZoomRate(rate: Int): Completable
 }

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/persistence/repositories/IAppPreferencesRepository.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/persistence/repositories/IAppPreferencesRepository.kt
@@ -37,4 +37,6 @@ interface IAppPreferencesRepository {
     fun setLocaleLanguage(language: Language): Completable
     fun appTheme(): Single<ColorTheme>
     fun setAppTheme(theme: ColorTheme): Completable
+    fun sourceTextZoomRate(): Single<Int>
+    fun setSourceTextZoomRate(rate: Int): Completable
 }

--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/dialog/PluginOpenedPage.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/dialog/PluginOpenedPage.kt
@@ -20,6 +20,7 @@ package org.wycliffeassociates.otter.jvm.controls.dialog
 
 import javafx.beans.property.SimpleBooleanProperty
 import javafx.beans.property.SimpleDoubleProperty
+import javafx.beans.property.SimpleIntegerProperty
 import javafx.beans.property.SimpleObjectProperty
 import javafx.beans.property.SimpleStringProperty
 import javafx.beans.value.ChangeListener
@@ -48,6 +49,7 @@ class PluginOpenedPage : Fragment() {
     val sourceOrientationProperty = SimpleObjectProperty<NodeOrientation>()
     val sourceSpeedRateProperty = SimpleDoubleProperty()
     val targetSpeedRateProperty = SimpleDoubleProperty()
+    val sourceTextZoomRateProperty = SimpleIntegerProperty()
 
     private var sourcePlayerListener: ChangeListener<IAudioPlayer>? = null
     private var targetPlayerListener: ChangeListener<IAudioPlayer>? = null
@@ -93,6 +95,9 @@ class PluginOpenedPage : Fragment() {
 
                 sourceSpeedRateProperty.bind(this@PluginOpenedPage.sourceSpeedRateProperty)
                 targetSpeedRateProperty.bind(this@PluginOpenedPage.targetSpeedRateProperty)
+                this@PluginOpenedPage.sourceTextZoomRateProperty.onChange {
+                    zoomRateProperty.set(it)
+                }
             }
         )
     }

--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/dialog/PluginOpenedPage.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/dialog/PluginOpenedPage.kt
@@ -35,7 +35,7 @@ import org.wycliffeassociates.otter.jvm.controls.styles.tryImportStylesheet
 import org.wycliffeassociates.otter.jvm.utils.onChangeAndDoNowWithListener
 import tornadofx.*
 
-class PluginOpenedPage : Fragment() {
+class PluginOpenedPage : View() {
 
     val dialogTitleProperty = SimpleStringProperty()
     val dialogTextProperty = SimpleStringProperty()

--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/media/SourceContent.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/media/SourceContent.kt
@@ -61,6 +61,7 @@ class SourceContent : Control() {
     val enableAudioProperty = SimpleBooleanProperty(true)
     val isMinimizableProperty = SimpleBooleanProperty(true)
     val isMinimizedProperty = SimpleBooleanProperty(false)
+    val zoomRateProperty = SimpleIntegerProperty(100)
 
     val orientationProperty = SimpleObjectProperty<NodeOrientation>()
     val sourceOrientationProperty = SimpleObjectProperty<NodeOrientation>()

--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/media/SourceContent.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/media/SourceContent.kt
@@ -32,6 +32,8 @@ import org.wycliffeassociates.otter.jvm.controls.skins.media.SourceContentSkin
 import tornadofx.*
 import java.text.MessageFormat
 
+class SourceTextZoomRateChangedEvent(val rate: Int) : FXEvent()
+
 class SourceContent : Control() {
     val contentTitleProperty = SimpleStringProperty()
 

--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/skins/media/SourceContentSkin.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/skins/media/SourceContentSkin.kt
@@ -242,9 +242,9 @@ class SourceContentSkin(private val sourceContent: SourceContent) : SkinBase<Sou
         zoomOutBtn.setOnAction { textZoom(-10) }
 
         sourceContent.zoomRateProperty.onChangeAndDoNow { rate ->
-            sourceTextChunksContainer.items.forEach { item ->
-                item.styleClass.removeAll { it.startsWith("text-zoom") }
-                item.addClass("text-zoom-$rate")
+            sourceTextChunksContainer.apply {
+                styleClass.removeAll { it.startsWith("text-zoom") }
+                addClass("text-zoom-$rate")
             }
         }
     }

--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/skins/media/SourceContentSkin.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/skins/media/SourceContentSkin.kt
@@ -32,6 +32,7 @@ import javafx.scene.control.ScrollBar
 import javafx.scene.control.SkinBase
 import javafx.scene.layout.HBox
 import javafx.scene.layout.VBox
+import javafx.scene.text.TextAlignment
 import org.kordamp.ikonli.javafx.FontIcon
 import org.kordamp.ikonli.materialdesign.MaterialDesign
 import org.wycliffeassociates.otter.jvm.controls.media.PlaybackRateChangedEvent
@@ -240,9 +241,11 @@ class SourceContentSkin(private val sourceContent: SourceContent) : SkinBase<Sou
         zoomInBtn.setOnAction { textZoom(10) }
         zoomOutBtn.setOnAction { textZoom(-10) }
 
-        sourceContent.zoomRateProperty.onChange { rate ->
-            sourceTextChunksContainer.styleClass.removeAll { it.startsWith("text-zoom") }
-            sourceTextChunksContainer.addClass("text-zoom-$rate")
+        sourceContent.zoomRateProperty.onChangeAndDoNow { rate ->
+            sourceTextChunksContainer.items.forEach { item ->
+                item.styleClass.removeAll { it.startsWith("text-zoom") }
+                item.addClass("text-zoom-$rate")
+            }
         }
     }
 

--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/skins/media/SourceContentSkin.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/skins/media/SourceContentSkin.kt
@@ -96,6 +96,15 @@ class SourceContentSkin(private val sourceContent: SourceContent) : SkinBase<Sou
     lateinit var minimizeBtn: Button
 
     @FXML
+    lateinit var zoomInBtn: Button
+
+    @FXML
+    lateinit var zoomOutBtn: Button
+
+    @FXML
+    lateinit var zoomRateText: Label
+
+    @FXML
     lateinit var sourceAudioBlock: VBox
 
     init {
@@ -221,10 +230,32 @@ class SourceContentSkin(private val sourceContent: SourceContent) : SkinBase<Sou
             hiddenWhen(sourceContent.isMinimizedProperty)
             managedWhen(visibleProperty())
         }
+
+        zoomRateText.apply {
+            textProperty().bind(sourceContent.zoomRateProperty.stringBinding{
+                String.format("%d%%", it)
+            })
+        }
+
+        zoomInBtn.setOnAction { textZoom(10) }
+        zoomOutBtn.setOnAction { textZoom(-10) }
+
+        sourceContent.zoomRateProperty.onChange { rate ->
+            sourceTextChunksContainer.styleClass.removeAll { it.startsWith("text-zoom") }
+            sourceTextChunksContainer.addClass("text-zoom-$rate")
+        }
     }
 
     private fun toggleBody() {
         sourceContent.isMinimizedProperty.set(!sourceContent.isMinimizedProperty.value)
+    }
+
+    private fun textZoom(delta: Int) {
+        val zoomTo = sourceContent.zoomRateProperty.value + delta
+        if (zoomTo < 50 || zoomTo > 200) {
+            return
+        }
+        sourceContent.zoomRateProperty += delta
     }
 
     private fun buildChunkText(textContent: String, index: Int): Label {

--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/skins/media/SourceContentSkin.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/skins/media/SourceContentSkin.kt
@@ -259,8 +259,9 @@ class SourceContentSkin(private val sourceContent: SourceContent) : SkinBase<Sou
         if (zoomTo < 50 || zoomTo > 200) {
             return
         }
-        FX.eventbus.fire(SourceTextZoomRateChangedEvent(zoomTo))
         sourceContent.zoomRateProperty.set(zoomTo)
+        /* notify listeners to save zoom preference */
+        FX.eventbus.fire(SourceTextZoomRateChangedEvent(zoomTo))
     }
 
     private fun buildChunkText(textContent: String, index: Int): Label {

--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/skins/media/SourceContentSkin.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/skins/media/SourceContentSkin.kt
@@ -39,6 +39,7 @@ import org.wycliffeassociates.otter.jvm.controls.media.PlaybackRateChangedEvent
 import org.wycliffeassociates.otter.jvm.controls.media.PlaybackRateType
 import org.wycliffeassociates.otter.jvm.controls.media.SimpleAudioPlayer
 import org.wycliffeassociates.otter.jvm.controls.media.SourceContent
+import org.wycliffeassociates.otter.jvm.controls.media.SourceTextZoomRateChangedEvent
 import org.wycliffeassociates.otter.jvm.utils.enableScrollByKey
 import org.wycliffeassociates.otter.jvm.utils.onChangeAndDoNow
 import tornadofx.*
@@ -258,13 +259,13 @@ class SourceContentSkin(private val sourceContent: SourceContent) : SkinBase<Sou
         if (zoomTo < 50 || zoomTo > 200) {
             return
         }
-        sourceContent.zoomRateProperty += delta
+        FX.eventbus.fire(SourceTextZoomRateChangedEvent(zoomTo))
+        sourceContent.zoomRateProperty.set(zoomTo)
     }
 
     private fun buildChunkText(textContent: String, index: Int): Label {
         return Label(textContent).apply {
             addClass("source-content__text")
-            isWrapText = true
             prefWidthProperty().bind(
                 sourceTextChunksContainer.widthProperty().minus(50)
             )

--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/skins/media/SourceContentSkin.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/skins/media/SourceContentSkin.kt
@@ -31,6 +31,7 @@ import javafx.scene.control.ListView
 import javafx.scene.control.ScrollBar
 import javafx.scene.control.SkinBase
 import javafx.scene.layout.HBox
+import javafx.scene.layout.Region
 import javafx.scene.layout.VBox
 import javafx.scene.text.TextAlignment
 import org.kordamp.ikonli.javafx.FontIcon
@@ -267,8 +268,10 @@ class SourceContentSkin(private val sourceContent: SourceContent) : SkinBase<Sou
     private fun buildChunkText(textContent: String, index: Int): Label {
         return Label(textContent).apply {
             addClass("source-content__text")
+            minHeight = Region.USE_PREF_SIZE // avoid ellipsis
+
             prefWidthProperty().bind(
-                sourceTextChunksContainer.widthProperty().minus(50)
+                sourceTextChunksContainer.widthProperty().minus(60) // scrollbar offset
             )
 
             sourceContent.highlightedChunk.onChangeAndDoNow { highlightedIndex ->
@@ -284,6 +287,10 @@ class SourceContentSkin(private val sourceContent: SourceContent) : SkinBase<Sou
     private fun buildLicenseText(): Label {
         return Label().apply {
             addClass("source-content__license-text")
+
+            prefWidthProperty().bind(
+                sourceTextChunksContainer.widthProperty().minus(60)
+            )
             textProperty().bind(sourceContent.licenseTextProperty)
             styleProperty().bind(sourceContent.orientationProperty.objectBinding {
                 when (it) {

--- a/jvm/controls/src/main/resources/css/source-content.css
+++ b/jvm/controls/src/main/resources/css/source-content.css
@@ -106,6 +106,7 @@
 .source-content__text {
     -fx-padding: 0 15px;
     -fx-text-fill: -wa-regular-text;
+    -fx-wrap-text: true;
 }
 
 .source-content__text--highlighted {
@@ -116,6 +117,7 @@
     -fx-padding: 10px 15px 0 15px;
     -fx-font-size: 1.25em;
     -fx-text-fill: -wa-note-text;
+    -fx-wrap-text: true;
 }
 
 .source-content__title {

--- a/jvm/controls/src/main/resources/css/source-content.css
+++ b/jvm/controls/src/main/resources/css/source-content.css
@@ -105,7 +105,6 @@
 
 .source-content__text {
     -fx-padding: 0 15px;
-    -fx-font-size: 1.5em;
     -fx-text-fill: -wa-regular-text;
 }
 
@@ -123,6 +122,7 @@
     -fx-font-size: 1.5em;
     -fx-font-weight: bold;
     -fx-text-fill: -wa-regular-text;
+    -fx-padding: 0 80px 0 0;
 }
 
 .source-content__zoom-control {
@@ -130,56 +130,58 @@
 }
 
 .source-content__zoom-rate-text {
+    -fx-padding: 0 5px;
     -fx-font-size: 1.25em;
     -fx-text-fill: -wa-regular-text;
+    -fx-text-alignment: center;
 }
 
 /* font size zoom rates */
 .text-zoom-50 {
-    -fx-font-size: 0.5em;
-}
-.text-zoom-60 {
-    -fx-font-size: 0.6em;
-}
-.text-zoom-70 {
-    -fx-font-size: 0.7em;
-}
-.text-zoom-80 {
-    -fx-font-size: 0.8em;
-}
-.text-zoom-90 {
-    -fx-font-size: 0.9em;
-}
-.text-zoom-100 {
     -fx-font-size: 1em;
 }
-.text-zoom-110 {
+.text-zoom-60 {
     -fx-font-size: 1.1em;
 }
-.text-zoom-120 {
+.text-zoom-70 {
     -fx-font-size: 1.2em;
 }
-.text-zoom-130 {
+.text-zoom-80 {
     -fx-font-size: 1.3em;
 }
-.text-zoom-140 {
+.text-zoom-90 {
     -fx-font-size: 1.4em;
 }
-.text-zoom-150 {
+.text-zoom-100 {
     -fx-font-size: 1.5em;
 }
-.text-zoom-160 {
+.text-zoom-110 {
     -fx-font-size: 1.6em;
 }
-.text-zoom-170 {
+.text-zoom-120 {
     -fx-font-size: 1.7em;
 }
-.text-zoom-180 {
+.text-zoom-130 {
     -fx-font-size: 1.8em;
 }
-.text-zoom-190 {
+.text-zoom-140 {
     -fx-font-size: 1.9em;
 }
+.text-zoom-150 {
+    -fx-font-size: 2.0em;
+}
+.text-zoom-160 {
+    -fx-font-size: 2.1em;
+}
+.text-zoom-170 {
+    -fx-font-size: 2.2em;
+}
+.text-zoom-180 {
+    -fx-font-size: 2.3em;
+}
+.text-zoom-190 {
+    -fx-font-size: 2.4em;
+}
 .text-zoom-200 {
-    -fx-font-size: 2em;
+    -fx-font-size: 2.5em;
 }

--- a/jvm/controls/src/main/resources/css/source-content.css
+++ b/jvm/controls/src/main/resources/css/source-content.css
@@ -119,21 +119,23 @@
 }
 
 .source-content__title {
+    -fx-padding: 0 80px 0 0;
     -fx-font-size: 1.5em;
     -fx-font-weight: bold;
     -fx-text-fill: -wa-regular-text;
-    -fx-padding: 0 80px 0 0;
+    -fx-wrap-text: true;
 }
 
 .source-content__zoom-control {
-    -fx-alignment: center;
+    -fx-alignment: center-left;
 }
 
 .source-content__zoom-rate-text {
+    -fx-min-width: 70px;
     -fx-padding: 0 5px;
     -fx-font-size: 1.25em;
     -fx-text-fill: -wa-regular-text;
-    -fx-text-alignment: center;
+    -fx-alignment: center;
 }
 
 /* font size zoom rates */

--- a/jvm/controls/src/main/resources/css/source-content.css
+++ b/jvm/controls/src/main/resources/css/source-content.css
@@ -123,7 +123,6 @@
     -fx-font-size: 1.5em;
     -fx-font-weight: bold;
     -fx-text-fill: -wa-regular-text;
-    -fx-wrap-text: true;
 }
 
 .source-content__zoom-control {
@@ -131,8 +130,8 @@
 }
 
 .source-content__zoom-rate-text {
-    -fx-min-width: 70px;
-    -fx-padding: 0 5px;
+    -fx-min-width: 65px;
+    -fx-padding: 0 2px;
     -fx-font-size: 1.25em;
     -fx-text-fill: -wa-regular-text;
     -fx-alignment: center;

--- a/jvm/controls/src/main/resources/css/source-content.css
+++ b/jvm/controls/src/main/resources/css/source-content.css
@@ -124,3 +124,62 @@
     -fx-font-weight: bold;
     -fx-text-fill: -wa-regular-text;
 }
+
+.source-content__zoom-control {
+    -fx-alignment: center;
+}
+
+.source-content__zoom-rate-text {
+    -fx-font-size: 1.25em;
+    -fx-text-fill: -wa-regular-text;
+}
+
+/* font size zoom rates */
+.text-zoom-50 {
+    -fx-font-size: 0.5em;
+}
+.text-zoom-60 {
+    -fx-font-size: 0.6em;
+}
+.text-zoom-70 {
+    -fx-font-size: 0.7em;
+}
+.text-zoom-80 {
+    -fx-font-size: 0.8em;
+}
+.text-zoom-90 {
+    -fx-font-size: 0.9em;
+}
+.text-zoom-100 {
+    -fx-font-size: 1em;
+}
+.text-zoom-110 {
+    -fx-font-size: 1.1em;
+}
+.text-zoom-120 {
+    -fx-font-size: 1.2em;
+}
+.text-zoom-130 {
+    -fx-font-size: 1.3em;
+}
+.text-zoom-140 {
+    -fx-font-size: 1.4em;
+}
+.text-zoom-150 {
+    -fx-font-size: 1.5em;
+}
+.text-zoom-160 {
+    -fx-font-size: 1.6em;
+}
+.text-zoom-170 {
+    -fx-font-size: 1.7em;
+}
+.text-zoom-180 {
+    -fx-font-size: 1.8em;
+}
+.text-zoom-190 {
+    -fx-font-size: 1.9em;
+}
+.text-zoom-200 {
+    -fx-font-size: 2em;
+}

--- a/jvm/controls/src/main/resources/org/wycliffeassociates/otter/jvm/controls/skins/media/SourceContent.fxml
+++ b/jvm/controls/src/main/resources/org/wycliffeassociates/otter/jvm/controls/skins/media/SourceContent.fxml
@@ -34,6 +34,19 @@
 <VBox styleClass="source-content__root" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
     <children>
         <HBox fx:id="titleContainer">
+            <HBox styleClass="source-content__zoom-control">
+                <Button fx:id="zoomOutBtn" styleClass="btn,btn--icon,btn--borderless">
+                    <graphic>
+                        <FontIcon iconLiteral="mdi-magnify-minus" />
+                    </graphic>
+                </Button>
+                <Label fx:id="zoomRateText" styleClass="source-content__zoom-rate-text"></Label>
+                <Button fx:id="zoomInBtn" styleClass="btn,btn--icon,btn--borderless">
+                    <graphic>
+                        <FontIcon iconLiteral="mdi-magnify-plus" />
+                    </graphic>
+                </Button>
+            </HBox>
             <HBox alignment="CENTER" HBox.hgrow="ALWAYS">
                 <Label fx:id="title" styleClass="source-content__title">
                     <VBox.margin>

--- a/jvm/markerapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/markerapp/app/view/SourceTextFragment.kt
+++ b/jvm/markerapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/markerapp/app/view/SourceTextFragment.kt
@@ -23,6 +23,7 @@ import javafx.geometry.NodeOrientation
 import org.wycliffeassociates.otter.jvm.controls.media.SourceContent
 import org.wycliffeassociates.otter.jvm.workbookplugin.plugin.ParameterizedScope
 import tornadofx.*
+import java.lang.Exception
 import java.text.MessageFormat
 
 class SourceTextFragment : Fragment() {
@@ -38,6 +39,7 @@ class SourceTextFragment : Fragment() {
         var license: String? = null
         var direction: String? = null
         var sourceDirection: String? = null
+        var sourceTextZoom: String? = null
 
         if (scope is ParameterizedScope) {
             val parameters = (scope as? ParameterizedScope)?.parameters
@@ -53,6 +55,7 @@ class SourceTextFragment : Fragment() {
                     parameters.named["chapter_number"],
                     parameters.named["unit_number"]
                 )
+                sourceTextZoom = parameters.named["source_text_zoom"]
             }
         }
 
@@ -73,6 +76,13 @@ class SourceTextFragment : Fragment() {
                 when (sourceDirection) {
                     "rtl" -> NodeOrientation.RIGHT_TO_LEFT
                     else -> NodeOrientation.LEFT_TO_RIGHT
+                }
+            )
+            zoomRateProperty.set(
+                try {
+                    sourceTextZoom?.toInt() ?: 100
+                } catch (e: Exception) {
+                    100
                 }
             )
         }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/persistence/AppPreferences.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/persistence/AppPreferences.kt
@@ -49,6 +49,7 @@ class AppPreferences @Inject constructor(database: AppDatabase) : IAppPreference
     private val AUDIO_RECORD_DEVICE_KEY = "audioRecordDevice"
     private val LOCALE_LANGUAGE_KEY = "localeLanguage"
     private val APP_THEME_KEY = "appTheme"
+    private val SOURCE_TEXT_ZOOM_KEY = "sourceTextZoom"
 
     private fun putInt(key: String, value: Int): Completable {
         return Completable
@@ -204,5 +205,13 @@ class AppPreferences @Inject constructor(database: AppDatabase) : IAppPreference
 
     override fun setAppTheme(theme: String): Completable {
         return putString(APP_THEME_KEY, theme)
+    }
+
+    override fun sourceTextZoomRate(): Single<Int> {
+        return getInt(SOURCE_TEXT_ZOOM_KEY, 100)
+    }
+
+    override fun setSourceTextZoomRate(rate: Int): Completable {
+        return putInt(SOURCE_TEXT_ZOOM_KEY, rate)
     }
 }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/persistence/repositories/AppPreferencesRepository.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/persistence/repositories/AppPreferencesRepository.kt
@@ -105,4 +105,12 @@ class AppPreferencesRepository @Inject constructor(
     override fun setAppTheme(theme: ColorTheme): Completable {
         return preferences.setAppTheme(theme.name)
     }
+
+    override fun sourceTextZoomRate(): Single<Int> {
+        return preferences.sourceTextZoomRate()
+    }
+
+    override fun setSourceTextZoomRate(rate: Int): Completable {
+        return preferences.setSourceTextZoomRate(rate)
+    }
 }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/plugin/AudioPlugin.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/plugin/AudioPlugin.kt
@@ -145,7 +145,8 @@ class AudioPlugin(
                     "--direction=${pluginParameters.direction}",
                     "--source_direction=${pluginParameters.sourceDirection}",
                     "--source_rate=${pluginParameters.sourceRate}",
-                    "--target_rate=${pluginParameters.targetRate}"
+                    "--target_rate=${pluginParameters.targetRate}",
+                    "--source_text_zoom=${pluginParameters.sourceTextZoom}"
                 )
             }
         return ParametersImpl(insertedArgs)

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/ChapterPage.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/ChapterPage.kt
@@ -127,7 +127,6 @@ class ChapterPage : View() {
         workspace.subscribe<PluginOpenedEvent> { pluginInfo ->
             if (!pluginInfo.isNative) {
                 workspace.dock(pluginOpenedPage)
-                pluginOpenedPage.onDock()
                 viewModel.openPlayers()
             }
         }
@@ -324,7 +323,7 @@ class ChapterPage : View() {
 
     private fun createPluginOpenedPage(): PluginOpenedPage {
         // Plugin active cover
-        return PluginOpenedPage().apply {
+        return find<PluginOpenedPage>().apply {
             dialogTitleProperty.bind(viewModel.dialogTitleBinding())
             dialogTextProperty.bind(viewModel.dialogTextBinding())
             playerProperty.bind(viewModel.sourceAudioPlayerProperty)

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/ChapterPage.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/ChapterPage.kt
@@ -347,6 +347,9 @@ class ChapterPage : View() {
                     it.translation.targetRate.toLazyBinding()
                 }
             )
+            sourceTextZoomRateProperty.bind(
+                workbookDataStore.sourceTextZoomRateProperty
+            )
         }
     }
 

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/ChapterPage.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/ChapterPage.kt
@@ -133,7 +133,6 @@ class ChapterPage : View() {
         workspace.subscribe<PluginClosedEvent> {
             (workspace.dockedComponentProperty.value as? PluginOpenedPage)?.let {
                 workspace.navigateBack()
-                pluginOpenedPage.onUndock()
             }
         }
     }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/RecordResourceFragment.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/RecordResourceFragment.kt
@@ -351,7 +351,7 @@ class RecordResourceFragment(private val recordableViewModel: RecordableViewMode
 
     private fun createPluginOpenedPage(): PluginOpenedPage {
         // Plugin active cover
-        return PluginOpenedPage().apply {
+        return find<PluginOpenedPage>().apply {
             dialogTitleProperty.bind(recordableViewModel.dialogTitleBinding())
             dialogTextProperty.bind(recordableViewModel.dialogTextBinding())
             playerProperty.bind(recordableViewModel.sourceAudioPlayerProperty)

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/RecordScripturePage.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/RecordScripturePage.kt
@@ -100,6 +100,7 @@ class RecordScripturePage : View() {
             orientationProperty.bind(settingsViewModel.orientationProperty)
             sourceOrientationProperty.bind(settingsViewModel.sourceOrientationProperty)
 
+            zoomRateProperty.set(workbookDataStore.sourceTextZoomRateProperty.value)
             sourceSpeedRateProperty.bind(
                 workbookDataStore.activeWorkbookProperty.select {
                     it.translation.sourceRate.toLazyBinding()

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/RecordScripturePage.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/RecordScripturePage.kt
@@ -100,7 +100,7 @@ class RecordScripturePage : View() {
             orientationProperty.bind(settingsViewModel.orientationProperty)
             sourceOrientationProperty.bind(settingsViewModel.sourceOrientationProperty)
 
-            zoomRateProperty.set(workbookDataStore.sourceTextZoomRateProperty.value)
+            zoomRateProperty.bindBidirectional(workbookDataStore.sourceTextZoomRateProperty)
             sourceSpeedRateProperty.bind(
                 workbookDataStore.activeWorkbookProperty.select {
                     it.translation.sourceRate.toLazyBinding()

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/RecordScripturePage.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/RecordScripturePage.kt
@@ -183,7 +183,6 @@ class RecordScripturePage : View() {
         workspace.subscribe<PluginOpenedEvent> { pluginInfo ->
             if (!pluginInfo.isNative) {
                 workspace.dock(pluginOpenedPage)
-                pluginOpenedPage.onDock()
                 recordScriptureViewModel.openSourceAudioPlayer()
                 recordScriptureViewModel.openTargetAudioPlayer()
             }
@@ -191,7 +190,6 @@ class RecordScripturePage : View() {
         workspace.subscribe<PluginClosedEvent> {
             (workspace.dockedComponentProperty.value as? PluginOpenedPage)?.let {
                 workspace.navigateBack()
-                pluginOpenedPage.onUndock()
             }
             recordScriptureViewModel.openPlayers()
         }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/RecordScripturePage.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/RecordScripturePage.kt
@@ -23,6 +23,7 @@ import com.jfoenix.controls.JFXSnackbar
 import com.jfoenix.controls.JFXSnackbarLayout
 import javafx.beans.binding.Bindings
 import javafx.beans.property.SimpleBooleanProperty
+import javafx.beans.property.SimpleIntegerProperty
 import javafx.beans.value.ChangeListener
 import javafx.scene.Parent
 import javafx.scene.control.ScrollPane
@@ -100,7 +101,6 @@ class RecordScripturePage : View() {
             orientationProperty.bind(settingsViewModel.orientationProperty)
             sourceOrientationProperty.bind(settingsViewModel.sourceOrientationProperty)
 
-            zoomRateProperty.bindBidirectional(workbookDataStore.sourceTextZoomRateProperty)
             sourceSpeedRateProperty.bind(
                 workbookDataStore.activeWorkbookProperty.select {
                     it.translation.sourceRate.toLazyBinding()
@@ -492,6 +492,7 @@ class RecordScripturePage : View() {
         super.onDock()
         recordScriptureViewModel.loadTakes()
         recordScriptureViewModel.openPlayers()
+        sourceContent.zoomRateProperty.set(workbookDataStore.sourceTextZoomRateProperty.value)
         navigator.dock(this, breadCrumb)
 
         initializeImportProgressDialog()

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/RecordScripturePage.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/RecordScripturePage.kt
@@ -396,7 +396,7 @@ class RecordScripturePage : View() {
 
     private fun createPluginOpenedPage(): PluginOpenedPage {
         // Plugin active cover
-        return PluginOpenedPage().apply {
+        return find<PluginOpenedPage>().apply {
             dialogTitleProperty.bind(recordScriptureViewModel.dialogTitleBinding())
             dialogTextProperty.bind(recordScriptureViewModel.dialogTextBinding())
             playerProperty.bind(recordScriptureViewModel.sourceAudioPlayerProperty)
@@ -418,6 +418,9 @@ class RecordScripturePage : View() {
                 workbookDataStore.activeWorkbookProperty.select {
                     it.translation.targetRate.toLazyBinding()
                 }
+            )
+            sourceTextZoomRateProperty.bind(
+                workbookDataStore.sourceTextZoomRateProperty
             )
         }
     }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/AudioPluginViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/AudioPluginViewModel.kt
@@ -103,6 +103,7 @@ class AudioPluginViewModel : ViewModel() {
 
         val sourceRate = (workbookDataStore.workbook.translation.sourceRate as BehaviorRelay).value ?: 1.0
         val targetRate = (workbookDataStore.workbook.translation.targetRate as BehaviorRelay).value ?: 1.0
+        val sourceTextZoom = workbookDataStore.sourceTextZoomRateProperty.value
 
         return PluginParameters(
             languageName = workbook.target.language.name,
@@ -123,7 +124,8 @@ class AudioPluginViewModel : ViewModel() {
             direction = localeLanguage.preferredLanguage?.direction,
             sourceDirection = workbook.source.language.direction,
             sourceRate = sourceRate,
-            targetRate = targetRate
+            targetRate = targetRate,
+            sourceTextZoom = sourceTextZoom
         )
     }
 

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ChapterPageViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ChapterPageViewModel.kt
@@ -27,6 +27,7 @@ import io.reactivex.subjects.PublishSubject
 import javafx.beans.binding.Bindings
 import javafx.beans.binding.StringBinding
 import javafx.beans.property.SimpleBooleanProperty
+import javafx.beans.property.SimpleIntegerProperty
 import javafx.beans.property.SimpleObjectProperty
 import javafx.collections.FXCollections
 import javafx.collections.ObservableList
@@ -39,6 +40,7 @@ import org.wycliffeassociates.otter.common.data.workbook.Take
 import org.wycliffeassociates.otter.common.device.IAudioPlayer
 import org.wycliffeassociates.otter.common.domain.content.ConcatenateAudio
 import org.wycliffeassociates.otter.common.domain.content.TakeActions
+import org.wycliffeassociates.otter.common.persistence.repositories.IAppPreferencesRepository
 import org.wycliffeassociates.otter.common.persistence.repositories.PluginType
 import org.wycliffeassociates.otter.jvm.workbookapp.di.IDependencyGraphProvider
 import org.wycliffeassociates.otter.jvm.workbookapp.plugin.PluginClosedEvent
@@ -61,6 +63,9 @@ class ChapterPageViewModel : ViewModel() {
 
     @Inject
     lateinit var concatenateAudio: ConcatenateAudio
+
+    @Inject
+    lateinit var appPreferencesRepo: IAppPreferencesRepository
 
     // List of content to display on the screen
     // Boolean tracks whether the content has takes associated with it
@@ -125,6 +130,10 @@ class ChapterPageViewModel : ViewModel() {
                 checkCanCompile()
                 setWorkChunk()
             }
+
+        appPreferencesRepo.sourceTextZoomRate().subscribe { rate ->
+            workbookDataStore.sourceTextZoomRateProperty.set(rate)
+        }
     }
 
     fun undock() {

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/WorkbookDataStore.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/WorkbookDataStore.kt
@@ -20,6 +20,7 @@ package org.wycliffeassociates.otter.jvm.workbookapp.ui.viewmodel
 
 import io.reactivex.Completable
 import io.reactivex.Maybe
+import io.reactivex.Single
 import io.reactivex.schedulers.Schedulers
 import javafx.beans.binding.Bindings
 import javafx.beans.binding.StringBinding
@@ -38,8 +39,10 @@ import org.wycliffeassociates.otter.common.domain.languages.LocaleLanguage
 import org.wycliffeassociates.otter.common.domain.resourcecontainer.SourceAudio
 import org.wycliffeassociates.otter.common.domain.resourcecontainer.project.ProjectFilesAccessor
 import org.wycliffeassociates.otter.common.persistence.IDirectoryProvider
+import org.wycliffeassociates.otter.common.persistence.repositories.IAppPreferencesRepository
 import org.wycliffeassociates.otter.jvm.controls.media.PlaybackRateChangedEvent
 import org.wycliffeassociates.otter.jvm.controls.media.PlaybackRateType
+import org.wycliffeassociates.otter.jvm.controls.media.SourceTextZoomRateChangedEvent
 import org.wycliffeassociates.otter.jvm.utils.onChangeAndDoNow
 import org.wycliffeassociates.otter.jvm.workbookapp.di.IDependencyGraphProvider
 import tornadofx.*
@@ -51,6 +54,9 @@ import javax.inject.Inject
 class WorkbookDataStore : Component(), ScopedInstance {
     @Inject
     lateinit var directoryProvider: IDirectoryProvider
+
+    @Inject
+    lateinit var appPreferenceRepo: IAppPreferencesRepository
 
     @Inject
     lateinit var localeLanguage: LocaleLanguage
@@ -86,6 +92,7 @@ class WorkbookDataStore : Component(), ScopedInstance {
     val targetAudioProperty = SimpleObjectProperty<TargetAudio>()
     val selectedChapterPlayerProperty = SimpleObjectProperty<IAudioPlayer>()
 
+    val sourceTextZoomRateProperty = SimpleIntegerProperty()
     val sourceLicenseProperty = SimpleStringProperty()
 
     init {
@@ -103,6 +110,9 @@ class WorkbookDataStore : Component(), ScopedInstance {
 
         workspace.subscribe<PlaybackRateChangedEvent> { event ->
             updatePlaybackSpeedRate(event)
+        }
+        workspace.subscribe<SourceTextZoomRateChangedEvent> { event ->
+            appPreferenceRepo.setSourceTextZoomRate(event.rate).subscribe()
         }
     }
 

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/WorkbookDataStore.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/WorkbookDataStore.kt
@@ -112,6 +112,7 @@ class WorkbookDataStore : Component(), ScopedInstance {
             updatePlaybackSpeedRate(event)
         }
         workspace.subscribe<SourceTextZoomRateChangedEvent> { event ->
+            sourceTextZoomRateProperty.set(event.rate)
             appPreferenceRepo.setSourceTextZoomRate(event.rate).subscribe()
         }
     }


### PR DESCRIPTION
Allows changing font size of source text. The zoom ratio should be consistent among different places including: ` PluginOpenedPage, RecordScripturePage and MarkerView - SourceTextFragment `

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/orature/558)
<!-- Reviewable:end -->

![image](https://user-images.githubusercontent.com/34975907/163249754-48ffe327-37a2-401e-99fc-1e3fac356725.png)


