### PR TITLE
Import sources before projects - initializer

### DIFF
--- a/assets/src/main/kotlin/org/wycliffeassociates/otter/assets/initialization/InitializeApp.kt
+++ b/assets/src/main/kotlin/org/wycliffeassociates/otter/assets/initialization/InitializeApp.kt
@@ -24,6 +24,7 @@ import org.slf4j.LoggerFactory
 import javax.inject.Inject
 
 class InitializeApp @Inject constructor(
+    private val initializeSources: InitializeSources,
     private val initializeLanguages: InitializeLanguages,
     private val initializeUlb: InitializeUlb,
     private val initializeArtwork: InitializeArtwork,
@@ -42,6 +43,7 @@ class InitializeApp @Inject constructor(
             .fromPublisher<Double> { progress ->
                 val initializers = listOf(
                     initializeLanguages,
+                    initializeSources,
                     initializeUlb,
                     initializeArtwork,
                     initializeRecorder,

--- a/assets/src/main/kotlin/org/wycliffeassociates/otter/assets/initialization/InitializeProjects.kt
+++ b/assets/src/main/kotlin/org/wycliffeassociates/otter/assets/initialization/InitializeProjects.kt
@@ -46,7 +46,7 @@ class InitializeProjects @Inject constructor(
     private val rcImporter: ImportResourceContainer
 ) : Installable {
     override val name = "PROJECTS"
-    override val version = 1
+    override val version = 2
 
     private val log = LoggerFactory.getLogger(InitializeProjects::class.java)
 

--- a/assets/src/main/kotlin/org/wycliffeassociates/otter/assets/initialization/InitializeProjects.kt
+++ b/assets/src/main/kotlin/org/wycliffeassociates/otter/assets/initialization/InitializeProjects.kt
@@ -45,7 +45,7 @@ class InitializeProjects @Inject constructor(
     private val rcImporter: ImportResourceContainer
 ) : Installable {
     override val name = "PROJECTS"
-    override val version = 2
+    override val version = 1
 
     private val log = LoggerFactory.getLogger(InitializeProjects::class.java)
 

--- a/assets/src/main/kotlin/org/wycliffeassociates/otter/assets/initialization/InitializeProjects.kt
+++ b/assets/src/main/kotlin/org/wycliffeassociates/otter/assets/initialization/InitializeProjects.kt
@@ -21,6 +21,7 @@ package org.wycliffeassociates.otter.assets.initialization
 
 import io.reactivex.Completable
 import org.slf4j.LoggerFactory
+import org.wycliffeassociates.otter.common.data.OratureFileFormat
 import org.wycliffeassociates.otter.common.data.primitives.ResourceMetadata
 import org.wycliffeassociates.otter.common.data.workbook.Workbook
 import org.wycliffeassociates.otter.common.domain.resourcecontainer.ImportResourceContainer
@@ -65,6 +66,7 @@ class InitializeProjects @Inject constructor(
 
             if (fetchProjects().isEmpty()) {
                 log.info("Importing projects...")
+                importSources(directoryProvider.internalSourceRCDirectory)
 
                 val dir = directoryProvider.getUserDataDirectory("/")
                 importProjects(dir)
@@ -163,6 +165,17 @@ class InitializeProjects @Inject constructor(
                 // Delete empty dir
                 take.path.parentFile.delete()
             }
+    }
+
+    private fun importSources(dir: File) {
+        if (dir.isFile || !dir.exists()) return
+
+        dir.walk().filter { it.isFile && it.name != EN_ULB_FILENAME }.forEach {
+            // Find resource containers to import
+            if (it.extension in OratureFileFormat.extensionList) {
+                importProject(it)
+            }
+        }
     }
 
     private fun importProjects(dir: File) {

--- a/assets/src/main/kotlin/org/wycliffeassociates/otter/assets/initialization/InitializeProjects.kt
+++ b/assets/src/main/kotlin/org/wycliffeassociates/otter/assets/initialization/InitializeProjects.kt
@@ -21,7 +21,6 @@ package org.wycliffeassociates.otter.assets.initialization
 
 import io.reactivex.Completable
 import org.slf4j.LoggerFactory
-import org.wycliffeassociates.otter.common.data.OratureFileFormat
 import org.wycliffeassociates.otter.common.data.primitives.ResourceMetadata
 import org.wycliffeassociates.otter.common.data.workbook.Workbook
 import org.wycliffeassociates.otter.common.domain.resourcecontainer.ImportResourceContainer
@@ -63,9 +62,6 @@ class InitializeProjects @Inject constructor(
             } else {
                 log.info("$name up to date with version: $version")
             }
-
-            log.info("Importing sources...")
-            importSources(directoryProvider.internalSourceRCDirectory)
 
             if (fetchProjects().isEmpty()) {
                 log.info("Importing projects...")
@@ -166,29 +162,6 @@ class InitializeProjects @Inject constructor(
 
                 // Delete empty dir
                 take.path.parentFile.delete()
-            }
-    }
-
-    private fun importSources(dir: File) {
-        if (dir.isFile || !dir.exists()) return
-        val existingPaths = fetchSourcePaths()
-
-        dir.walk().filter {
-            it.isFile && it !in existingPaths
-        }.forEach {
-            // Find resource containers to import
-            if (it.extension in OratureFileFormat.extensionList) {
-                importProject(it)
-            }
-        }
-    }
-
-    private fun fetchSourcePaths(): List<File> {
-        return resourceMetadataRepo
-            .getAllSources()
-            .blockingGet()
-            .map {
-                it.path
             }
     }
 

--- a/assets/src/main/kotlin/org/wycliffeassociates/otter/assets/initialization/InitializeSources.kt
+++ b/assets/src/main/kotlin/org/wycliffeassociates/otter/assets/initialization/InitializeSources.kt
@@ -1,0 +1,75 @@
+package org.wycliffeassociates.otter.assets.initialization
+
+import io.reactivex.Completable
+import org.slf4j.LoggerFactory
+import org.wycliffeassociates.otter.common.data.OratureFileFormat
+import org.wycliffeassociates.otter.common.domain.resourcecontainer.ImportResourceContainer
+import org.wycliffeassociates.otter.common.persistence.IDirectoryProvider
+import org.wycliffeassociates.otter.common.persistence.config.Installable
+import org.wycliffeassociates.otter.common.persistence.repositories.IInstalledEntityRepository
+import org.wycliffeassociates.otter.common.persistence.repositories.IResourceMetadataRepository
+import java.io.File
+import javax.inject.Inject
+
+class InitializeSources @Inject constructor(
+    private val directoryProvider: IDirectoryProvider,
+    private val resourceMetadataRepo: IResourceMetadataRepository,
+    private val installedEntityRepo: IInstalledEntityRepository,
+    private val rcImporter: ImportResourceContainer
+): Installable {
+
+    override val name = "SOURCES"
+    override val version = 1
+
+    private val logger = LoggerFactory.getLogger(javaClass)
+
+    override fun exec(): Completable {
+        return Completable
+            .fromAction {
+                val installedVersion = installedEntityRepo.getInstalledVersion(this)
+                if (installedVersion != version) {
+                    logger.info("Initializing sources...")
+
+                    importSources(directoryProvider.internalSourceRCDirectory)
+
+                    installedEntityRepo.install(this)
+                    logger.info("$name version: $version installed!")
+                } else {
+                    logger.info("$name up to date with version: $version")
+                }
+            }
+    }
+
+    private fun importSources(dir: File) {
+        if (dir.isFile || !dir.exists()) return
+        val existingPaths = fetchSourcePaths()
+
+        dir.walk().filter {
+            it.isFile && it !in existingPaths
+        }.forEach {
+            // Find resource containers to import
+            if (it.extension in OratureFileFormat.extensionList) {
+                importFile(it)
+            }
+        }
+    }
+
+    private fun fetchSourcePaths(): List<File> {
+        return resourceMetadataRepo
+            .getAllSources()
+            .blockingGet()
+            .map {
+                it.path
+            }
+    }
+
+    private fun importFile(file: File) {
+        rcImporter.import(file).toObservable()
+            .doOnError { e ->
+                logger.error("Error importing $file.", e)
+            }
+            .blockingSubscribe {
+                logger.info("${file.name} imported!")
+            }
+    }
+}

--- a/assets/src/main/kotlin/org/wycliffeassociates/otter/assets/initialization/InitializeSources.kt
+++ b/assets/src/main/kotlin/org/wycliffeassociates/otter/assets/initialization/InitializeSources.kt
@@ -30,7 +30,7 @@ class InitializeSources @Inject constructor(
                 if (installedVersion != version) {
                     logger.info("Initializing sources...")
 
-                    importSources(directoryProvider.internalSourceRCDirectory)
+                    migrate()
 
                     installedEntityRepo.install(this)
                     logger.info("$name version: $version installed!")
@@ -40,8 +40,19 @@ class InitializeSources @Inject constructor(
             }
     }
 
+    private fun migrate() {
+        `migrate to version 1`()
+    }
+
+    private fun `migrate to version 1`() {
+        importSources(directoryProvider.internalSourceRCDirectory)
+    }
+
     private fun importSources(dir: File) {
-        if (dir.isFile || !dir.exists()) return
+        if (dir.isFile || !dir.exists()) {
+            return
+        }
+
         val existingPaths = fetchSourcePaths()
 
         dir.walk().filter {

--- a/assets/src/main/kotlin/org/wycliffeassociates/otter/assets/initialization/InitializeUlb.kt
+++ b/assets/src/main/kotlin/org/wycliffeassociates/otter/assets/initialization/InitializeUlb.kt
@@ -78,8 +78,16 @@ class InitializeUlb @Inject constructor(
     }
 
     private fun isAlreadyImported(): Boolean {
-        return rcImporter.isAlreadyImported(
-            File(javaClass.classLoader.getResource(EN_ULB_PATH).file)
-        )
+        val enUlbStream = javaClass.classLoader.getResourceAsStream(EN_ULB_PATH)!!
+        val tempFile = kotlin.io.path.createTempFile().toFile()
+            .also(File::deleteOnExit)
+
+        enUlbStream.use { input ->
+            tempFile.outputStream().use { output ->
+                input.transferTo(output)
+            }
+        }
+
+        return rcImporter.isAlreadyImported(tempFile)
     }
 }

--- a/assets/src/main/kotlin/org/wycliffeassociates/otter/assets/initialization/InitializeUlb.kt
+++ b/assets/src/main/kotlin/org/wycliffeassociates/otter/assets/initialization/InitializeUlb.kt
@@ -23,6 +23,7 @@ import org.slf4j.LoggerFactory
 import org.wycliffeassociates.otter.common.domain.resourcecontainer.ImportException
 import org.wycliffeassociates.otter.common.domain.resourcecontainer.ImportResourceContainer
 import org.wycliffeassociates.otter.common.domain.resourcecontainer.ImportResult
+import org.wycliffeassociates.otter.common.persistence.IDirectoryProvider
 import org.wycliffeassociates.otter.common.persistence.config.Installable
 import org.wycliffeassociates.otter.common.persistence.repositories.IInstalledEntityRepository
 import java.io.File
@@ -32,6 +33,7 @@ const val EN_ULB_FILENAME = "en_ulb"
 private const val EN_ULB_PATH = "content/$EN_ULB_FILENAME.zip"
 
 class InitializeUlb @Inject constructor(
+    private val directoryProvider: IDirectoryProvider,
     private val installedEntityRepo: IInstalledEntityRepository,
     private val rcImporter: ImportResourceContainer
 ) : Installable {
@@ -79,7 +81,7 @@ class InitializeUlb @Inject constructor(
 
     private fun isAlreadyImported(): Boolean {
         val enUlbStream = javaClass.classLoader.getResourceAsStream(EN_ULB_PATH)!!
-        val tempFile = kotlin.io.path.createTempFile().toFile()
+        val tempFile = directoryProvider.createTempFile("en_ulb-test", ".zip")
             .also(File::deleteOnExit)
 
         enUlbStream.use { input ->

--- a/assets/src/main/kotlin/org/wycliffeassociates/otter/assets/initialization/InitializeUlb.kt
+++ b/assets/src/main/kotlin/org/wycliffeassociates/otter/assets/initialization/InitializeUlb.kt
@@ -27,7 +27,7 @@ import org.wycliffeassociates.otter.common.persistence.config.Installable
 import org.wycliffeassociates.otter.common.persistence.repositories.IInstalledEntityRepository
 import javax.inject.Inject
 
-private const val EN_ULB_FILENAME = "en_ulb"
+const val EN_ULB_FILENAME = "en_ulb"
 private const val EN_ULB_PATH = "content/$EN_ULB_FILENAME.zip"
 
 class InitializeUlb @Inject constructor(

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/ImportResourceContainer.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/ImportResourceContainer.kt
@@ -133,7 +133,7 @@ class ImportResourceContainer @Inject constructor(
         }
     }
 
-    private fun isAlreadyImported(file: File): Boolean {
+    fun isAlreadyImported(file: File): Boolean {
         val rc = ResourceContainer.load(file, true)
         val language = languageRepository.getBySlug(rc.manifest.dublinCore.language.identifier).blockingGet()
         val resourceMetadata = rc.manifest.dublinCore.mapToMetadata(file, language)

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/persistence/IDirectoryProvider.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/persistence/IDirectoryProvider.kt
@@ -98,6 +98,7 @@ interface IDirectoryProvider {
 
     val databaseDirectory: File
     val resourceContainerDirectory: File
+    val internalSourceRCDirectory: File
     val userProfileImageDirectory: File
     val userProfileAudioDirectory: File
     val audioPluginDirectory: File

--- a/jvm/workbookapp/build.gradle
+++ b/jvm/workbookapp/build.gradle
@@ -152,6 +152,7 @@ dependencies {
     testImplementation "org.testfx:openjfx-monocle:$testFxMonocleVer"
     integrationTestCompile group: 'junit', name: 'junit', version: "$junitVer"
     integrationTestCompile "org.mockito:mockito-core:$mockitoVer"
+    integrationTestImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:$mockitoKotlinVer"
     integrationTestImplementation sourceSets.main.compileClasspath
     integrationTestImplementation sourceSets.main.output
 

--- a/jvm/workbookapp/src/integration-test/kotlin/integrationtest/di/TestPersistenceComponent.kt
+++ b/jvm/workbookapp/src/integration-test/kotlin/integrationtest/di/TestPersistenceComponent.kt
@@ -20,6 +20,7 @@ package integrationtest.di
 
 import dagger.Component
 import integrationtest.initialization.TestInitializeProjects
+import integrationtest.initialization.TestInitializeSources
 import integrationtest.initialization.TestInitializeUlb
 import integrationtest.projects.TestProjectCreate
 import integrationtest.projects.TestProjectExport
@@ -46,6 +47,7 @@ import javax.inject.Singleton
 )
 @Singleton
 interface TestPersistenceComponent : AppDependencyGraph {
+    fun inject(test: TestInitializeSources)
     fun inject(test: TestInitializeUlb)
     fun inject(test: TestInitializeProjects)
     fun inject(test: TestProjectCreate)

--- a/jvm/workbookapp/src/integration-test/kotlin/integrationtest/initialization/TestInitializeProjects.kt
+++ b/jvm/workbookapp/src/integration-test/kotlin/integrationtest/initialization/TestInitializeProjects.kt
@@ -32,6 +32,7 @@ import org.wycliffeassociates.otter.common.data.primitives.ContentType
 import org.wycliffeassociates.otter.common.data.primitives.Language
 import org.wycliffeassociates.otter.common.data.primitives.ResourceMetadata
 import org.wycliffeassociates.otter.common.persistence.IDirectoryProvider
+import org.wycliffeassociates.otter.common.persistence.repositories.IResourceMetadataRepository
 import java.io.File
 import java.time.LocalDate
 import javax.inject.Inject
@@ -44,6 +45,9 @@ class TestInitializeProjects {
 
     @Inject
     lateinit var directoryProvider: IDirectoryProvider
+
+    @Inject
+    lateinit var resourceMetadataRepository: IResourceMetadataRepository
 
     @Inject
     lateinit var env: DatabaseEnvironment
@@ -110,6 +114,39 @@ class TestInitializeProjects {
         )
     }
 
+    @Test
+    fun testInitializeProjectsWithSources() {
+        prepareInitialProject()
+        prepareSource()
+
+        Assert.assertEquals(
+            0, resourceMetadataRepository.getAllSources().blockingGet().size
+        )
+
+        val testSub = TestObserver<Completable>()
+        val init = initProjectsProvider.get()
+        init
+            .exec()
+            .subscribe(testSub)
+
+        testSub.assertComplete()
+        testSub.assertNoErrors()
+
+        val sources = resourceMetadataRepository.getAllSources().blockingGet()
+        Assert.assertEquals(2, sources.size)
+
+        env.assertRowCounts(
+            RowCount(
+                contents = mapOf(
+                    ContentType.META to 1211,
+                    ContentType.TEXT to 31509
+                ),
+                collections = 1280,
+                links = 0
+            )
+        )
+    }
+
     private fun prepareInitialProject() {
         val targetDir = directoryProvider.getProjectDirectory(
             sourceMetadata,
@@ -117,5 +154,12 @@ class TestInitializeProjects {
             project
         )
         env.unzipProject("en-x-demo1-ulb-rev.zip", targetDir)
+    }
+
+    private fun prepareSource() {
+        val targetSource = directoryProvider.internalSourceRCDirectory.resolve("hi_ulb.zip")
+        val sourceToCopy = File(javaClass.classLoader.getResource("resource-containers/hi_ulb.zip").file)
+
+        sourceToCopy.copyTo(targetSource, overwrite = true)
     }
 }

--- a/jvm/workbookapp/src/integration-test/kotlin/integrationtest/initialization/TestInitializeProjects.kt
+++ b/jvm/workbookapp/src/integration-test/kotlin/integrationtest/initialization/TestInitializeProjects.kt
@@ -114,39 +114,6 @@ class TestInitializeProjects {
         )
     }
 
-    @Test
-    fun testInitializeProjectsWithSources() {
-        prepareInitialProject()
-        prepareSource()
-
-        Assert.assertEquals(
-            0, resourceMetadataRepository.getAllSources().blockingGet().size
-        )
-
-        val testSub = TestObserver<Completable>()
-        val init = initProjectsProvider.get()
-        init
-            .exec()
-            .subscribe(testSub)
-
-        testSub.assertComplete()
-        testSub.assertNoErrors()
-
-        val sources = resourceMetadataRepository.getAllSources().blockingGet()
-        Assert.assertEquals(2, sources.size)
-
-        env.assertRowCounts(
-            RowCount(
-                contents = mapOf(
-                    ContentType.META to 1211,
-                    ContentType.TEXT to 31509
-                ),
-                collections = 1280,
-                links = 0
-            )
-        )
-    }
-
     private fun prepareInitialProject() {
         val targetDir = directoryProvider.getProjectDirectory(
             sourceMetadata,
@@ -154,12 +121,5 @@ class TestInitializeProjects {
             project
         )
         env.unzipProject("en-x-demo1-ulb-rev.zip", targetDir)
-    }
-
-    private fun prepareSource() {
-        val targetSource = directoryProvider.internalSourceRCDirectory.resolve("hi_ulb.zip")
-        val sourceToCopy = File(javaClass.classLoader.getResource("resource-containers/hi_ulb.zip").file)
-
-        sourceToCopy.copyTo(targetSource, overwrite = true)
     }
 }

--- a/jvm/workbookapp/src/integration-test/kotlin/integrationtest/initialization/TestInitializeSources.kt
+++ b/jvm/workbookapp/src/integration-test/kotlin/integrationtest/initialization/TestInitializeSources.kt
@@ -1,0 +1,69 @@
+package integrationtest.initialization
+
+import integrationtest.di.DaggerTestPersistenceComponent
+import io.reactivex.Completable
+import io.reactivex.observers.TestObserver
+import org.junit.Assert
+import org.junit.Test
+import org.wycliffeassociates.otter.assets.initialization.InitializeSources
+import org.wycliffeassociates.otter.common.domain.languages.ImportLanguages
+import org.wycliffeassociates.otter.common.persistence.IDirectoryProvider
+import org.wycliffeassociates.otter.common.persistence.repositories.IResourceMetadataRepository
+import org.wycliffeassociates.otter.jvm.workbookapp.persistence.database.AppDatabase
+import java.io.File
+import javax.inject.Inject
+import javax.inject.Provider
+
+class TestInitializeSources {
+    @Inject
+    lateinit var database: AppDatabase
+
+    @Inject
+    lateinit var directoryProvider: IDirectoryProvider
+
+    @Inject
+    lateinit var initSourcesProvider: Provider<InitializeSources>
+
+    @Inject
+    lateinit var importLanguages: Provider<ImportLanguages>
+
+    @Inject
+    lateinit var resourceMetadataRepository: IResourceMetadataRepository
+
+    init {
+        DaggerTestPersistenceComponent.create().inject(this)
+        val langNames = ClassLoader.getSystemResourceAsStream("content/langnames.json")!!
+        importLanguages.get().import(langNames).blockingGet()
+    }
+
+    @Test
+    fun testInitializeSources() {
+        prepareSource()
+
+        Assert.assertEquals(
+            0, resourceMetadataRepository.getAllSources().blockingGet().size
+        )
+
+        val testSub = TestObserver<Completable>()
+        val init = initSourcesProvider.get()
+
+        init
+            .exec()
+            .subscribe(testSub)
+
+        testSub.assertComplete()
+        testSub.assertNoErrors()
+
+        Assert.assertEquals(init.version, database.installedEntityDao.fetchVersion(init))
+        Assert.assertEquals(
+            1, resourceMetadataRepository.getAllSources().blockingGet().size
+        )
+    }
+
+    private fun prepareSource() {
+        val sourceToCopy = File(javaClass.classLoader.getResource("resource-containers/hi_ulb.zip").file)
+        val targetSource = directoryProvider.internalSourceRCDirectory.resolve(sourceToCopy.name)
+
+        sourceToCopy.copyTo(targetSource, overwrite = true)
+    }
+}

--- a/jvm/workbookapp/src/integration-test/kotlin/integrationtest/initialization/TestInitializeUlb.kt
+++ b/jvm/workbookapp/src/integration-test/kotlin/integrationtest/initialization/TestInitializeUlb.kt
@@ -18,15 +18,24 @@
  */
 package integrationtest.initialization
 
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.never
+import com.nhaarman.mockitokotlin2.verify
 import integrationtest.di.DaggerTestPersistenceComponent
 import io.reactivex.Completable
 import io.reactivex.observers.TestObserver
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
+import org.mockito.Mockito
 import org.wycliffeassociates.otter.assets.initialization.InitializeUlb
 import org.wycliffeassociates.otter.common.domain.languages.ImportLanguages
+import org.wycliffeassociates.otter.common.domain.resourcecontainer.ImportResourceContainer
+import org.wycliffeassociates.otter.common.persistence.repositories.IInstalledEntityRepository
 import org.wycliffeassociates.otter.jvm.workbookapp.persistence.database.AppDatabase
+import java.io.File
+import java.io.InputStream
 import javax.inject.Inject
 import javax.inject.Provider
 
@@ -40,6 +49,13 @@ class TestInitializeUlb {
 
     @Inject
     lateinit var importLanguages: Provider<ImportLanguages>
+
+    @Inject
+    lateinit var importRCProvider: Provider<ImportResourceContainer>
+
+    @Inject
+    lateinit var installedEntityRepo: IInstalledEntityRepository
+
 
     @Before
     fun setup() {
@@ -60,5 +76,28 @@ class TestInitializeUlb {
         testSub.assertNoErrors()
 
         Assert.assertEquals(init.version, database.installedEntityDao.fetchVersion(init))
+    }
+
+    @Test
+    fun `test en_ulb import skipped when already imported`() {
+        val importer = importRCProvider.get()
+        val importerSpy = Mockito.spy(importer)
+        doReturn(true).`when`(importerSpy).isAlreadyImported(any())
+
+        val init = InitializeUlb(
+            installedEntityRepo,
+            importerSpy
+        )
+        val testSub = TestObserver<Completable>()
+
+        init.exec()
+            .subscribe(testSub)
+
+        testSub.assertComplete()
+        testSub.assertNoErrors()
+
+        verify(importerSpy).isAlreadyImported(any())
+        verify(importerSpy, never()).import(any<File>())
+        verify(importerSpy, never()).import(any<String>(), any<InputStream>())
     }
 }

--- a/jvm/workbookapp/src/integration-test/kotlin/integrationtest/initialization/TestInitializeUlb.kt
+++ b/jvm/workbookapp/src/integration-test/kotlin/integrationtest/initialization/TestInitializeUlb.kt
@@ -32,6 +32,7 @@ import org.mockito.Mockito
 import org.wycliffeassociates.otter.assets.initialization.InitializeUlb
 import org.wycliffeassociates.otter.common.domain.languages.ImportLanguages
 import org.wycliffeassociates.otter.common.domain.resourcecontainer.ImportResourceContainer
+import org.wycliffeassociates.otter.common.persistence.IDirectoryProvider
 import org.wycliffeassociates.otter.common.persistence.repositories.IInstalledEntityRepository
 import org.wycliffeassociates.otter.jvm.workbookapp.persistence.database.AppDatabase
 import java.io.File
@@ -43,6 +44,9 @@ class TestInitializeUlb {
 
     @Inject
     lateinit var database: AppDatabase
+
+    @Inject
+    lateinit var directoryProvider: IDirectoryProvider
 
     @Inject
     lateinit var initUlbProvider: Provider<InitializeUlb>
@@ -85,6 +89,7 @@ class TestInitializeUlb {
         doReturn(true).`when`(importerSpy).isAlreadyImported(any())
 
         val init = InitializeUlb(
+            directoryProvider,
             installedEntityRepo,
             importerSpy
         )

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/persistence/DirectoryProvider.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/persistence/DirectoryProvider.kt
@@ -156,24 +156,22 @@ class DirectoryProvider(
         val dublinCore = container.manifest.dublinCore
         container.close()
         val appendedPath = listOf(
-            "src",
             dublinCore.creator,
             "${dublinCore.language.identifier}_${dublinCore.identifier}",
             "v${dublinCore.version}"
         ).joinToString(pathSeparator)
-        val path = resourceContainerDirectory.resolve(appendedPath)
+        val path = internalSourceRCDirectory.resolve(appendedPath)
         path.mkdirs()
         return path
     }
 
     override fun getSourceContainerDirectory(metadata: ResourceMetadata): File {
         return listOf(
-            "src",
             metadata.creator,
             "${metadata.language.slug}_${metadata.identifier}",
             "v${metadata.version}"
         )
-            .fold(resourceContainerDirectory, File::resolve)
+            .fold(internalSourceRCDirectory, File::resolve)
             .apply { mkdirs() }
     }
 
@@ -215,6 +213,9 @@ class DirectoryProvider(
 
     override val resourceContainerDirectory: File
         get() = getAppDataDirectory("rc")
+
+    override val internalSourceRCDirectory: File
+        get() = resourceContainerDirectory.resolve("src")
 
     override val userProfileAudioDirectory: File
         get() = getAppDataDirectory("users${pathSeparator}audio")


### PR DESCRIPTION
To avoids missing sources import after database creation/migration, we try importing all the resource containers in the internal directory (rc/src) before importing the en_ulb and other resumable projects

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/orature/661)
<!-- Reviewable:end -->
