### PR TITLE
"Save contributor" button enabled

### DIFF
--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/data/primitives/Contributor.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/data/primitives/Contributor.kt
@@ -19,7 +19,7 @@
 package org.wycliffeassociates.otter.common.data.primitives
 
 data class Contributor(
-    var name: String
+    val name: String
 ) {
     override fun toString(): String {
         return name

--- a/jvm/controls/src/main/resources/css/contributor-info.css
+++ b/jvm/controls/src/main/resources/css/contributor-info.css
@@ -35,9 +35,10 @@
     -fx-wrap-text: true;
 }
 
-.contributor__license-link,
-.contributor__license-link:visited {
-    -fx-text-fill: -wa-highlight-text;
+.contributor__license-link {
+    -fx-font-size: 1.1em;
+    -fx-wrap-text: true;
+    -fx-padding: 0;
 }
 
 .contributor__add-section {

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/WorkbookPage.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/WorkbookPage.kt
@@ -27,6 +27,7 @@ import javafx.scene.control.ListView
 import javafx.scene.control.Tab
 import javafx.scene.control.TabPane
 import javafx.scene.layout.Priority
+import javafx.scene.layout.Region
 import javafx.scene.layout.VBox
 import org.kordamp.ikonli.javafx.FontIcon
 import org.kordamp.ikonli.materialdesign.MaterialDesign
@@ -471,16 +472,14 @@ class WorkbookPage : View() {
                         isDisable = true
                     }
                 }
-                textflow {
+                vbox {
                     label(messages["licenseDescription"]) {
                         addClass("contributor__section-text")
-                        fitToParentWidth()
-                        isWrapText = true
+                        minHeight = Region.USE_PREF_SIZE // prevent overflow
                     }
                     hyperlink(messages["licenseCCBYSA"]) {
-                        addClass("contributor__license-link")
-                        fitToParentWidth()
-                        isWrapText = true
+                        addClass("wa-text--hyperlink","contributor__license-link")
+                        minHeight = Region.USE_PREF_SIZE // prevent overflow
 
                         val url = "https://creativecommons.org/licenses/by-sa/4.0/"
                         tooltip(url)

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ExportChapterViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ExportChapterViewModel.kt
@@ -84,7 +84,8 @@ class ExportChapterViewModel : ViewModel() {
     }
 
     fun editContributor(data: ContributorCellData) {
-        contributors[data.index].name = data.name
+        // replace the object in list to trigger onChange
+        contributors[data.index] = Contributor(data.name)
     }
 
     fun removeContributor(index: Int) {

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/WorkbookPageViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/WorkbookPageViewModel.kt
@@ -267,7 +267,8 @@ class WorkbookPageViewModel : ViewModel() {
     }
 
     fun editContributor(data: ContributorCellData) {
-        contributors[data.index].name = data.name
+        // replace the object in list to trigger onChange
+        contributors[data.index] = Contributor(data.name)
     }
 
     fun removeContributor(index: Int) {


### PR DESCRIPTION
A change in #560 breaks this feature, as we expect the "Save Contributor" button to be available after editing any contributor's name
- "Save Contributor" enabled when editing text field
- css fix

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/orature/576)
<!-- Reviewable:end -->
