### PR TITLE
Unlock app controls in native plugin (marker & recorder)

### DIFF
--- a/assets/src/main/kotlin/org/wycliffeassociates/otter/assets/initialization/InitializeMarker.kt
+++ b/assets/src/main/kotlin/org/wycliffeassociates/otter/assets/initialization/InitializeMarker.kt
@@ -39,7 +39,7 @@ class InitializeMarker @Inject constructor(
 ) : Installable {
 
     override val name = "MARKER"
-    override val version = 25
+    override val version = 26
     val log = LoggerFactory.getLogger(InitializeMarker::class.java)
 
     override fun exec(): Completable {

--- a/assets/src/main/kotlin/org/wycliffeassociates/otter/assets/initialization/InitializeRecorder.kt
+++ b/assets/src/main/kotlin/org/wycliffeassociates/otter/assets/initialization/InitializeRecorder.kt
@@ -39,7 +39,7 @@ class InitializeRecorder @Inject constructor(
 ) : Installable {
 
     override val name = "RECORDER"
-    override val version = 22
+    override val version = 23
 
     val log = LoggerFactory.getLogger(InitializeRecorder::class.java)
 

--- a/jvm/markerapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/markerapp/app/view/MarkerView.kt
+++ b/jvm/markerapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/markerapp/app/view/MarkerView.kt
@@ -21,6 +21,7 @@ package org.wycliffeassociates.otter.jvm.markerapp.app.view
 import com.github.thomasnield.rxkotlinfx.observeOnFx
 import com.sun.javafx.util.Utils
 import javafx.animation.AnimationTimer
+import javafx.event.EventHandler
 import org.wycliffeassociates.otter.jvm.controls.Shortcut
 import org.wycliffeassociates.otter.jvm.controls.breadcrumbs.BreadcrumbBar
 import org.wycliffeassociates.otter.jvm.controls.model.pixelsToFrames
@@ -170,5 +171,14 @@ class MarkerView : PluginEntrypoint() {
                 }
             }
 
+        runLater {
+            currentWindow?.setOnCloseRequest {
+                if (viewModel.isLoadingProperty.value) {
+                    it.consume()
+                } else {
+                    viewModel.saveChanges()
+                }
+            }
+        }
     }
 }

--- a/jvm/markerapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/markerapp/app/view/MarkerView.kt
+++ b/jvm/markerapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/markerapp/app/view/MarkerView.kt
@@ -29,6 +29,7 @@ import org.wycliffeassociates.otter.jvm.controls.waveform.MarkerPlacementWavefor
 import org.wycliffeassociates.otter.jvm.controls.waveform.MarkerTrackControl
 import org.wycliffeassociates.otter.jvm.markerapp.app.viewmodel.VerseMarkerViewModel
 import org.wycliffeassociates.otter.jvm.utils.onChangeAndDoNow
+import org.wycliffeassociates.otter.jvm.workbookplugin.plugin.ParameterizedScope
 import org.wycliffeassociates.otter.jvm.workbookplugin.plugin.PluginEntrypoint
 import tornadofx.*
 
@@ -90,6 +91,7 @@ class MarkerView : PluginEntrypoint() {
         waveform.markerStateProperty.unbind()
         waveform.positionProperty.unbind()
         minimap?.cleanUpOnUndock()
+        viewModel.saveChanges()
     }
 
     override val root =
@@ -140,6 +142,15 @@ class MarkerView : PluginEntrypoint() {
                 add<PlaybackControlsFragment>()
             }
             shortcut(Shortcut.ADD_MARKER.value, viewModel::placeMarker)
-            shortcut(Shortcut.GO_BACK.value, viewModel::saveAndQuit)
+            shortcut(Shortcut.GO_BACK.value) {
+                viewModel.saveChanges {
+                    (scope as ParameterizedScope).let {
+                        runLater {
+                            it.navigateBack()
+                            System.gc()
+                        }
+                    }
+                }
+            }
         }
 }

--- a/jvm/markerapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/markerapp/app/view/MarkerView.kt
+++ b/jvm/markerapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/markerapp/app/view/MarkerView.kt
@@ -49,7 +49,7 @@ class MarkerView : PluginEntrypoint() {
 
     override fun onDock() {
         super.onDock()
-        bindLoadingNavigationLock()
+        blockAppControlsWhenLoading()
         viewModel.onDock()
         viewModel.imageCleanup = waveform::freeImages
         timer = object : AnimationTimer() {
@@ -157,11 +157,18 @@ class MarkerView : PluginEntrypoint() {
             }
         }
 
-    private fun bindLoadingNavigationLock() {
+    private fun blockAppControlsWhenLoading() {
         currentStage?.scene?.root
-            ?.findChildren(BreadcrumbBar::class)?.firstOrNull()
-            ?.let { bar ->
-                (bar as BreadcrumbBar).disableProperty().bind(viewModel.isLoadingProperty)
+            ?.let { node ->
+                node.findChildren(BreadcrumbBar::class)?.firstOrNull()
+                ?.let { bar ->
+                    (bar as BreadcrumbBar).disableProperty().bind(viewModel.isLoadingProperty)
+                }
+
+                node.lookupAll(".app-bar").firstOrNull()?.let {
+                    it.disableProperty().bind(viewModel.isLoadingProperty)
+                }
             }
+
     }
 }

--- a/jvm/markerapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/markerapp/app/view/MarkerView.kt
+++ b/jvm/markerapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/markerapp/app/view/MarkerView.kt
@@ -22,12 +22,14 @@ import com.github.thomasnield.rxkotlinfx.observeOnFx
 import com.sun.javafx.util.Utils
 import javafx.animation.AnimationTimer
 import org.wycliffeassociates.otter.jvm.controls.Shortcut
+import org.wycliffeassociates.otter.jvm.controls.breadcrumbs.BreadcrumbBar
 import org.wycliffeassociates.otter.jvm.controls.model.pixelsToFrames
 import org.wycliffeassociates.otter.jvm.controls.styles.tryImportStylesheet
 import org.wycliffeassociates.otter.jvm.controls.waveform.AudioSlider
 import org.wycliffeassociates.otter.jvm.controls.waveform.MarkerPlacementWaveform
 import org.wycliffeassociates.otter.jvm.controls.waveform.MarkerTrackControl
 import org.wycliffeassociates.otter.jvm.markerapp.app.viewmodel.VerseMarkerViewModel
+import org.wycliffeassociates.otter.jvm.utils.findChildren
 import org.wycliffeassociates.otter.jvm.utils.onChangeAndDoNow
 import org.wycliffeassociates.otter.jvm.workbookplugin.plugin.ParameterizedScope
 import org.wycliffeassociates.otter.jvm.workbookplugin.plugin.PluginEntrypoint
@@ -47,6 +49,7 @@ class MarkerView : PluginEntrypoint() {
 
     override fun onDock() {
         super.onDock()
+        bindLoadingNavigationLock()
         viewModel.onDock()
         viewModel.imageCleanup = waveform::freeImages
         timer = object : AnimationTimer() {
@@ -153,4 +156,12 @@ class MarkerView : PluginEntrypoint() {
                 }
             }
         }
+
+    private fun bindLoadingNavigationLock() {
+        currentStage?.scene?.root
+            ?.findChildren(BreadcrumbBar::class)?.firstOrNull()
+            ?.let { bar ->
+                (bar as BreadcrumbBar).disableProperty().bind(viewModel.isLoadingProperty)
+            }
+    }
 }

--- a/jvm/markerapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/markerapp/app/view/MarkerView.kt
+++ b/jvm/markerapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/markerapp/app/view/MarkerView.kt
@@ -83,7 +83,7 @@ class MarkerView : PluginEntrypoint() {
         tryImportStylesheet(resources.get("/css/chunk-marker.css"))
 
         initThemeProperty()
-        overrideClosingAppHandler()
+        overrideCloseRequestHandler()
     }
 
     override fun onUndock() {
@@ -162,15 +162,12 @@ class MarkerView : PluginEntrypoint() {
         }
     }
 
-    private fun overrideClosingAppHandler() {
+    private fun overrideCloseRequestHandler() {
         runLater {
-            currentWindow?.let {
-                viewModel.defaultOnCloseRequest = it.onCloseRequest
-            }
-            currentWindow?.setOnCloseRequest {
-                if (viewModel.isLoadingProperty.value) {
-                    it.consume()
-                } else {
+            currentWindow?.let { window ->
+                viewModel.defaultOnCloseRequest = window.onCloseRequest
+
+                window.setOnCloseRequest {
                     viewModel.saveChanges()
                 }
             }

--- a/jvm/markerapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/markerapp/app/view/PlaybackControlsFragment.kt
+++ b/jvm/markerapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/markerapp/app/view/PlaybackControlsFragment.kt
@@ -25,6 +25,7 @@ import javafx.scene.layout.Priority
 import org.kordamp.ikonli.javafx.FontIcon
 import org.slf4j.LoggerFactory
 import org.wycliffeassociates.otter.jvm.markerapp.app.viewmodel.VerseMarkerViewModel
+import org.wycliffeassociates.otter.jvm.workbookplugin.plugin.ParameterizedScope
 import tornadofx.*
 
 class PlaybackControlsFragment : Fragment() {
@@ -79,7 +80,14 @@ class PlaybackControlsFragment : Fragment() {
 
         disableProperty().bind(viewModel.isLoadingProperty)
         setOnAction {
-            viewModel.saveAndQuit()
+            viewModel.saveChanges {
+                (scope as ParameterizedScope).let {
+                    runLater {
+                        it.navigateBack()
+                        System.gc()
+                    }
+                }
+            }
         }
     }
 

--- a/jvm/markerapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/markerapp/app/view/PlaybackControlsFragment.kt
+++ b/jvm/markerapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/markerapp/app/view/PlaybackControlsFragment.kt
@@ -80,14 +80,7 @@ class PlaybackControlsFragment : Fragment() {
 
         disableProperty().bind(viewModel.isLoadingProperty)
         setOnAction {
-            viewModel.saveChanges {
-                (scope as ParameterizedScope).let {
-                    runLater {
-                        it.navigateBack()
-                        System.gc()
-                    }
-                }
-            }
+            viewModel.saveAndQuit()
         }
     }
 

--- a/jvm/markerapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/markerapp/app/viewmodel/VerseMarkerViewModel.kt
+++ b/jvm/markerapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/markerapp/app/viewmodel/VerseMarkerViewModel.kt
@@ -26,9 +26,11 @@ import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.subjects.PublishSubject
 import javafx.beans.property.*
 import javafx.beans.value.ChangeListener
+import javafx.event.EventHandler
 import javafx.scene.control.Slider
 import javafx.scene.image.Image
 import javafx.scene.paint.Color
+import javafx.stage.WindowEvent
 import org.slf4j.LoggerFactory
 import org.wycliffeassociates.otter.common.audio.AudioFile
 import org.wycliffeassociates.otter.common.data.ColorTheme
@@ -65,6 +67,7 @@ class VerseMarkerViewModel : ViewModel() {
 
     lateinit var waveformMinimapImageListener: ChangeListener<Image>
     lateinit var markerStateListener: ChangeListener<VerseMarkerModel>
+    lateinit var defaultOnCloseRequest: EventHandler<WindowEvent>
 
     val logger = LoggerFactory.getLogger(VerseMarkerViewModel::class.java)
 
@@ -166,6 +169,17 @@ class VerseMarkerViewModel : ViewModel() {
             .subscribe {
                 callback()
             }
+    }
+
+    fun saveAndQuit() {
+        saveChanges {
+            (scope as ParameterizedScope).let {
+                runLater {
+                    it.navigateBack()
+                    System.gc()
+                }
+            }
+        }
     }
 
     fun placeMarker() {

--- a/jvm/markerapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/markerapp/app/viewmodel/VerseMarkerViewModel.kt
+++ b/jvm/markerapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/markerapp/app/viewmodel/VerseMarkerViewModel.kt
@@ -173,11 +173,9 @@ class VerseMarkerViewModel : ViewModel() {
 
     fun saveAndQuit() {
         saveChanges {
-            (scope as ParameterizedScope).let {
-                runLater {
-                    it.navigateBack()
-                    System.gc()
-                }
+            runLater {
+                (scope as ParameterizedScope).navigateBack()
+                System.gc()
             }
         }
     }

--- a/jvm/recorderapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/recorder/app/RecordingApp.kt
+++ b/jvm/recorderapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/recorder/app/RecordingApp.kt
@@ -30,6 +30,6 @@ class RecordingApp : App() {
     init {
         val args =
             if (!parameters?.raw.isNullOrEmpty()) parameters.raw.toTypedArray() else arrayOf("--wav=recording.wav")
-        this.scope = ParameterizedScope(ParametersImpl(args)) {}
+        this.scope = ParameterizedScope(ParametersImpl(args), {}, {})
     }
 }

--- a/jvm/recorderapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/recorder/app/view/ControlFragment.kt
+++ b/jvm/recorderapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/recorder/app/view/ControlFragment.kt
@@ -105,7 +105,7 @@ class ControlFragment : Fragment() {
             visibleProperty().bind(vm.canSaveProperty)
             managedProperty().bind(vm.recordingProperty.or(vm.hasWrittenProperty))
             setOnAction {
-                vm.save()
+                vm.saveAndQuit()
             }
             shortcut(Shortcut.GO_BACK.value)
         }
@@ -116,7 +116,7 @@ class ControlFragment : Fragment() {
             visibleProperty().bind(vm.recordingProperty.not().and(vm.hasWrittenProperty.not()))
             managedProperty().bind(visibleProperty())
             setOnAction {
-                vm.save()
+                vm.saveAndQuit()
             }
             shortcut(Shortcut.GO_BACK.value)
         }

--- a/jvm/recorderapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/recorder/app/view/RecorderView.kt
+++ b/jvm/recorderapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/recorder/app/view/RecorderView.kt
@@ -21,6 +21,7 @@ package org.wycliffeassociates.otter.jvm.recorder.app.view
 import javafx.stage.Screen
 import org.wycliffeassociates.otter.jvm.controls.styles.tryImportStylesheet
 import org.wycliffeassociates.otter.jvm.recorder.app.viewmodel.RecorderViewModel
+import org.wycliffeassociates.otter.jvm.workbookplugin.plugin.ParameterizedScope
 import org.wycliffeassociates.otter.jvm.workbookplugin.plugin.PluginEntrypoint
 import tornadofx.*
 
@@ -55,6 +56,20 @@ class RecorderView : PluginEntrypoint() {
             if (!viewInflated && width.toInt() > 0) {
                 recorderViewModel.onViewReady(width.toInt())
                 viewInflated = true
+            }
+        }
+    }
+
+    override fun onDock() {
+        super.onDock()
+        recorderViewModel.dock()
+    }
+
+    override fun onUndock() {
+        super.onUndock()
+        recorderViewModel.save {
+            runLater {
+                (scope as ParameterizedScope).onNavigate()
             }
         }
     }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/plugin/AudioPlugin.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/plugin/AudioPlugin.kt
@@ -195,12 +195,20 @@ class AudioPlugin(
 
     private fun runInOtterMainWindow(pluginClass: KClass<PluginEntrypoint>, parameters: Parameters) {
         val appWorkspace: Workspace = find()
-        val scope = ParameterizedScope(parameters) {
-            synchronized(monitor) {
-                monitor.notify()
-                appWorkspace.navigateBack()
+        val scope = ParameterizedScope(
+            parameters,
+            {
+                synchronized(monitor) {
+                    monitor.notify()
+                    appWorkspace.navigateBack()
+                }
+            },
+            {
+                synchronized(monitor) {
+                    monitor.notify()
+                }
             }
-        }
+        )
         val paramsMap = appWorkspace.params
         val oldEntries = paramsMap.entries.map { it.toPair() }.toTypedArray()
         val newEntries = mapOf(*oldEntries, Pair("audioConnectionFactory", connectionFactory))

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/AppBar.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/AppBar.kt
@@ -89,6 +89,8 @@ class AppBar : Fragment() {
         root.apply {
             styleClass.setAll("app-bar")
 
+            disableProperty().bind(rootViewModel.externalPluginOpenedProperty)
+
             label {
                 addClass("app-bar__logo")
                 graphic = FontIcon(MaterialDesign.MDI_HEADSET)

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/AppBar.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/AppBar.kt
@@ -89,8 +89,6 @@ class AppBar : Fragment() {
         root.apply {
             styleClass.setAll("app-bar")
 
-            disableProperty().bind(rootViewModel.pluginOpenedProperty)
-
             label {
                 addClass("app-bar__logo")
                 graphic = FontIcon(MaterialDesign.MDI_HEADSET)

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/AppContent.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/AppContent.kt
@@ -41,7 +41,6 @@ class AppContent : View() {
             borderpane {
                 top = navigator.breadCrumbsBar.apply {
                     orientationScaleProperty.bind(settingsViewModel.orientationScaleProperty)
-                    disableWhen(rootViewModel.pluginOpenedProperty)
                 }
                 center<Workspace>()
             }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/AppContent.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/AppContent.kt
@@ -41,6 +41,7 @@ class AppContent : View() {
             borderpane {
                 top = navigator.breadCrumbsBar.apply {
                     orientationScaleProperty.bind(settingsViewModel.orientationScaleProperty)
+                    disableProperty().bind(rootViewModel.externalPluginOpenedProperty)
                 }
                 center<Workspace>()
             }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/RootView.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/RootView.kt
@@ -43,7 +43,7 @@ class RootView : View() {
         // Plugins being opened should block the app from closing as this could result in a
         // loss of communication between the app and the external plugin, thus data loss
         workspace.subscribe<PluginOpenedEvent> {
-            (app as OtterApp).shouldBlockWindowCloseRequest = true
+            (app as OtterApp).shouldBlockWindowCloseRequest = !it.isNative
             viewModel.pluginOpenedProperty.set(true)
         }
         workspace.subscribe<PluginClosedEvent> {

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/RootView.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/RootView.kt
@@ -44,11 +44,11 @@ class RootView : View() {
         // loss of communication between the app and the external plugin, thus data loss
         workspace.subscribe<PluginOpenedEvent> {
             (app as OtterApp).shouldBlockWindowCloseRequest = !it.isNative
-            viewModel.pluginOpenedProperty.set(true)
+            viewModel.externalPluginOpenedProperty.set(!it.isNative)
         }
         workspace.subscribe<PluginClosedEvent> {
             (app as OtterApp).shouldBlockWindowCloseRequest = false
-            viewModel.pluginOpenedProperty.set(false)
+            viewModel.externalPluginOpenedProperty.set(false)
         }
         workspace.header.removeFromParent()
         workspace.root.vgrow = Priority.ALWAYS

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/RootViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/RootViewModel.kt
@@ -33,7 +33,7 @@ class RootViewModel : ViewModel() {
 
     val logger = LoggerFactory.getLogger(RootViewModel::class.java)
 
-    val pluginOpenedProperty = SimpleBooleanProperty(false)
+    val externalPluginOpenedProperty = SimpleBooleanProperty(false)
     val drawerOpenedProperty = SimpleBooleanProperty(false)
 
     val showAudioErrorDialogProperty = SimpleBooleanProperty(false)

--- a/jvm/workbookplugin/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookplugin/plugin/ParameterizedScope.kt
+++ b/jvm/workbookplugin/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookplugin/plugin/ParameterizedScope.kt
@@ -23,9 +23,14 @@ import tornadofx.Scope
 
 class ParameterizedScope(
     val parameters: Application.Parameters,
-    private val onNavigateBackCallback: () -> Unit
+    private val onNavigateBackCallback: () -> Unit,
+    private val onNavigateRequest: () -> Unit = {}
 ) : Scope() {
     fun navigateBack() {
         onNavigateBackCallback()
+    }
+
+    fun onNavigate() {
+        onNavigateRequest()
     }
 }


### PR DESCRIPTION
Previously, markerapp disables breadcrumb navigation and app bar when a plugin is opened (even for native plugins).

This PR releases the sandboxed controls for native plugins so that these controls are available after the waveform has finished loading. Additionally, navigating back or exit the app will automatically save the current data.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/orature/630)
<!-- Reviewable:end -->
