### PR TITLE
Fix integration test silently failed

### DIFF
--- a/common/src/test/kotlin/org/wycliffeassociates/otter/common/domain/audio/AudioExporterTest.kt
+++ b/common/src/test/kotlin/org/wycliffeassociates/otter/common/domain/audio/AudioExporterTest.kt
@@ -22,6 +22,13 @@ import org.junit.Assert.assertTrue
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.wycliffeassociates.otter.common.audio.AudioFile
+import org.wycliffeassociates.otter.common.audio.DEFAULT_BITS_PER_SAMPLE
+import org.wycliffeassociates.otter.common.audio.DEFAULT_CHANNELS
+import org.wycliffeassociates.otter.common.audio.DEFAULT_SAMPLE_RATE
+import org.wycliffeassociates.otter.common.audio.wav.CueChunk
+import org.wycliffeassociates.otter.common.audio.wav.WavFile
+import org.wycliffeassociates.otter.common.audio.wav.WavMetadata
+import org.wycliffeassociates.otter.common.audio.wav.WavOutputStream
 import org.wycliffeassociates.otter.common.data.primitives.Contributor
 import org.wycliffeassociates.otter.common.data.primitives.License
 import java.io.File
@@ -31,7 +38,7 @@ class AudioExporterTest {
 
     @Test
     fun exportMp3() {
-        val inputFile = File(javaClass.classLoader.getResource("mini-sample-audio.wav").file)
+        val inputFile = createTestWavFile()
             .apply { deleteOnExit() }
         val outputDir = createTempDirectory().toFile()
             .apply { deleteOnExit() }
@@ -55,5 +62,25 @@ class AudioExporterTest {
         val audioFile = AudioFile(outputFile)
         assertEquals(2, audioFile.metadata.artists().size)
         assertEquals(license.url, audioFile.metadata.getLegalInformationUrl())
+    }
+
+    private fun createTestWavFile(): File {
+        val testFile = File.createTempFile("test-take", "wav")
+            .apply { deleteOnExit() }
+
+        val wav = WavFile(
+            testFile,
+            DEFAULT_CHANNELS,
+            DEFAULT_SAMPLE_RATE,
+            DEFAULT_BITS_PER_SAMPLE,
+            WavMetadata(listOf(CueChunk()))
+        )
+        WavOutputStream(wav).use {
+            for (i in 0 until 4) {
+                it.write(i)
+            }
+        }
+        wav.update()
+        return testFile
     }
 }

--- a/jvm/workbookapp/src/test/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/TranslationViewModelTest.kt
+++ b/jvm/workbookapp/src/test/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/TranslationViewModelTest.kt
@@ -111,13 +111,9 @@ class TranslationViewModelTest {
     @Test
     fun loadTargetLanguages() {
         val languages = LanguageSelectionViewModelTest.initLanguages()
-        val translation = Translation(sourceLanguage, languages[0], null)
-
         val mockLanguageRepo = mock(ILanguageRepository::class.java)
         `when`(mockLanguageRepo.getAll())
             .thenReturn(Single.just(languages))
-        `when`(mockLanguageRepo.getAllTranslations())
-            .thenReturn(Single.just(listOf(translation)))
         vm.languageRepo = mockLanguageRepo
 
         assertEquals(0, vm.targetLanguages.size)
@@ -128,6 +124,5 @@ class TranslationViewModelTest {
 
         assertEquals(languages.size, vm.targetLanguages.size)
         verify(mockLanguageRepo).getAll()
-        verify(mockLanguageRepo).getAllTranslations()
     }
 }


### PR DESCRIPTION
`importSources()` in _ProjectImporter.kt_ will retry after an import result of UNMATCHED_HELP is found. However, when re-importing occurs, `importContainer()` in _ImportResourceContainer.kt_ marks the RC as already exists and blocks the importing process with an exception, thus failed the test `tnHelps()` in _TestProjectImport.kt_.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/orature/583)
<!-- Reviewable:end -->
