### PR TITLE
Blocks exit from Verse Marker until loading completes

### DIFF
--- a/jvm/markerapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/markerapp/app/view/PlaybackControlsFragment.kt
+++ b/jvm/markerapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/markerapp/app/view/PlaybackControlsFragment.kt
@@ -76,6 +76,8 @@ class PlaybackControlsFragment : Fragment() {
         text = messages["continue"]
         graphic = continueIcon
         styleClass.addAll("btn", "btn--primary", "btn--borderless", continueButtonStyle)
+
+        disableProperty().bind(viewModel.isLoadingProperty)
         setOnAction {
             viewModel.saveAndQuit()
         }

--- a/jvm/markerapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/markerapp/app/viewmodel/VerseMarkerViewModel.kt
+++ b/jvm/markerapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/markerapp/app/viewmodel/VerseMarkerViewModel.kt
@@ -73,6 +73,7 @@ class VerseMarkerViewModel : ViewModel() {
 
     val audioPlayer = SimpleObjectProperty<IAudioPlayer>()
 
+    val isLoadingProperty = SimpleBooleanProperty(false)
     val isPlayingProperty = SimpleBooleanProperty(false)
     val markerRatioProperty = SimpleStringProperty()
     val headerTitle = SimpleStringProperty()
@@ -86,6 +87,7 @@ class VerseMarkerViewModel : ViewModel() {
     private var resumeAfterScroll = false
 
     fun onDock() {
+        isLoadingProperty.set(true)
         val audio = loadAudio()
         loadMarkers(audio)
         loadTitles()
@@ -268,7 +270,11 @@ class VerseMarkerViewModel : ViewModel() {
                     height = height,
                     waveformSubject
                 )
-            ).subscribe()
+            ).subscribe {
+                runLater {
+                    isLoadingProperty.set(false)
+                }
+            }
     }
 
     fun computeImageWidth(secondsOnScreen: Int): Double {


### PR DESCRIPTION
Prevents the issue with file still opened & locked exception after closing verse marker

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/orature/574)
<!-- Reviewable:end -->
