### PR TITLE
Correctly parse wav file headers

### DIFF
--- a/common/audio/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/RiffChunk.kt
+++ b/common/audio/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/RiffChunk.kt
@@ -20,6 +20,7 @@ package org.wycliffeassociates.otter.common.audio.wav
 
 import java.nio.ByteBuffer
 
+internal const val RIFF_HEADER_SIZE = 12
 internal const val CHUNK_HEADER_SIZE = 8
 internal const val CHUNK_LABEL_SIZE = 4
 internal const val DWORD_SIZE = 4

--- a/common/audio/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/WavFile.kt
+++ b/common/audio/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/WavFile.kt
@@ -143,6 +143,9 @@ class WavFile private constructor() : AudioFormatStrategy {
         metadata.writeMetadata(outputStream)
     }
 
+    /**
+     * Updates the wav header with the file size and audio size to the riff and data chunks respectively
+     */
     @Throws(IOException::class)
     internal fun finishWrite(totalAudioLength: Int) {
         header.totalAudioLength = totalAudioLength
@@ -157,8 +160,6 @@ class WavFile private constructor() : AudioFormatStrategy {
             it.write(header.generateHeaderArray())
         }
     }
-
-
 
     private fun parseMetadata() {
         val nonMetadataSize = totalAudioLength + (headerSize - CHUNK_HEADER_SIZE)
@@ -180,6 +181,9 @@ class WavFile private constructor() : AudioFormatStrategy {
 
     fun sampleIndex(sample: Int) = sample * frameSizeInBytes
 
+    /**
+     * Updates the wav file, writing out any changes made to the wav file metadata.
+     */
     override fun update() {
         // the use block will write nothing, but will call .close()
         // which will truncate the file at the end of the audio section,

--- a/common/audio/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/WavFileReader.kt
+++ b/common/audio/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/WavFileReader.kt
@@ -58,7 +58,9 @@ internal class WavFileReader(val wav: WavFile, val start: Int? = null, val end: 
     }
 
     fun computeBounds(wav: WavFile): Pair<Int, Int> {
-        if (wav.file.length() <= WAV_HEADER_SIZE) {
+        val headerSize = wav.headerSize
+
+        if (wav.file.length() <= headerSize) {
             logger.info("Wav file ${wav.file.name} is just a header or empty, size is ${wav.file.length()}")
             return Pair(0, 0)
         }
@@ -67,15 +69,16 @@ internal class WavFileReader(val wav: WavFile, val start: Int? = null, val end: 
         var begin = if (start != null) min(max(0, start), totalFrames) else 0
         var end = if (end != null) min(max(begin, end), totalFrames) else totalFrames
 
+
         // Convert from frames to array index
         begin *= wav.frameSizeInBytes
-        begin += WAV_HEADER_SIZE
+        begin += headerSize
         end *= wav.frameSizeInBytes
-        end += WAV_HEADER_SIZE
+        end += headerSize
 
         // Should be clamped between header size, computed beginning, and the file length
-        val clampedBegin = max(WAV_HEADER_SIZE, min(begin, max(wav.file.length().toInt(), WAV_HEADER_SIZE)))
-        val clampedEnd = max(clampedBegin, min(end, max(wav.file.length().toInt(), WAV_HEADER_SIZE)))
+        val clampedBegin = max(headerSize, min(begin, max(wav.file.length().toInt(), headerSize)))
+        val clampedEnd = max(clampedBegin, min(end, max(wav.file.length().toInt(), headerSize)))
 
         if (clampedBegin != begin || clampedEnd != end) {
             logger.error("Error in file ${wav.file.name}")

--- a/common/audio/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/WavHeader.kt
+++ b/common/audio/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/WavHeader.kt
@@ -1,0 +1,124 @@
+package org.wycliffeassociates.otter.common.audio.wav
+
+import java.io.File
+import java.io.FileInputStream
+import java.io.InputStream
+import java.lang.Exception
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+private data class Chunk(val label: String, val start: Int, val chunkSize: Int)
+
+enum class ParseResult {
+    VALID_NORMAL_WAV,
+    VALID_EXTENDED_HEADER_WAV,
+    INVALID
+}
+
+class WavHeader {
+
+    private var readHeadPosition = 0
+    private var dataChunkStart = 0
+    private var totalAudioSize = 0
+
+    private val chunks: MutableList<Chunk> = mutableListOf()
+
+    fun parse(file: File): ParseResult {
+        chunks.clear()
+        if (file.length() < 8) {
+            return ParseResult.INVALID
+        }
+        file.inputStream().use {
+            if (!validateRiff(it)) {
+                return ParseResult.INVALID
+            }
+            while (it.available() > 8) {
+                parseChunk(it)
+            }
+        }
+
+        val preDataChunk = mutableListOf<Chunk>()
+        for (chunk in chunks) {
+            if (chunk.label == "DATA") {
+                dataChunkStart = chunk.start
+                break
+            } else {
+                preDataChunk.add(chunk)
+            }
+        }
+
+        computeTotalAudioSize()
+
+        // The fmt chunk is required in all WAV files, WAVs with extensions will have additional pre-data chunks.
+        preDataChunk.removeAll { it.label == "fmt " }
+
+        if (!chunks.map { it.label }.containsAll(listOf("fmt ", "DATA"))) {
+            return ParseResult.INVALID
+        }
+
+        if (preDataChunk.size > 0) {
+            return ParseResult.VALID_EXTENDED_HEADER_WAV
+        }
+
+        return ParseResult.VALID_NORMAL_WAV
+    }
+
+    private fun computeTotalAudioSize() {
+        val data = chunks.find { it.label == "DATA" }
+        data?.let { data ->
+            totalAudioSize = data.chunkSize
+        }
+    }
+
+    private fun parseChunk(inputStream: FileInputStream) {
+        if (inputStream.available() < 8) {
+            return
+        }
+
+        val bytes = ByteArray(4)
+        inputStream.read(bytes)
+        var bb = ByteBuffer.wrap(bytes)
+        bb.order(ByteOrder.LITTLE_ENDIAN)
+        val label = bb.getText(4)
+
+        inputStream.read(bytes)
+        bb = ByteBuffer.wrap(bytes)
+        bb.order(ByteOrder.LITTLE_ENDIAN)
+        val size = bb.int
+
+        readHeadPosition += 8
+
+        val skip = wordAlign(size)
+        inputStream.skip(skip.toLong())
+        chunks.add(Chunk(label, readHeadPosition, size))
+
+        readHeadPosition += skip
+    }
+
+    private fun validateRiff(inputStream: FileInputStream): Boolean {
+        if (inputStream.available() < 12) {
+            return false
+        }
+
+        val bytes = ByteArray(4)
+        inputStream.read(bytes)
+        var bb = ByteBuffer.wrap(bytes)
+        bb.order(ByteOrder.LITTLE_ENDIAN)
+        val label = bb.getText(4)
+
+        inputStream.read(bytes)
+        bb = ByteBuffer.wrap(bytes)
+        bb.order(ByteOrder.LITTLE_ENDIAN)
+        val size = bb.int
+
+        inputStream.read(bytes)
+        bb = ByteBuffer.wrap(bytes)
+        bb.order(ByteOrder.LITTLE_ENDIAN)
+        val form = bb.getText(4)
+
+        chunks.add(Chunk("RIFF", 8, size))
+
+        readHeadPosition += 12
+        return label == "RIFF" && form == "WAVE"
+    }
+}

--- a/common/audio/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/WavHeader.kt
+++ b/common/audio/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/WavHeader.kt
@@ -144,6 +144,12 @@ class WavHeader {
      * label, and a 4 byte chunk size. This method will populate a complete list of all chunks and their corresponding
      * sizes contained within the audio file. While this class is concerned primarily with the header, this list will
      * contain all chunks, including metadata chunks.
+     *
+     * Note that the size of a chunk does not contain a pad byte. If the size is odd, the chunk should contain a pad byte
+     * at the end to word align the chunk as per the wav file spec:
+     * https://www.mmsp.ece.mcgill.ca/Documents/AudioFormats/WAVE/Docs/riffmci.pdf
+     *
+     * We accomplish this by calling the wordAlign function prior to seeking in the buffer.
      */
     private fun parseChunk(inputStream: FileInputStream) {
         if (inputStream.available() < CHUNK_HEADER_SIZE) {

--- a/common/audio/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/WavHeader.kt
+++ b/common/audio/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/WavHeader.kt
@@ -1,5 +1,8 @@
 package org.wycliffeassociates.otter.common.audio.wav
 
+import org.wycliffeassociates.otter.common.audio.DEFAULT_BITS_PER_SAMPLE
+import org.wycliffeassociates.otter.common.audio.DEFAULT_CHANNELS
+import org.wycliffeassociates.otter.common.audio.DEFAULT_SAMPLE_RATE
 import java.io.File
 import java.io.FileInputStream
 import java.nio.ByteBuffer
@@ -7,55 +10,65 @@ import java.nio.ByteOrder
 
 private data class Chunk(val label: String, val start: Int, val chunkSize: Int)
 
-enum class ParseResult {
+enum class WavHeaderParseResult {
     VALID_NORMAL_WAV,
     VALID_EXTENDED_HEADER_WAV,
-    INVALID
 }
+
+private const val RIFF = "RIFF"
+private const val WAVE = "WAVE"
+private const val FMT = "fmt "
+private const val DATA = "data"
+private const val PCM: Short = 1
+private const val DEFAULT_HEADER_SIZE = 44
+private const val BITS_IN_BYTE = 8
+
 
 class WavHeader {
 
     private var readHeadPosition = 0
-    private var dataChunkStart = 0
+    private var dataChunkStart = DEFAULT_HEADER_SIZE
 
     val totalHeaderSize: Int
         get() = dataChunkStart
 
     internal var totalDataLength = 0
-        private set
     internal var totalAudioLength = 0
-        private set
 
-    var channels = 0
+    var channels = DEFAULT_CHANNELS
         private set
-    var bitsPerSample = 0
+    var bitsPerSample = DEFAULT_BITS_PER_SAMPLE
         private set
-    var sampleRate = 0
+    var sampleRate = DEFAULT_SAMPLE_RATE
         private set
-    var byteRate = 0
+    var byteRate = sampleRate * channels * (bitsPerSample / BITS_IN_BYTE)
         private set
-    var blockAlign = 0
+    var blockAlign = channels * (bitsPerSample / BITS_IN_BYTE)
         private set
 
     private val chunks: MutableList<Chunk> = mutableListOf()
 
-    fun parse(file: File): ParseResult {
+    /**
+     * Reads the header of a wav file.
+     */
+    @Throws(InvalidWavFileException::class)
+    fun parse(file: File): WavHeaderParseResult {
         chunks.clear()
-        if (file.length() < 8) {
-            return ParseResult.INVALID
+        if (file.length() < CHUNK_HEADER_SIZE) {
+            throw InvalidWavFileException("File length is less than a chunk header.")
         }
         file.inputStream().use {
             if (!validateRiff(it)) {
-                return ParseResult.INVALID
+                throw InvalidWavFileException("File does not contain a RIFF header.")
             }
-            while (it.available() > 8) {
+            while (it.available() > CHUNK_HEADER_SIZE) {
                 parseChunk(it)
             }
         }
 
         val preDataChunk = mutableListOf<Chunk>()
         for (chunk in chunks) {
-            if (chunk.label == "data") {
+            if (chunk.label == DATA) {
                 dataChunkStart = chunk.start
                 break
             } else {
@@ -66,23 +79,32 @@ class WavHeader {
         computeTotalAudioSize()
 
         // The fmt chunk is required in all WAV files, WAVs with extensions will have additional pre-data chunks.
-        preDataChunk.removeAll { it.label == "fmt " }
+        preDataChunk.removeAll { it.label == FMT }
 
-        if (!chunks.map { it.label }.containsAll(listOf("fmt ", "data"))) {
-            return ParseResult.INVALID
+        val chunkLabels: List<String> = chunks.map { it.label }
+        if (!chunkLabels.containsAll(listOf(FMT, DATA))) {
+            when {
+                chunkLabels.containsAll(listOf(DATA)) -> {
+                    throw InvalidWavFileException("Wav header missing fmt chunk.")
+                }
+                chunkLabels.containsAll(listOf(FMT)) -> {
+                    throw InvalidWavFileException("Wav header missing data chunk.")
+                }
+                else -> throw InvalidWavFileException("Wav header missing both fmt and data chunks.")
+            }
         }
 
         readFmtChunk(file)
 
         if (preDataChunk.size > 0) {
-            return ParseResult.VALID_EXTENDED_HEADER_WAV
+            return WavHeaderParseResult.VALID_EXTENDED_HEADER_WAV
         }
 
-        return ParseResult.VALID_NORMAL_WAV
+        return WavHeaderParseResult.VALID_NORMAL_WAV
     }
 
     fun readFmtChunk(file: File) {
-        val fmt = chunks.find { it.label == "fmt " }
+        val fmt = chunks.find { it.label == FMT }
         fmt?.let { fmt ->
             file.inputStream().use {
                 it.skip(fmt.start.toLong())
@@ -101,29 +123,29 @@ class WavHeader {
     }
 
     private fun computeTotalAudioSize() {
-        val data = chunks.find { it.label == "data" }
+        val data = chunks.find { it.label == DATA }
         data?.let { data ->
             totalAudioLength = data.chunkSize
         }
     }
 
     private fun parseChunk(inputStream: FileInputStream) {
-        if (inputStream.available() < 8) {
+        if (inputStream.available() < CHUNK_HEADER_SIZE) {
             return
         }
 
-        val bytes = ByteArray(4)
+        val bytes = ByteArray(CHUNK_LABEL_SIZE)
         inputStream.read(bytes)
         var bb = ByteBuffer.wrap(bytes)
         bb.order(ByteOrder.LITTLE_ENDIAN)
-        val label = bb.getText(4)
+        val label = bb.getText(CHUNK_LABEL_SIZE)
 
         inputStream.read(bytes)
         bb = ByteBuffer.wrap(bytes)
         bb.order(ByteOrder.LITTLE_ENDIAN)
         val size = bb.int
 
-        readHeadPosition += 8
+        readHeadPosition += CHUNK_HEADER_SIZE
 
         val skip = wordAlign(size)
         inputStream.skip(skip.toLong())
@@ -133,15 +155,15 @@ class WavHeader {
     }
 
     private fun validateRiff(inputStream: FileInputStream): Boolean {
-        if (inputStream.available() < 12) {
+        if (inputStream.available() < RIFF_HEADER_SIZE) {
             return false
         }
 
-        val bytes = ByteArray(4)
+        val bytes = ByteArray(CHUNK_LABEL_SIZE)
         inputStream.read(bytes)
         var bb = ByteBuffer.wrap(bytes)
         bb.order(ByteOrder.LITTLE_ENDIAN)
-        val label = bb.getText(4)
+        val label = bb.getText(CHUNK_LABEL_SIZE)
 
         inputStream.read(bytes)
         bb = ByteBuffer.wrap(bytes)
@@ -151,11 +173,37 @@ class WavHeader {
         inputStream.read(bytes)
         bb = ByteBuffer.wrap(bytes)
         bb.order(ByteOrder.LITTLE_ENDIAN)
-        val form = bb.getText(4)
+        val form = bb.getText(CHUNK_LABEL_SIZE)
 
-        chunks.add(Chunk("RIFF", 8, size))
+        chunks.add(Chunk(RIFF, CHUNK_HEADER_SIZE, size))
         totalDataLength = size
-        readHeadPosition += 12
-        return label == "RIFF" && form == "WAVE"
+        readHeadPosition += RIFF_HEADER_SIZE
+        return label == RIFF && form == WAVE
+    }
+
+    // http://soundfile.sapp.org/doc/WaveFormat/ for equations
+    internal fun generateHeaderArray(): ByteArray {
+        val header = ByteBuffer.allocate(DEFAULT_HEADER_SIZE)
+        val longSampleRate = sampleRate
+        val byteRate = (bitsPerSample * sampleRate * channels) / BITS_IN_BYTE
+
+        header.order(ByteOrder.LITTLE_ENDIAN)
+        header.put(RIFF.toByteArray(Charsets.US_ASCII))
+        header.putInt(totalDataLength)
+        header.put(WAVE.toByteArray(Charsets.US_ASCII))
+        header.put(FMT.toByteArray(Charsets.US_ASCII))
+        header.putInt(bitsPerSample)
+        header.putShort(PCM) // format = 1 for pcm
+        header.putShort(channels.toShort()) // number of channels
+        header.putInt(longSampleRate)
+        header.putInt(byteRate)
+        header.putShort(((channels * bitsPerSample) / BITS_IN_BYTE).toShort()) // block align
+        header.putShort(bitsPerSample.toShort()) // bits per sample
+        header.put(DATA.toByteArray(Charsets.US_ASCII))
+        header.putInt(totalAudioLength) // initial size
+
+        header.flip()
+
+        return header.array()
     }
 }

--- a/common/audio/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/WavOutputStream.kt
+++ b/common/audio/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/WavOutputStream.kt
@@ -53,7 +53,7 @@ class WavOutputStream @Throws(FileNotFoundException::class)
         try {
             FileOutputStream(wav.file, true)
                 .channel
-                .truncate((whereToTruncate + WAV_HEADER_SIZE).toLong())
+                .truncate((whereToTruncate + wav.headerSize).toLong())
         } catch (e: IOException) {
             e.printStackTrace()
         }
@@ -123,7 +123,7 @@ class WavOutputStream @Throws(FileNotFoundException::class)
             bb.order(ByteOrder.LITTLE_ENDIAN)
             bb.putInt(audioDataLength)
             // move to audio size index
-            raf.seek((WAV_HEADER_SIZE - CHUNK_LABEL_SIZE).toLong())
+            raf.seek((wav.headerSize - CHUNK_LABEL_SIZE).toLong())
             raf.write(bb.array())
         }
     }

--- a/common/audio/src/test/kotlin/org/wycliffeassociates/otter/common/audio/wav/WavFileTest.kt
+++ b/common/audio/src/test/kotlin/org/wycliffeassociates/otter/common/audio/wav/WavFileTest.kt
@@ -1,0 +1,128 @@
+package org.wycliffeassociates.otter.common.audio.wav
+
+import org.junit.Assert
+import org.junit.Test
+import java.io.File
+import java.io.InputStream
+import java.io.OutputStream
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import kotlin.random.Random
+
+class WavFileTest {
+}
+
+class WavHeaderTest {
+
+    @Test
+    fun `test normal wav without metadata chunks has 44 byte header`() {
+        val testEnv = writeWav(0, 0, 0)
+        val header = WavHeader().apply { parse(testEnv.file) }
+        validateFormat(header)
+        Assert.assertEquals("normal header should be 44 bytes", 44, header.totalHeaderSize)
+        testEnv.file.delete()
+    }
+
+    @Test
+    fun `test normal wav with metadata chunks has 44 byte header`() {
+        val testEnv = writeWav(0, 0, 3)
+        val header = WavHeader().apply { parse(testEnv.file) }
+        validateFormat(header)
+        Assert.assertEquals("normal header should be 44 bytes", 44, header.totalHeaderSize)
+        testEnv.file.delete()
+    }
+
+    @Test
+    fun `test header has chunks before fmt`() {
+        val testEnv = writeWav(5, 0, 3)
+        val header = WavHeader().apply { parse(testEnv.file) }
+        validateFormat(header)
+        val reader = WavFileReader(WavFile(testEnv.file))
+        reader.open()
+        val audio = ByteArray(header.totalAudioLength)
+        Assert.assertEquals("Audio size", testEnv.dataSize, header.totalAudioLength)
+        reader.getPcmBuffer(audio)
+        val buffer = ByteBuffer.wrap(audio)
+        buffer.order(ByteOrder.LITTLE_ENDIAN)
+        Assert.assertEquals("Audio data should begin with STRT", buffer.getText(4), "STRT")
+        buffer.seek(audio.size - 8)
+        Assert.assertEquals("Audio data should end with END ", buffer.getText(4), "END ")
+        testEnv.file.delete()
+    }
+
+    private fun validateFormat(header: WavHeader) {
+        Assert.assertEquals("bit rate should be 16", 16, header.bitsPerSample)
+        Assert.assertEquals("channels should be 1", 1, header.channels)
+        Assert.assertEquals("sample rate should be 44100", 44100, header.sampleRate)
+    }
+}
+
+class AudioTestEnv(
+    val file: File,
+    val dataSize: Int
+)
+
+fun writeWav(
+    preFmtChunks: Int,
+    postFmtChunks: Int,
+    postDataChunks: Int
+): AudioTestEnv {
+    val testFile = File.createTempFile("test", ".wav").apply { deleteOnExit() }
+
+    val bytes = ByteBuffer.allocate(12)
+    bytes.order(ByteOrder.LITTLE_ENDIAN)
+    bytes.put("RIFF".toByteArray())
+    bytes.putInt(0)
+    bytes.put("WAVE".toByteArray())
+
+    var dataSize = 0
+    testFile.outputStream().use {
+        it.write(bytes.array())
+        for (i in 1..preFmtChunks) {
+            writeArbitraryChunks(it, "JUNK")
+        }
+        writeFmtChunk(it)
+        for (i in 1..postFmtChunks) {
+            writeArbitraryChunks(it, "JUNK")
+        }
+        dataSize = writeArbitraryChunks(it, "data")
+        for (i in 1..postDataChunks) {
+            writeArbitraryChunks(it, "JUNK")
+        }
+    }
+
+    return AudioTestEnv(testFile, dataSize - 8)
+}
+
+fun writeArbitraryChunks(outputStream: OutputStream, label: String): Int {
+    var dataSize = Random(System.currentTimeMillis()).nextInt(8, 500)
+    if (label == "data" && dataSize % 2 == 1) { // data chunks of 16 bit audio must be even
+        dataSize++
+    }
+    val padSize = if (dataSize % 2 == 0) 0 else 1
+    val totalSize = dataSize + 8 + padSize
+    val bytes = ByteBuffer.allocate(totalSize)
+    bytes.order(ByteOrder.LITTLE_ENDIAN)
+    bytes.put(label.toByteArray())
+    bytes.putInt(dataSize)
+    bytes.put("STRT".toByteArray())
+    bytes.seek(totalSize - 4 - 12 - padSize)
+    bytes.put("END ".toByteArray())
+
+    outputStream.write(bytes.array())
+    return bytes.array().size
+}
+
+fun writeFmtChunk(outputStream: OutputStream) {
+    val bytes = ByteBuffer.allocate(24)
+    bytes.order(ByteOrder.LITTLE_ENDIAN)
+    bytes.put("fmt ".toByteArray())
+    bytes.putInt(16)
+    bytes.putShort(1)
+    bytes.putShort(1)
+    bytes.putInt(44100)
+    bytes.putInt(88200)
+    bytes.putShort(2)
+    bytes.putShort(16)
+    outputStream.write(bytes.array())
+}

--- a/common/audio/src/test/kotlin/org/wycliffeassociates/otter/common/audio/wav/WavFileTest.kt
+++ b/common/audio/src/test/kotlin/org/wycliffeassociates/otter/common/audio/wav/WavFileTest.kt
@@ -91,7 +91,7 @@ fun writeWav(
         }
     }
 
-    return AudioTestEnv(testFile, dataSize - 8)
+    return AudioTestEnv(testFile, dataSize)
 }
 
 fun writeArbitraryChunks(outputStream: OutputStream, label: String): Int {
@@ -110,7 +110,7 @@ fun writeArbitraryChunks(outputStream: OutputStream, label: String): Int {
     bytes.put("END ".toByteArray())
 
     outputStream.write(bytes.array())
-    return bytes.array().size
+    return dataSize
 }
 
 fun writeFmtChunk(outputStream: OutputStream) {

--- a/common/audio/src/test/kotlin/org/wycliffeassociates/otter/common/audio/wav/WavHeaderTest.kt
+++ b/common/audio/src/test/kotlin/org/wycliffeassociates/otter/common/audio/wav/WavHeaderTest.kt
@@ -49,9 +49,9 @@ class WavHeaderTest {
         reader.getPcmBuffer(audio)
         val buffer = ByteBuffer.wrap(audio)
         buffer.order(ByteOrder.LITTLE_ENDIAN)
-        Assert.assertEquals("Audio data should begin with STRT", buffer.getText(4), "STRT")
+        Assert.assertEquals("Audio data should begin with 'STRT', data size is ${testEnv.dataSize}", buffer.getText(4), "STRT")
         buffer.seek(audio.size - 8)
-        Assert.assertEquals("Audio data should end with END ", buffer.getText(4), "END ")
+        Assert.assertEquals("Audio data should end with 'END ', data size is ${testEnv.dataSize}", buffer.getText(4), "END ")
         testEnv.file.delete()
     }
 
@@ -70,9 +70,9 @@ class WavHeaderTest {
         reader.getPcmBuffer(audio)
         val buffer = ByteBuffer.wrap(audio)
         buffer.order(ByteOrder.LITTLE_ENDIAN)
-        Assert.assertEquals("Audio data should begin with STRT", buffer.getText(4), "STRT")
+        Assert.assertEquals("Audio data should begin with 'STRT', data size is ${testEnv.dataSize}", buffer.getText(4), "STRT")
         buffer.seek(audio.size - 8)
-        Assert.assertEquals("Audio data should end with END ", buffer.getText(4), "END ")
+        Assert.assertEquals("Audio data should end with 'END ', data size is ${testEnv.dataSize}", buffer.getText(4), "END ")
         testEnv.file.delete()
     }
 
@@ -91,9 +91,9 @@ class WavHeaderTest {
         reader.getPcmBuffer(audio)
         val buffer = ByteBuffer.wrap(audio)
         buffer.order(ByteOrder.LITTLE_ENDIAN)
-        Assert.assertEquals("Audio data should begin with STRT", buffer.getText(4), "STRT")
+        Assert.assertEquals("Audio data should begin with 'STRT', data size is ${testEnv.dataSize}", buffer.getText(4), "STRT")
         buffer.seek(audio.size - 8)
-        Assert.assertEquals("Audio data should end with END ", buffer.getText(4), "END ")
+        Assert.assertEquals("Audio data should end with 'END ', data size is ${testEnv.dataSize}", buffer.getText(4), "END ")
         testEnv.file.delete()
     }
 

--- a/jvm/workbookapp/src/test/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/utils/Audio.kt
+++ b/jvm/workbookapp/src/test/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/utils/Audio.kt
@@ -18,17 +18,12 @@
  */
 package org.wycliffeassociates.otter.jvm.workbookapp.utils
 
-import io.reactivex.Observable
-import org.wycliffeassociates.otter.common.audio.AudioFile
-import org.wycliffeassociates.otter.common.recorder.WavFileWriter
+import org.wycliffeassociates.otter.common.audio.wav.WavFile
+import org.wycliffeassociates.otter.common.audio.wav.WavOutputStream
 import java.io.File
 
 fun writeWavFile(target: File) {
-    val wav = AudioFile(target, 1, 44100, 16)
-    val stream = Observable.just(
-        // sample data
-        byteArrayOf(73, -1, -18, 40, 44, 76, 92, 68, -4, 28, -91, -19, 63, 39, 93, -21, -88, -33, -19, -43, 70)
-    )
-    val writer = WavFileWriter(wav, stream) {}
-    writer.start()
+    val wav = WavFile(target, 1, 44100, 16)
+    val data = byteArrayOf(73, -1, -18, 40, 44, 76, 92, 68, -4, 28, -91, -19, 63, 39, 93, -21, -88, -33, -19, -43, 70)
+    WavOutputStream(wav).use { it.write(data) }
 }


### PR DESCRIPTION
Rather than rely on a hardcoded 44 byte wav header, this parses possible extension chunks appearing before or after the fmt chunk, including those of a broadcast wav (bwf)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/orature/680)
<!-- Reviewable:end -->
