### PR TITLE
Scope chunking wizard to clean memory

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -16,7 +16,7 @@ ext {
     kotlinVer = '1.5.10'
     javafxVer = '18'
     javaGridviewVer = '1.0.0'
-    tornadofxVer = '2.0.0-WA-fork'
+    tornadofxVer = '2.1.1-WA-fork'
     rxkotlinVer = '2.4.0'
     rxkotlinfxVer = '2.2.2'
     rxrelayVer = '2.1.0'

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/ChapterPage.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/ChapterPage.kt
@@ -114,7 +114,7 @@ class ChapterPage : View() {
 
         chunkListView.refresh()
         initializeProgressDialog()
-        clearChunkingScope()
+        resetChunkingScope()
     }
 
     override fun onUndock() {
@@ -149,7 +149,7 @@ class ChapterPage : View() {
         }
     }
 
-    private fun clearChunkingScope() {
+    private fun resetChunkingScope() {
         if (::chunkingScope.isInitialized) {
             logger.info("Deregistering chunking scope")
             chunkingScope.deregister()

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/chunking/ChunkingWizard.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/chunking/ChunkingWizard.kt
@@ -21,8 +21,13 @@ package org.wycliffeassociates.otter.jvm.workbookapp.ui.screens.chunking
 import javafx.scene.Node
 import javafx.scene.layout.Region
 import javafx.scene.shape.Rectangle
+import org.kordamp.ikonli.javafx.FontIcon
+import org.kordamp.ikonli.materialdesign.MaterialDesign
+import org.slf4j.LoggerFactory
+import org.wycliffeassociates.otter.jvm.controls.breadcrumbs.BreadCrumb
 import org.wycliffeassociates.otter.jvm.controls.styles.tryImportStylesheet
 import org.wycliffeassociates.otter.jvm.utils.onChangeAndDoNow
+import org.wycliffeassociates.otter.jvm.workbookapp.ui.NavigationMediator
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.viewmodel.ChunkingViewModel
 import tornadofx.*
 
@@ -31,27 +36,35 @@ private const val STEP_HEIGHT = 8.0
 
 class ChunkingWizard : Wizard() {
 
-    val vm: ChunkingViewModel by inject()
+    private val logger = LoggerFactory.getLogger(ChunkingWizard::class.java)
 
-    val consumeStep = Rectangle(STEP_WIDTH, STEP_HEIGHT).apply {
+    private val vm: ChunkingViewModel by inject()
+    private val navigator: NavigationMediator by inject()
+
+    private val consumeStep = Rectangle(STEP_WIDTH, STEP_HEIGHT).apply {
         addClass("chunking-wizard__step")
         vm.consumeStepColor.onChangeAndDoNow {
             updateStepCssClass(it!!, this)
         }
     }
 
-    val verbalizeStep = Rectangle(STEP_WIDTH, STEP_HEIGHT).apply {
+    private val verbalizeStep = Rectangle(STEP_WIDTH, STEP_HEIGHT).apply {
         addClass("chunking-wizard__step")
         vm.verbalizeStepColor.onChangeAndDoNow {
             updateStepCssClass(it!!, this)
         }
     }
 
-    val chunkStep = Rectangle(STEP_WIDTH, STEP_HEIGHT).apply {
+    private val chunkStep = Rectangle(STEP_WIDTH, STEP_HEIGHT).apply {
         addClass("chunking-wizard__step")
         vm.chunkStepColor.onChangeAndDoNow {
             updateStepCssClass(it!!, this)
         }
+    }
+
+    private val breadCrumb = BreadCrumb().apply {
+        titleProperty.bind(vm.titleProperty)
+        iconProperty.set(FontIcon(MaterialDesign.MDI_VIEW_CAROUSEL))
     }
 
     private fun updateStepCssClass(cssClass: String, node: Node) {
@@ -66,6 +79,7 @@ class ChunkingWizard : Wizard() {
     }
 
     override fun onDock() {
+        navigator.dock(this, breadCrumb)
         tryImportStylesheet(resources["/css/chunking-wizard.css"])
         pages.clear()
         add<Consume>()

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/chunking/Verbalize.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/chunking/Verbalize.kt
@@ -18,12 +18,12 @@
  */
 package org.wycliffeassociates.otter.jvm.workbookapp.ui.screens.chunking
 
+import javafx.beans.binding.Bindings
 import javafx.scene.shape.Circle
 import org.kordamp.ikonli.javafx.FontIcon
 import org.kordamp.ikonli.materialdesign.MaterialDesign
 import org.slf4j.LoggerFactory
 import org.wycliffeassociates.otter.jvm.controls.styles.tryImportStylesheet
-import org.wycliffeassociates.otter.jvm.utils.onChangeAndDoNow
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.viewmodel.ChunkingViewModel
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.viewmodel.ChunkingWizardPage
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.viewmodel.VerbalizeViewModel
@@ -62,14 +62,17 @@ class Verbalize : View() {
             button {
                 styleClass.addAll("btn", "btn--primary", "verbalize__btn--secondary")
                 visibleProperty().bind(vm.hasContentProperty)
-                vm.isPlayingProperty.onChangeAndDoNow {
-                    it?.let {
-                        when(it) {
-                            true -> graphic = pauseIcon
-                            false -> graphic = playIcon
-                        }
-                    }
-                }
+                graphicProperty().bind(
+                    Bindings.createObjectBinding(
+                        {
+                            when(vm.isPlayingProperty.value) {
+                                true -> pauseIcon
+                                false -> playIcon
+                            }
+                        },
+                        vm.isPlayingProperty
+                    )
+                )
                 action { vm.playToggle() }
             }
             stackpane {
@@ -77,15 +80,17 @@ class Verbalize : View() {
                 add(arc)
                 button {
                     styleClass.addAll("btn", "btn--cta", "verbalize__btn--primary")
-                    vm.recordingProperty.onChangeAndDoNow {
-                        it?.let {
-                            graphic = if (it) {
-                                stopIcon
-                            } else {
-                                recordIcon
-                            }
-                        }
-                    }
+                    graphicProperty().bind(
+                        Bindings.createObjectBinding(
+                            {
+                                when(vm.recordingProperty.value) {
+                                    true -> stopIcon
+                                    false -> recordIcon
+                                }
+                            },
+                            vm.recordingProperty
+                        )
+                    )
                     action {
                         arc.radiusProperty().bind(vm.arcLengthProperty)
                         vm.toggle()

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ChunkingViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ChunkingViewModel.kt
@@ -215,6 +215,7 @@ class ChunkingViewModel() : ViewModel(), IMarkerViewModel {
         consumeImageCleanup()
         chunkImageCleanup()
         compositeDisposable.clear()
+        stopAnimationTimer()
         disposeables.forEach { it.dispose() }
     }
 


### PR DESCRIPTION
Cleans the state and releases memory by using scopes which can deregister when the user leaves the chunking area.

Updates tornadofx to use a fix of the Wizard which does not add the wizard to the onCloseRequest of the stage (leaks memory)

Adds a breadcrumb for the chunking wizard.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/orature/654)
<!-- Reviewable:end -->
