### PR TITLE
Fix chunk source text changed after restart

### DIFF
--- a/jvm/device/src/main/kotlin/org/wycliffeassociates/otter/jvm/device/audio/AudioBufferPlayer.kt
+++ b/jvm/device/src/main/kotlin/org/wycliffeassociates/otter/jvm/device/audio/AudioBufferPlayer.kt
@@ -91,7 +91,6 @@ class AudioBufferPlayer(
         reader?.let { close() }
         begin = frameStart
         end = frameEnd
-        logger.info("Loading mp3 file ${file.name} from start: $frameStart to end: $end")
         reader = AudioFile(file).reader(frameStart, frameEnd).let { _reader ->
             bytes = ByteArray(processor.inputBufferSize * 2)
             listeners.forEach { it.onEvent(AudioPlayerEvent.LOAD) }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/WorkbookDataStore.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/WorkbookDataStore.kt
@@ -243,18 +243,7 @@ class WorkbookDataStore : Component(), ScopedInstance {
     }
 
     private fun getChunkSourceText(): Maybe<String> {
-        chunk?.let { chunk ->
-            val accessor = ProjectFilesAccessor(
-                directoryProvider,
-                workbook.source.resourceMetadata,
-                workbook.target.resourceMetadata,
-                workbook.target
-            )
-            val verses = accessor.getChunkText(workbook.source.slug, chapter.sort, chunk.start, chunk.end)
-            val text = combineVerses(verses)
-            return Maybe.just(text)
-        }
-        return Maybe.just("")
+        return Maybe.just(chunk?.textItem?.text ?: "")
     }
 
     private fun combineVerses(verses: List<String>): String {


### PR DESCRIPTION
The chunk `end` is not stored in database and when we restart the app, it assumes end = start (default) and look for one verse instead of displaying the stored chunk text.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/orature/674)
<!-- Reviewable:end -->
