### PR TITLE
Release AudioFile after init

### DIFF
--- a/common/audio/src/main/kotlin/org/wycliffeassociates/otter/common/audio/AudioFile.kt
+++ b/common/audio/src/main/kotlin/org/wycliffeassociates/otter/common/audio/AudioFile.kt
@@ -44,7 +44,9 @@ class AudioFile private constructor() {
         this.file = file
         strategy = when (AudioFileFormat.of(file.extension)) {
             AudioFileFormat.WAV -> WavFile(file, metadata as WavMetadata)
-            AudioFileFormat.MP3 -> MP3FileReader(file)
+            AudioFileFormat.MP3 -> MP3FileReader(file).apply {
+                release()
+            }
         }
     }
 
@@ -52,7 +54,9 @@ class AudioFile private constructor() {
         this.file = file
         strategy = when (AudioFileFormat.of(file.extension)) {
             AudioFileFormat.WAV -> WavFile(file)
-            AudioFileFormat.MP3 -> MP3FileReader(file)
+            AudioFileFormat.MP3 -> MP3FileReader(file).apply {
+                release()
+            }
         }
     }
 
@@ -65,7 +69,9 @@ class AudioFile private constructor() {
         this.file = file
         strategy = when (AudioFileFormat.of(file.extension)) {
             AudioFileFormat.WAV -> WavFile(file, channels, sampleRate, bitsPerSample)
-            AudioFileFormat.MP3 -> MP3FileReader(file)
+            AudioFileFormat.MP3 -> MP3FileReader(file).apply {
+                release()
+            }
         }
     }
 
@@ -79,7 +85,9 @@ class AudioFile private constructor() {
         this.file = file
         strategy = when (AudioFileFormat.of(file.extension)) {
             AudioFileFormat.WAV -> WavFile(file, channels, sampleRate, bitsPerSample, metadata as WavMetadata)
-            AudioFileFormat.MP3 -> MP3FileReader(file)
+            AudioFileFormat.MP3 -> MP3FileReader(file).apply {
+                release()
+            }
         }
     }
 

--- a/common/audio/src/main/kotlin/org/wycliffeassociates/otter/common/audio/AudioFile.kt
+++ b/common/audio/src/main/kotlin/org/wycliffeassociates/otter/common/audio/AudioFile.kt
@@ -45,7 +45,7 @@ class AudioFile private constructor() {
         strategy = when (AudioFileFormat.of(file.extension)) {
             AudioFileFormat.WAV -> WavFile(file, metadata as WavMetadata)
             AudioFileFormat.MP3 -> MP3FileReader(file).apply {
-                release()
+                release() // clean up resource after parsing the metadata
             }
         }
     }


### PR DESCRIPTION
When an `AudioFile` object is created from .mp3, it implicitly leaves the decoder open. This prevents the file from being properly cleaned up if `AudioFile.update() - decoder.stop() ` is not invoked

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/orature/570)
<!-- Reviewable:end -->
