### PR TITLE
Fix crash editing contributor 

### DIFF
--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/ContributorCell.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/ContributorCell.kt
@@ -36,6 +36,8 @@ class ContributorCell : HBox() {
     val onRemoveContributorActionProperty = SimpleObjectProperty<EventHandler<ActionEvent>>(null)
     val onEditContributorActionProperty = SimpleObjectProperty<EventHandler<ActionEvent>>(null)
 
+    val lastModifiedIndexProperty = SimpleIntegerProperty(-1)
+
     init {
         addClass("contributor__list-cell")
 
@@ -62,8 +64,16 @@ class ContributorCell : HBox() {
             addClass("btn", "btn--icon")
             graphic = FontIcon(Material.DELETE)
             setOnAction {
+                val index = if (indexProperty.value < 0) {
+                    // when an item is deleted, its index will no longer be valid (-1)
+                    // uses the last modified will track the latest item changed, allows deleting the correct one
+                    lastModifiedIndexProperty.value
+                } else {
+                    indexProperty.value
+                }
+
                 onRemoveContributorActionProperty.value?.handle(
-                    ActionEvent(indexProperty.value, this@ContributorCell)
+                    ActionEvent(index, this@ContributorCell)
                 )
             }
         }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/ContributorInfo.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/ContributorInfo.kt
@@ -19,6 +19,7 @@
 package org.wycliffeassociates.otter.jvm.workbookapp.ui.components
 
 import javafx.beans.binding.Bindings
+import javafx.beans.property.SimpleIntegerProperty
 import javafx.beans.property.SimpleObjectProperty
 import javafx.collections.ObservableList
 import javafx.event.ActionEvent
@@ -39,6 +40,7 @@ class ContributorInfo(
 ) : VBox() {
     var contributorField: TextField by singleAssign()
 
+    val lastModifiedIndex = SimpleIntegerProperty(-1)
     val addContributorCallbackProperty = SimpleObjectProperty<EventHandler<ActionEvent>>()
     val editContributorCallbackProperty = SimpleObjectProperty<EventHandler<ActionEvent>>()
     val removeContributorCallbackProperty = SimpleObjectProperty<EventHandler<ActionEvent>>()
@@ -107,6 +109,7 @@ class ContributorInfo(
                                 contributors
                             )
                         )
+                        lastModifiedIndexProperty.bind(lastModifiedIndex)
                         onRemoveContributorActionProperty.bind(removeContributorCallbackProperty)
                         onEditContributorActionProperty.bind(editContributorCallbackProperty)
                     }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/WorkbookPage.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/WorkbookPage.kt
@@ -451,7 +451,9 @@ class WorkbookPage : View() {
                 )
                 editContributorCallbackProperty.set(
                     EventHandler {
-                        viewModel.editContributor(it.source as ContributorCellData)
+                        val data = it.source as ContributorCellData
+                        viewModel.editContributor(data)
+                        lastModifiedIndex.set(data.index)
                     }
                 )
                 removeContributorCallbackProperty.set(

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/dialogs/ExportChapterDialog.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/dialogs/ExportChapterDialog.kt
@@ -122,6 +122,7 @@ class ExportChapterDialog : OtterDialog() {
                     EventHandler {
                         val data = it.source as ContributorCellData
                         viewModel.editContributor(data)
+                        lastModifiedIndex.set(data.index)
                     }
                 )
             }


### PR DESCRIPTION
When an item (contributor) is deleted, its index data is updated to -1 and the delete event registered with the old graphic Node, thus firing `delete(-1)` and causing a crash.

This PR adds an index tracking for latest item that was edited, so that the delete event can use such index (if current index is -1) for accurate operation

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/orature/595)
<!-- Reviewable:end -->
