### PR TITLE
Update plugins to support m1 macs

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,6 +1,6 @@
 ext {
     // Plugins
-    javafxPluginVer = '0.0.10'
+    javafxPluginVer = '0.0.13'
     jooqPluginVer = '4.0'
     install4jPluginVer = '9.0.2'
     nebulaLintPluginVer = '16.23.0' // Gradle Linter
@@ -22,7 +22,7 @@ ext {
     rxrelayVer = '2.1.0'
     jfoenixVer = '17-hotfix'
     kfoenixVer = "0.2.0"
-    sqliteJdbcVer = '3.28.0'
+    sqliteJdbcVer = '3.39.3.0'
     jooqVer = '3.12.4'
     franzXaverVer = '0.1' // SVG Loader
     franzXaverSvgVer = 'unspecified'

--- a/jvm/workbookapp/jooq.gradle
+++ b/jvm/workbookapp/jooq.gradle
@@ -32,7 +32,6 @@ task createDb {
     text.collect { it.trim() }.findAll { !it.isEmpty() && !it.startsWith("--") }.each {
         def sql = Sql.newInstance(sqliteConnect, "org.sqlite.JDBC")
         sql.execute(it)
-        sql.close()
     }
 }
 


### PR DESCRIPTION
The sqlite driver and javafx plugin both need to be updated to allow for building on m1 macs.

Additionally, the close() call in jooq.gradle causes errors, and will not allow the gradle project to sync.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/orature/671)
<!-- Reviewable:end -->
