### PR TITLE
call sql.close() when not on macos

### DIFF
--- a/jvm/workbookapp/jooq.gradle
+++ b/jvm/workbookapp/jooq.gradle
@@ -32,6 +32,9 @@ task createDb {
     text.collect { it.trim() }.findAll { !it.isEmpty() && !it.startsWith("--") }.each {
         def sql = Sql.newInstance(sqliteConnect, "org.sqlite.JDBC")
         sql.execute(it)
+        if(!(System.getProperty("os.name")).toUpperCase().contains("MAC")) {
+            sql.close()
+        }
     }
 }
 


### PR DESCRIPTION
M1 macs cannot execute this line, but are not bothered by deleting this file if it is open.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/orature/673)
<!-- Reviewable:end -->
