### PR TITLE
Allow creating translation which already exists

### DIFF
--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/persistence/repositories/LanguageRepository.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/persistence/repositories/LanguageRepository.kt
@@ -177,7 +177,13 @@ class LanguageRepository @Inject constructor(
         return Single
             .fromCallable {
                 val existing = translationDao.fetch(translation.source.id, translation.target.id)
-                existing?.id ?: translationDao.insert(translationMapper.mapToEntity(translation))
+                if (existing != null) {
+                    existing.modifiedTs = translation.modifiedTs?.toString()
+                    translationDao.update(existing)
+                    existing.id
+                } else {
+                    translationDao.insert(translationMapper.mapToEntity(translation))
+                }
             }
             .doOnError { e ->
                 logger.error("Error in insert for translation: $translation", e)

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/LanguageCell.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/LanguageCell.kt
@@ -38,7 +38,6 @@ enum class LanguageType {
 class LanguageCell(
     private val type: LanguageType,
     private val anglicisedProperty: BooleanProperty,
-    private val existingLanguages: ObservableList<Language> = observableListOf(),
     private val onSelected: (Language) -> Unit
 ) : ListCell<Language>() {
 
@@ -81,10 +80,6 @@ class LanguageCell(
             }
         }
 
-        disableProperty().bind(Bindings.createBooleanBinding(
-            { existingLanguages.contains(item) },
-            existingLanguages
-        ))
         mouseTransparentProperty().bind(disableProperty())
     }
 }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/TargetLanguageSelection.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/TargetLanguageSelection.kt
@@ -73,7 +73,6 @@ class TargetLanguageSelection : Fragment() {
                     LanguageCell(
                         LanguageType.TARGET,
                         viewModel.anglicizedProperty,
-                        translationViewModel.existingLanguages
                     ) {
                         translationViewModel.selectedTargetLanguageProperty.set(it)
                     }
@@ -84,7 +83,7 @@ class TargetLanguageSelection : Fragment() {
 
                 overrideDefaultKeyEventHandler {
                     val current = selectionModel.selectedItem
-                    val availableItems = getAvailableLanguages()
+                    val availableItems = viewModel.filteredLanguages
                     var index = availableItems.indexOf(current)
                     when (it) {
                         KeyCode.UP -> index--
@@ -99,19 +98,12 @@ class TargetLanguageSelection : Fragment() {
                 }
                 focusedProperty().onChange { focused ->
                     if (focused) {
-                        val item = getAvailableLanguages().firstOrNull()
+                        val item = viewModel.filteredLanguages.firstOrNull()
                         val index = items.indexOf(item)
                         selectionModel.select(index)
                     }
                 }
             }
-        }
-    }
-
-    private fun getAvailableLanguages(): List<Language> {
-        return viewModel.filteredLanguages.filter {
-            translationViewModel.existingLanguages
-                .contains(it).not()
         }
     }
 

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/TranslationViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/TranslationViewModel.kt
@@ -63,7 +63,6 @@ class TranslationViewModel : ViewModel() {
     val showProgressProperty = SimpleBooleanProperty(false)
 
     private val sourceResources = mutableListOf<ResourceMetadata>()
-    val existingLanguages = observableListOf<Language>()
 
     init {
         (app as IDependencyGraphProvider).dependencyGraph.inject(this)
@@ -119,7 +118,6 @@ class TranslationViewModel : ViewModel() {
         sourceResources.clear()
         sourceLanguages.clear()
         targetLanguages.clear()
-        existingLanguages.clear()
         selectedSourceLanguageProperty.set(null)
         selectedTargetLanguageProperty.set(null)
     }
@@ -153,26 +151,6 @@ class TranslationViewModel : ViewModel() {
             }
             .subscribe { retrieved ->
                 targetLanguages.addAll(retrieved)
-                loadTranslations()
-            }
-    }
-
-    private fun loadTranslations() {
-        languageRepo
-            .getAllTranslations()
-            .map { list ->
-                list.filter {
-                    it.source == selectedSourceLanguageProperty.value
-                }
-            }
-            .observeOnFx()
-            .doOnError { e ->
-                logger.error("Error loading translations", e)
-            }
-            .subscribe { translations ->
-                existingLanguages.setAll(
-                    translations.map { it.target }.intersect(targetLanguages)
-                )
             }
     }
 }


### PR DESCRIPTION
Let the target languages always available for selection. If there is an existing translation for the selected languages, simply update its timestamp = appears on top.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/orature/577)
<!-- Reviewable:end -->

![image](https://user-images.githubusercontent.com/34975907/166251847-7653f064-755a-4112-ad96-8058c0887e01.png)

Result at HomePage

![image](https://user-images.githubusercontent.com/34975907/166251935-f4acacef-93ee-407a-ba01-ea412a8008e3.png)
