### PR TITLE
Fix memory leaks on recording page

### DIFF
--- a/assets/src/main/kotlin/org/wycliffeassociates/otter/assets/initialization/InitializeRecorder.kt
+++ b/assets/src/main/kotlin/org/wycliffeassociates/otter/assets/initialization/InitializeRecorder.kt
@@ -39,7 +39,7 @@ class InitializeRecorder @Inject constructor(
 ) : Installable {
 
     override val name = "RECORDER"
-    override val version = 25
+    override val version = 26
 
     val log = LoggerFactory.getLogger(InitializeRecorder::class.java)
 

--- a/jvm/markerapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/markerapp/app/view/MarkerView.kt
+++ b/jvm/markerapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/markerapp/app/view/MarkerView.kt
@@ -62,7 +62,6 @@ class MarkerView : PluginEntrypoint() {
         subscribe<PluginCloseRequestEvent> {
             unsubscribe()
             viewModel.saveAndQuit()
-            unsubscribe()
         }
     }
 

--- a/jvm/recorderapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/recorder/app/view/ControlFragment.kt
+++ b/jvm/recorderapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/recorder/app/view/ControlFragment.kt
@@ -25,6 +25,7 @@ import javafx.scene.layout.Priority
 import org.kordamp.ikonli.javafx.FontIcon
 import org.wycliffeassociates.otter.jvm.controls.Shortcut
 import org.wycliffeassociates.otter.jvm.recorder.app.viewmodel.RecorderViewModel
+import org.wycliffeassociates.otter.jvm.workbookplugin.plugin.PluginCloseRequestEvent
 import tornadofx.*
 
 class ControlFragment : Fragment() {
@@ -102,7 +103,7 @@ class ControlFragment : Fragment() {
             visibleProperty().bind(vm.canSaveProperty)
             managedProperty().bind(vm.recordingProperty.or(vm.hasWrittenProperty))
             setOnAction {
-                vm.saveAndQuit()
+                fire(PluginCloseRequestEvent)
             }
             shortcut(Shortcut.GO_BACK.value)
         }
@@ -113,7 +114,7 @@ class ControlFragment : Fragment() {
             visibleProperty().bind(vm.recordingProperty.not().and(vm.hasWrittenProperty.not()))
             managedProperty().bind(visibleProperty())
             setOnAction {
-                vm.saveAndQuit()
+                fire(PluginCloseRequestEvent)
             }
             shortcut(Shortcut.GO_BACK.value)
         }

--- a/jvm/recorderapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/recorder/app/view/RecorderView.kt
+++ b/jvm/recorderapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/recorder/app/view/RecorderView.kt
@@ -32,6 +32,7 @@ class RecorderView : PluginEntrypoint() {
 
     private var viewInflated = false
 
+    private lateinit var sourceAudioFragment: SourceAudioFragment
     private val waveform = RecordingVisualizerFragment()
 
     private val spacer = region().apply {
@@ -47,7 +48,9 @@ class RecorderView : PluginEntrypoint() {
         add<InfoFragment>()
         add(spacer)
         add(waveform)
-        add<SourceAudioFragment>()
+        sourceAudioFragment = find<SourceAudioFragment>()
+        add(sourceAudioFragment)
+
         add<ControlFragment>()
     }
 
@@ -58,6 +61,7 @@ class RecorderView : PluginEntrypoint() {
 
     override fun onUndock() {
         super.onUndock()
+        sourceAudioFragment.cleanup()
         logger.info("Undocking RecorderView")
     }
 
@@ -75,6 +79,7 @@ class RecorderView : PluginEntrypoint() {
         }
 
         subscribe<PluginCloseRequestEvent> {
+            unsubscribe()
             recorderViewModel.saveAndQuit()
         }
     }

--- a/jvm/recorderapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/recorder/app/view/SourceAudioFragment.kt
+++ b/jvm/recorderapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/recorder/app/view/SourceAudioFragment.kt
@@ -32,7 +32,6 @@ import org.wycliffeassociates.otter.jvm.device.audio.AudioConnectionFactory
 class SourceAudioFragment : Fragment() {
 
     override val root = initializeSourceContent()
-
     private fun initializeSourceContent(): SourceContent {
 
         var sourceText: String? = null
@@ -127,6 +126,11 @@ class SourceAudioFragment : Fragment() {
                 }
             }
         }
+    }
+
+    fun cleanup() {
+        root.sourceAudioPlayerProperty.set(null)
+        root.targetAudioPlayerProperty.set(null)
     }
 
     private fun initializeAudioPlayer(file: File, start: Int? = null, end: Int? = null): IAudioPlayer? {


### PR DESCRIPTION
AudioPlayerController is not released from the SourceContentFragment, causing a leak when the RecorderView returns.

Also modified exiting to always use the events so the unsubscribe is properly called.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/orature/657)
<!-- Reviewable:end -->
