### PR TITLE
Add KFoenix

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -21,6 +21,7 @@ ext {
     rxkotlinfxVer = '2.2.2'
     rxrelayVer = '2.1.0'
     jfoenixVer = '17-hotfix'
+    kfoenixVer = "0.2.0"
     sqliteJdbcVer = '3.28.0'
     jooqVer = '3.12.4'
     franzXaverVer = '0.1' // SVG Loader

--- a/jvm/controls/build.gradle
+++ b/jvm/controls/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 
     // JFoenix
     implementation "com.jfoenix:jfoenix:$jfoenixVer"
+    implementation "com.github.bkenn:kfoenix:$kfoenixVer"
 
     // ControlsFX
     implementation "org.controlsfx:controlsfx:$controlsfxVer"

--- a/jvm/markerapp/build.gradle
+++ b/jvm/markerapp/build.gradle
@@ -26,6 +26,7 @@ dependencies {
 
     // JFoenix
     implementation "com.jfoenix:jfoenix:$jfoenixVer"
+    implementation "com.github.bkenn:kfoenix:$kfoenixVer"
 
     // Ikonli
     implementation "org.kordamp.ikonli:ikonli-javafx:$ikonliVer"

--- a/jvm/recorderapp/build.gradle
+++ b/jvm/recorderapp/build.gradle
@@ -24,6 +24,7 @@ dependencies {
 
     // JFoenix
     implementation "com.jfoenix:jfoenix:$jfoenixVer"
+    implementation "com.github.bkenn:kfoenix:$kfoenixVer"
 
     // Testing
     testImplementation "junit:junit:$junitVer"

--- a/jvm/workbookapp/build.gradle
+++ b/jvm/workbookapp/build.gradle
@@ -115,6 +115,7 @@ dependencies {
 
     // JFoenix
     implementation "com.jfoenix:jfoenix:$jfoenixVer"
+    implementation "com.github.bkenn:kfoenix:$kfoenixVer"
 
     // ControlsFX
     implementation "org.wycliffeassociates:javafx-gridview:$javaGridviewVer"


### PR DESCRIPTION
The kfoenix library adds tornadofx bindings to jfoenix.

rather than have to do:

add(JFXButton().apply {})

we can now do:
jfxbutton { }

like with other tornadofx controls

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/orature/626)
<!-- Reviewable:end -->
