### PR TITLE
Fix last verse overflow in Chapter page

### DIFF
--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/ChunkCell.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/ChunkCell.kt
@@ -128,7 +128,7 @@ class ChunkCell(
         val flow = listView
             .childrenUnmodifiable
             .find { it is VirtualFlow<*> } as VirtualFlow<*>
-        flow.scrollPixels(-1.0)
-        runLater { flow.scrollPixels(1.0) }
+        flow.scrollPixels(-5.0)
+        runLater { flow.scrollPixels(10.0) }
     }
 }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/ChunkCell.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/ChunkCell.kt
@@ -121,8 +121,8 @@ class ChunkCell(
     }
 
     /**
-     * Use workaround for the last item in the list view
-     * to fully display the expanded content of such item.
+     * Workaround for the last item in the list view
+     * to fully display when expanding causes an overflow
      */
     private fun forceScrollToResizeListView() {
         val flow = listView

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/ChunkCell.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/ChunkCell.kt
@@ -97,7 +97,8 @@ class ChunkCell(
                 }
             }
 
-            setOnMouseClicked {
+            // mouseReleased avoids drag click side effect
+            setOnMouseReleased {
                 requestFocus()
                 toggleShowTakes()
             }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/ChunkCell.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/ChunkCell.kt
@@ -35,6 +35,9 @@ class ChunkCell(
     private val focusedChunkProperty: Property<ChunkItem>
 ) : ListCell<CardData>() {
     private val view = ChunkItem()
+    init {
+        addClass("chunk-list-cell")
+    }
 
     override fun updateItem(item: CardData?, empty: Boolean) {
         super.updateItem(item, empty)
@@ -42,6 +45,12 @@ class ChunkCell(
         if (empty || item == null) {
             graphic = null
             return
+        }
+
+        // mouseReleased avoids drag click side effect
+        setOnMouseReleased {
+            view.requestFocus()
+            view.toggleShowTakes()
         }
 
         graphic = view.apply {
@@ -95,12 +104,6 @@ class ChunkCell(
                     }
                     KeyCode.ESCAPE -> hideTakes()
                 }
-            }
-
-            // mouseReleased avoids drag click side effect
-            setOnMouseReleased {
-                requestFocus()
-                toggleShowTakes()
             }
         }
     }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/ChunkCell.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/ChunkCell.kt
@@ -21,6 +21,7 @@ package org.wycliffeassociates.otter.jvm.workbookapp.ui.components
 import javafx.beans.property.Property
 import javafx.scene.control.Button
 import javafx.scene.control.ListCell
+import javafx.scene.control.skin.VirtualFlow
 import javafx.scene.input.KeyCode
 import org.wycliffeassociates.otter.common.utils.capitalizeString
 import org.wycliffeassociates.otter.jvm.utils.findChild
@@ -49,6 +50,9 @@ class ChunkCell(
 
         // mouseReleased avoids drag click side effect
         setOnMouseReleased {
+            if (index == listView.items.size - 1) {
+                forceScrollToResizeListView()
+            }
             view.requestFocus()
             view.toggleShowTakes()
         }
@@ -114,5 +118,17 @@ class ChunkCell(
                 .thenByDescending { it.take.file.lastModified() }
         )
         view.takes.setAll(sorted)
+    }
+
+    /**
+     * Use workaround for the last item in the list view
+     * to fully display the expanded content of such item.
+     */
+    private fun forceScrollToResizeListView() {
+        val flow = listView
+            .childrenUnmodifiable
+            .find { it is VirtualFlow<*> } as VirtualFlow<*>
+        flow.scrollPixels(-1.0)
+        runLater { flow.scrollPixels(1.0) }
     }
 }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/ChunkCell.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/ChunkCell.kt
@@ -90,6 +90,9 @@ class ChunkCell(
             setOnKeyReleased {
                 when (it.code) {
                     KeyCode.ENTER, KeyCode.SPACE -> {
+                        if (index == listView.items.size - 1) {
+                            forceScrollToResizeListView()
+                        }
                         toggleShowTakes()
                     }
                     KeyCode.DOWN, KeyCode.UP -> {

--- a/jvm/workbookapp/src/main/resources/css/chapter-page.css
+++ b/jvm/workbookapp/src/main/resources/css/chapter-page.css
@@ -107,7 +107,7 @@
 .chapter-page__chunks .list-view .list-cell:even,
 .chapter-page__chunks .list-view .list-cell:odd {
     -fx-background-color: -wa-foreground;
-    -fx-padding: 4px;
+    -fx-padding: 0;
 }
 
 .btn--icon .ikonli-font-icon {

--- a/jvm/workbookapp/src/main/resources/css/chapter-page.css
+++ b/jvm/workbookapp/src/main/resources/css/chapter-page.css
@@ -107,7 +107,11 @@
 .chapter-page__chunks .list-view .list-cell:even,
 .chapter-page__chunks .list-view .list-cell:odd {
     -fx-background-color: -wa-foreground;
-    -fx-padding: 0;
+    -fx-padding: 4px;
+}
+
+.chapter-page__chunks .list-view .list-cell:hover {
+    -fx-cursor: hand;
 }
 
 .btn--icon .ikonli-font-icon {


### PR DESCRIPTION
Clicking on the final item will not display properly due to overflow.
![image](https://user-images.githubusercontent.com/34975907/172652898-ab37ef3e-f2db-4aed-80fa-21159c22d2d8.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/orature/597)
<!-- Reviewable:end -->
