### PR TITLE
Align buttons (Narration)

### DIFF
--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/media/SourceContent.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/media/SourceContent.kt
@@ -210,9 +210,8 @@ class SourceContent : StackPane() {
 
                         button {
                             playTargetBtn = this
-                            addClass("btn", "btn--primary")
+                            addClass("btn", "btn--primary", "source-content__play-audio-btn")
                             graphic = FontIcon(MaterialDesign.MDI_PLAY)
-                            // Set icon size to 16
                         }
 
                         simpleaudioplayer {
@@ -225,6 +224,12 @@ class SourceContent : StackPane() {
                             playTextProperty.bind(playTargetLabelProperty)
                             pauseTextProperty.bind(pauseTargetLabelProperty)
                             menuSideProperty.set(Side.TOP)
+                        }
+
+                        // dummy button for better spacing & alignment
+                        button {
+                            addClass("btn", "btn--icon")
+                            isVisible = false
                         }
 
                         visibleWhen(targetAudioPlayerProperty.isNotNull)
@@ -255,7 +260,7 @@ class SourceContent : StackPane() {
 
                             button {
                                 playSourceBtn = this
-                                addClass("btn", "btn--primary")
+                                addClass("btn", "btn--primary", "source-content__play-audio-btn")
                                 graphic = FontIcon(MaterialDesign.MDI_PLAY)
                             }
 

--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/media/SourceContent.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/media/SourceContent.kt
@@ -230,6 +230,7 @@ class SourceContent : StackPane() {
                         button {
                             addClass("btn", "btn--icon")
                             isVisible = false
+                            managedWhen(sourceTextCompactMode)
                         }
 
                         visibleWhen(targetAudioPlayerProperty.isNotNull)

--- a/jvm/controls/src/main/resources/css/source-content.css
+++ b/jvm/controls/src/main/resources/css/source-content.css
@@ -38,16 +38,20 @@
 
 .source-content__bottom {
     -fx-min-height: 60px;
-    -fx-border-width: 1px 0 0 0;
-    -fx-border-color: -wa-border-light;
+}
+
+.source-content__bottom .source-content__play-audio-btn {
+    -fx-pref-width: 180px;
 }
 
 .source-content__control-group {
     -fx-alignment: center;
-    -fx-spacing: 10;
+    -fx-spacing: 15;
     -fx-background-color: -wa-transparent;
+    -fx-border-width: 1px 0 0 0;
+    -fx-border-color: -wa-border-light;
     -fx-background-radius: 5;
-    -fx-padding: 8px;
+    -fx-padding: 8;
 }
 
 .source-content__not-available {
@@ -84,13 +88,13 @@
 .source-content__audio_container {
     -fx-alignment: center-left;
     -fx-min-height: 60px;
-    -fx-spacing: 20px;
+    -fx-spacing: 15px;
 }
 
 .source-content__audio_container--target {
-    -fx-border-width: 0 0 1px 0;
+    -fx-border-width: 1px 0 0 0;
     -fx-border-color: -wa-border-light;
-    -fx-padding: 15px 5px;
+    -fx-padding: 10px 8px;
 }
 
 .source-content__text-container {


### PR DESCRIPTION
The spacing-dummy button should hide in full text narration 

![image](https://user-images.githubusercontent.com/34975907/194151633-1d35512f-6a9d-41fb-9382-736828a69ca0.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/orature/682)
<!-- Reviewable:end -->
