### PR TITLE
Remove use of ContentLabel.of()

### DIFF
--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/data/primitives/ContentLabel.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/data/primitives/ContentLabel.kt
@@ -18,6 +18,12 @@
  */
 package org.wycliffeassociates.otter.common.data.primitives
 
+@Deprecated(
+    """
+        "Don't use this to figure out labels to use for UI, as text could be verse or chunk.
+         Book elements already have a label field which should be used directly. This enum should be removed.
+"""
+)
 enum class ContentLabel(val value: String, val type: ContentType) {
     CHAPTER("chapter", ContentType.META),
     VERSE("verse", ContentType.TEXT),

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/controls/resourcecard/model/ResourceGroupCardItem.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/controls/resourcecard/model/ResourceGroupCardItem.kt
@@ -22,10 +22,7 @@ import io.reactivex.Observable
 import java.util.concurrent.Callable
 import javafx.beans.binding.Bindings
 import javafx.beans.binding.BooleanBinding
-import org.wycliffeassociates.otter.common.data.primitives.ContentLabel
 import org.wycliffeassociates.otter.common.data.workbook.BookElement
-import org.wycliffeassociates.otter.common.data.workbook.Chapter
-import org.wycliffeassociates.otter.common.data.workbook.Chunk
 import org.wycliffeassociates.otter.common.data.workbook.Resource
 import org.wycliffeassociates.otter.common.data.workbook.ResourceGroup
 import tornadofx.*
@@ -76,11 +73,7 @@ private fun findResourceGroup(element: BookElement, slug: String): ResourceGroup
 }
 
 private fun getGroupTitle(element: BookElement): String {
-    return when (element) {
-        is Chapter -> "${messages[ContentLabel.CHAPTER.value]} ${element.title}"
-        is Chunk -> "${messages["chunk"]} ${element.title}"
-        else -> element.title
-    }
+    return "${messages[element.label]} ${element.title}"
 }
 
 private fun getResourceCardItems(

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/model/CardData.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/model/CardData.kt
@@ -18,7 +18,6 @@
  */
 package org.wycliffeassociates.otter.jvm.workbookapp.ui.model
 
-import org.wycliffeassociates.otter.common.data.primitives.ContentLabel
 import org.wycliffeassociates.otter.common.data.workbook.Chapter
 import org.wycliffeassociates.otter.common.data.workbook.Chunk
 import org.wycliffeassociates.otter.common.device.IAudioPlayer
@@ -39,7 +38,7 @@ data class CardData(
     var onTakeSelected: (CardData, TakeModel) -> Unit = { _, _ -> }
 
     constructor(chunk: Chunk) : this(
-        item = ContentLabel.of(chunk.contentType).value,
+        item = chunk.label,
         dataType = CardDataType.CONTENT.value,
         bodyText = chunk.start.toString(),
         sort = chunk.sort,
@@ -47,7 +46,7 @@ data class CardData(
     )
 
     constructor(chapter: Chapter) : this(
-        item = ContentLabel.CHAPTER.value,
+        item = chapter.label,
         dataType = CardDataType.COLLECTION.value,
         bodyText = chapter.title,
         sort = chapter.sort,

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/model/ChapterCardModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/model/ChapterCardModel.kt
@@ -18,7 +18,6 @@
  */
 package org.wycliffeassociates.otter.jvm.workbookapp.ui.model
 
-import org.wycliffeassociates.otter.common.data.primitives.ContentLabel
 import org.wycliffeassociates.otter.common.data.workbook.BookElement
 import org.wycliffeassociates.otter.common.data.workbook.Chapter
 
@@ -34,7 +33,7 @@ class ChapterCardModel(
     constructor(title: String, chapter: Chapter, onClick: (chapter: BookElement) -> Unit) : this(
         sort = chapter.sort,
         title = title,
-        item = ContentLabel.CHAPTER.value,
+        item = chapter.label,
         dataType = CardDataType.COLLECTION.value,
         bodyText = chapter.title,
         source = chapter,

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/RecordScripturePage.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/RecordScripturePage.kt
@@ -132,7 +132,7 @@ class RecordScripturePage : View() {
                 chunk?.let {
                     MessageFormat.format(
                         messages["chunkTitle"],
-                        messages[ContentLabel.of(chunk.contentType).value],
+                        messages[chunk.label],
                         chunk.start
                     )
                 } ?: messages["chapter"]

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/RecordScriptureViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/RecordScriptureViewModel.kt
@@ -269,7 +269,7 @@ class RecordScriptureViewModel : ViewModel() {
     private fun setTitle(chunk: Chunk) {
         title = MessageFormat.format(
             messages["chunkTitle"],
-            messages["verse"],
+            messages[chunk.label],
             chunk.start
         )
     }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/WorkbookDataStore.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/WorkbookDataStore.kt
@@ -27,7 +27,6 @@ import javafx.beans.binding.StringBinding
 import javafx.beans.property.SimpleIntegerProperty
 import javafx.beans.property.SimpleObjectProperty
 import javafx.beans.property.SimpleStringProperty
-import org.wycliffeassociates.otter.common.data.primitives.ContentLabel
 import org.wycliffeassociates.otter.common.data.primitives.ResourceMetadata
 import org.wycliffeassociates.otter.common.data.workbook.Chapter
 import org.wycliffeassociates.otter.common.data.workbook.Chunk
@@ -269,7 +268,7 @@ class WorkbookDataStore : Component(), ScopedInstance {
                     if (activeChunkProperty.value != null) {
                         MessageFormat.format(
                             messages["chunkTitle"],
-                            messages[ContentLabel.of(activeChunkProperty.value.contentType).value],
+                            messages[activeChunkProperty.value.label],
                             activeChunkProperty.value.start
                         )
                     } else {

--- a/jvm/workbookapp/src/test/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/WorkbookDataStoreTest.kt
+++ b/jvm/workbookapp/src/test/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/WorkbookDataStoreTest.kt
@@ -130,7 +130,7 @@ class WorkbookDataStoreTest {
                 end = 1,
                 contentType = ContentType.TEXT,
                 resources = listOf(),
-                label = "Chunk"
+                label = "chunk"
             )
         }
 
@@ -368,7 +368,7 @@ class WorkbookDataStoreTest {
         val stringProperty = SimpleStringProperty()
         stringProperty.bind(workbookDataStore.activeChunkTitleBinding())
 
-        Assert.assertEquals("Verse 1", stringProperty.value)
+        Assert.assertEquals("Chunk 1", stringProperty.value)
     }
 
     @Test


### PR DESCRIPTION
ContentLabel does not allow for discerning between Chunk and Verse and as such cannot be used accurately.

BookElements, Collections, and Content already have label fields anyway, use that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/orature/575)
<!-- Reviewable:end -->
