### PR TITLE
WeakListeners for Audio Players

### DIFF
--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/device/IAudioPlayer.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/device/IAudioPlayer.kt
@@ -25,7 +25,14 @@ interface IAudioPlayer {
     val frameStart: Int
     val frameEnd: Int
     fun addEventListener(listener: IAudioPlayerListener)
-    fun addEventListener(onEvent: (event: AudioPlayerEvent) -> Unit)
+    fun addEventListener(onEvent: (event: AudioPlayerEvent) -> Unit) {
+        addEventListener(WeakAudioListener(object : IAudioPlayerListener {
+            override fun onEvent(event: AudioPlayerEvent) {
+                onEvent(event)
+            }
+        }))
+    }
+
     fun load(file: File)
     fun loadSection(file: File, frameStart: Int, frameEnd: Int)
     fun getAudioReader(): AudioFileReader?

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/device/IAudioPlayerListener.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/device/IAudioPlayerListener.kt
@@ -18,6 +18,20 @@
  */
 package org.wycliffeassociates.otter.common.device
 
+import java.lang.ref.WeakReference
+
 interface IAudioPlayerListener {
     fun onEvent(event: AudioPlayerEvent)
+}
+
+
+class WeakAudioListener(listener: IAudioPlayerListener) : IAudioPlayerListener {
+    private val wref: WeakReference<IAudioPlayerListener>
+    init {
+        wref = WeakReference(listener)
+    }
+
+    override fun onEvent(event: AudioPlayerEvent) {
+        wref.get()?.onEvent(event)
+    }
 }


### PR DESCRIPTION
Uses weak listeners for audio players and for the AudioPlayerController animation timer.

This addresses some types of memory leaks with the AudioPlayerController.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/orature/669)
<!-- Reviewable:end -->
