### PR TITLE
Fix memory leak in Create Project page

### DIFF
--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/book/BookSelection.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/book/BookSelection.kt
@@ -39,7 +39,7 @@ import org.wycliffeassociates.otter.jvm.workbookapp.ui.viewmodel.SettingsViewMod
 import tornadofx.*
 import java.text.MessageFormat
 
-class BookSelection : Fragment() {
+class BookSelection : View() {
 
     private val viewModel: BookWizardViewModel by inject()
     private val navigator: NavigationMediator by inject()


### PR DESCRIPTION
Using fragment leaves the artwork images of books not freeing up memory usage. Replaced fragment with view

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/orature/566)
<!-- Reviewable:end -->
