### PR TITLE
Pause audio on undock - chunking steps

### DIFF
--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/chunking/ChunkingPage.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/chunking/ChunkingPage.kt
@@ -102,6 +102,7 @@ class ChunkingPage : View() {
 
     override fun onUndock() {
         super.onUndock()
+        vm.pause()
         timer?.stop()
         vm.compositeDisposable.clear()
     }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/chunking/Consume.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/chunking/Consume.kt
@@ -69,6 +69,7 @@ class Consume : Fragment() {
 
     override fun onUndock() {
         super.onUndock()
+        vm.pause()
         timer?.stop()
         vm.compositeDisposable.clear()
     }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/chunking/Verbalize.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/chunking/Verbalize.kt
@@ -79,9 +79,10 @@ class Verbalize : View() {
                     styleClass.addAll("btn", "btn--cta", "verbalize__btn--primary")
                     vm.recordingProperty.onChangeAndDoNow {
                         it?.let {
-                            when (it) {
-                                true -> graphic = stopIcon
-                                false -> graphic = recordIcon
+                            graphic = if (it) {
+                                stopIcon
+                            } else {
+                                recordIcon
                             }
                         }
                     }
@@ -98,5 +99,10 @@ class Verbalize : View() {
                 action { vm.reRecord() }
             }
         }
+    }
+
+    override fun onUndock() {
+        super.onUndock()
+        vm.pausePlayback()
     }
 }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/VerbalizeViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/VerbalizeViewModel.kt
@@ -148,6 +148,13 @@ class VerbalizeViewModel : ViewModel() {
         toggle()
     }
 
+    fun pausePlayback() {
+        player?.let {
+            it.pause()
+        }
+        isPlayingProperty.set(false)
+    }
+
     fun playToggle() {
         player?.let { player ->
             if (!isLoaded) {
@@ -166,8 +173,7 @@ class VerbalizeViewModel : ViewModel() {
                 isLoaded = true
             }
             if (player.isPlaying()) {
-                isPlayingProperty.set(false)
-                player.pause()
+                pausePlayback()
             } else {
                 isPlayingProperty.set(true)
                 player.play()

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/VerbalizeViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/VerbalizeViewModel.kt
@@ -82,9 +82,12 @@ class VerbalizeViewModel : ViewModel() {
     }
 
     private fun prepareAudio() {
-        prepareVerbalizationFile()
+        isLoaded = false
         getAudioConnections()
-        prepareRecorder()
+        if (!hasContentProperty.value) {
+            prepareVerbalizationFile()
+            prepareRecorder()
+        }
     }
 
     private fun prepareVerbalizationFile() {


### PR DESCRIPTION
When leaving (undocking) the view, any active playback needs to pause. Also, this PR fixes the crash when returning to verbalize and clicking play button.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/orature/639)
<!-- Reviewable:end -->
