### PR TITLE
Fix verse accordion shows empty when first clicked

### DIFF
--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/ChunkCell.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/ChunkCell.kt
@@ -97,7 +97,8 @@ class ChunkCell(
                 }
             }
 
-            setOnMouseClicked {
+            // mouseReleased avoids drag click side effect
+            setOnMouseReleased {
                 requestFocus()
                 toggleShowTakes()
             }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/ChunkCell.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/ChunkCell.kt
@@ -35,6 +35,9 @@ class ChunkCell(
     private val focusedChunkProperty: Property<ChunkItem>
 ) : ListCell<CardData>() {
     private val view = ChunkItem()
+    init {
+        addClass("chunk-list-cell")
+    }
 
     override fun updateItem(item: CardData?, empty: Boolean) {
         super.updateItem(item, empty)
@@ -42,6 +45,12 @@ class ChunkCell(
         if (empty || item == null) {
             graphic = null
             return
+        }
+
+        // mouseReleased avoids drag click side effect
+        setOnMouseReleased {
+            view.requestFocus()
+            view.toggleShowTakes()
         }
 
         graphic = view.apply {
@@ -95,12 +104,6 @@ class ChunkCell(
                     }
                     KeyCode.ESCAPE -> hideTakes()
                 }
-            }
-
-            // mouseReleased avoids drag click side effect
-            setOnMouseReleased {
-                requestFocus()
-                toggleShowTakes()
             }
         }
     }

--- a/jvm/workbookapp/src/main/resources/css/chapter-page.css
+++ b/jvm/workbookapp/src/main/resources/css/chapter-page.css
@@ -107,7 +107,7 @@
 .chapter-page__chunks .list-view .list-cell:even,
 .chapter-page__chunks .list-view .list-cell:odd {
     -fx-background-color: -wa-foreground;
-    -fx-padding: 4px;
+    -fx-padding: 0;
 }
 
 .btn--icon .ikonli-font-icon {

--- a/jvm/workbookapp/src/main/resources/css/chapter-page.css
+++ b/jvm/workbookapp/src/main/resources/css/chapter-page.css
@@ -107,7 +107,11 @@
 .chapter-page__chunks .list-view .list-cell:even,
 .chapter-page__chunks .list-view .list-cell:odd {
     -fx-background-color: -wa-foreground;
-    -fx-padding: 0;
+    -fx-padding: 4px;
+}
+
+.chapter-page__chunks .list-view .list-cell:hover {
+    -fx-cursor: hand;
 }
 
 .btn--icon .ikonli-font-icon {


### PR DESCRIPTION
Move mouse event listener to list cell (wrapper of inner graphic node) to avoid clicking beyond the graphic node and losing focus


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/orature/594)
<!-- Reviewable:end -->
