### PR TITLE
Fix a memory leak related to plugins

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -16,7 +16,7 @@ ext {
     kotlinVer = '1.5.10'
     javafxVer = '18'
     javaGridviewVer = '1.0.0'
-    tornadofxVer = '2.0.0-SNAPSHOT'
+    tornadofxVer = '2.0.0-WA-fork'
     rxkotlinVer = '2.4.0'
     rxkotlinfxVer = '2.2.2'
     rxrelayVer = '2.1.0'

--- a/jvm/controls/build.gradle
+++ b/jvm/controls/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     implementation "com.jakewharton.rxrelay2:rxrelay:$rxrelayVer"
 
     // TornadoFX
-    implementation "no.tornado:tornadofx:$tornadofxVer"
+    implementation "no.tornado:tornadofx2:$tornadofxVer"
 
     // SVG Loader
     implementation "com.github.jsarabia:FranzXaverSVG:$franzXaverSvgVer"

--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/skins/cards/TranslationCardSkin.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/skins/cards/TranslationCardSkin.kt
@@ -112,11 +112,16 @@ class TranslationCardSkin<T>(private val card: TranslationCard<T>) : SkinBase<Tr
 
         seeMoreBtn.apply {
             textProperty().bind(card.showMoreTextProperty)
-            visibleProperty().bind(card.itemsProperty.booleanBinding {
-                it?.let {
-                    it.size > card.shownItemsNumberProperty.value
-                } ?: false
-            })
+            visibleProperty().bind(
+                booleanBinding(
+                    card.itemsProperty,
+                    op = {
+                        card.itemsProperty.value?.let {
+                            it.size > card.shownItemsNumberProperty.value
+                        } ?: false
+                    }
+                )
+            )
             managedProperty().bind(visibleProperty())
             textProperty().bind(seeMoreLessTextBinding())
             tooltip { textProperty().bind(seeMoreLessTextBinding()) }

--- a/jvm/markerapp/build.gradle
+++ b/jvm/markerapp/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     implementation "com.jakewharton.rxrelay2:rxrelay:$rxrelayVer"
 
     // TornadoFX
-    implementation "no.tornado:tornadofx:$tornadofxVer"
+    implementation "no.tornado:tornadofx2:$tornadofxVer"
 
     // JFoenix
     implementation "com.jfoenix:jfoenix:$jfoenixVer"

--- a/jvm/recorderapp/build.gradle
+++ b/jvm/recorderapp/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     implementation "com.jakewharton.rxrelay2:rxrelay:$rxrelayVer"
 
     // TornadoFX
-    implementation "no.tornado:tornadofx:$tornadofxVer"
+    implementation "no.tornado:tornadofx2:$tornadofxVer"
 
     // JFoenix
     implementation "com.jfoenix:jfoenix:$jfoenixVer"

--- a/jvm/utils/build.gradle
+++ b/jvm/utils/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     implementation "com.jakewharton.rxrelay2:rxrelay:$rxrelayVer"
 
     // TornadoFX
-    implementation "no.tornado:tornadofx:$tornadofxVer"
+    implementation "no.tornado:tornadofx2:$tornadofxVer"
 
     // SVG Loader
     implementation "com.github.jsarabia:FranzXaverSVG:$franzXaverSvgVer"

--- a/jvm/utils/src/main/kotlin/org/wycliffeassociates/otter/jvm/utils/images/SVGImage.kt
+++ b/jvm/utils/src/main/kotlin/org/wycliffeassociates/otter/jvm/utils/images/SVGImage.kt
@@ -33,24 +33,24 @@ class SVGImage(svgGroup: Group) : StackPane() {
     init {
         // Setup bindings so svg scales to fit Node
         svgGroup.scaleXProperty().bind(
-                widthProperty().doubleBinding(heightProperty(), preserveAspectProperty()) {
-                    var scaleX = (it?.toDouble() ?: 0.0) / svgGroup.boundsInLocal.width
-                    if (preserveAspect && width / height > svgAspectRatio) {
-                        // Wider than it should be
-                        scaleX = svgAspectRatio * height / svgGroup.boundsInLocal.width
-                    }
-                    return@doubleBinding scaleX
+            doubleBinding(widthProperty(), heightProperty(), preserveAspectProperty(), op = {
+                var scaleX = (widthProperty().value?.toDouble() ?: 0.0) / svgGroup.boundsInLocal.width
+                if (preserveAspect && width / height > svgAspectRatio) {
+                    // Wider than it should be
+                    scaleX = svgAspectRatio * height / svgGroup.boundsInLocal.width
                 }
+                return@doubleBinding scaleX
+            })
         )
         svgGroup.scaleYProperty().bind(
-                heightProperty().doubleBinding(widthProperty(), preserveAspectProperty()) {
-                    var scaleY = (it?.toDouble() ?: 0.0) / svgGroup.boundsInLocal.height
-                    if (preserveAspect && width / height < svgAspectRatio) {
-                        // Taller than it should be
-                        scaleY = (width / svgAspectRatio) / svgGroup.boundsInLocal.height
-                    }
-                    return@doubleBinding scaleY
+            doubleBinding(heightProperty(), widthProperty(), preserveAspectProperty(), op = {
+                var scaleY = (heightProperty().value?.toDouble() ?: 0.0) / svgGroup.boundsInLocal.height
+                if (preserveAspect && width / height < svgAspectRatio) {
+                    // Taller than it should be
+                    scaleY = (width / svgAspectRatio) / svgGroup.boundsInLocal.height
                 }
+                return@doubleBinding scaleY
+            })
         )
         minHeight = 0.0
         minWidth = 0.0

--- a/jvm/workbookapp/build.gradle
+++ b/jvm/workbookapp/build.gradle
@@ -103,7 +103,7 @@ dependencies {
     implementation "com.jakewharton.rxrelay2:rxrelay:$rxrelayVer"
 
     // TornadoFX
-    implementation "no.tornado:tornadofx:$tornadofxVer"
+    implementation "no.tornado:tornadofx2:$tornadofxVer"
 
     //OpenJFX cross-platform fat jar dependencies
     runtimeOnly "org.openjfx:javafx-graphics:$javafxVer:win"

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/plugin/AudioPlugin.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/plugin/AudioPlugin.kt
@@ -212,6 +212,7 @@ class AudioPlugin(
         }
         synchronized(monitor) {
             monitor.wait()
+            scope.deregister()
         }
     }
 }

--- a/jvm/workbookplugin/build.gradle
+++ b/jvm/workbookplugin/build.gradle
@@ -13,5 +13,5 @@ repositories {
 
 dependencies {
     // TornadoFX
-    implementation "no.tornado:tornadofx:$tornadofxVer"
+    implementation "no.tornado:tornadofx2:$tornadofxVer"
 }


### PR DESCRIPTION
Each scope stores a map in tornadofx holding all Views and Fragments for that scope- as such, without deregistering, they will leak every time a plugin is opened.

Also updates tornadofx to a self hosted build which includes the latest changes including a fix to a Fragment related memory leak.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/orature/633)
<!-- Reviewable:end -->
