### PR TITLE
Export backup should contain only relevant source audio

### DIFF
--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/project/ProjectFilesAccessor.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/project/ProjectFilesAccessor.kt
@@ -41,6 +41,8 @@ import org.wycliffeassociates.resourcecontainer.ZipAccessor
 import org.wycliffeassociates.resourcecontainer.entity.Project
 import java.io.File
 import java.io.OutputStream
+import javax.inject.Inject
+import kotlin.io.path.createTempDirectory
 import kotlin.io.path.outputStream
 
 class ProjectFilesAccessor(
@@ -117,7 +119,36 @@ class ProjectFilesAccessor(
         sources
             .map { it.path }
             .distinct()
-            .forEach { fileWriter.copyFile(it, RcConstants.SOURCE_DIR) }
+            .forEach {
+                fileWriter.copyFile(it, RcConstants.SOURCE_DIR)
+            }
+    }
+
+    /**
+     * Copies the source files of the project containing project-related media only.
+     *
+     * @param fileWriter used to write to the project file.
+     * @param tempDir a temporary directory used to dump source file before copying.
+     * @param linkedResource the associated resource file to the project's source.
+     */
+    fun copySourceFilesOfProject(
+        fileWriter: IFileWriter,
+        tempDir: File,
+        linkedResource: ResourceMetadata? = null
+    ) {
+        val sources = listOfNotNull(sourceMetadata, linkedResource)
+        /* generate a sub-temp directory to avoid dirty file
+            being accidentally reused due to the same name */
+        val sourceTempDir = createTempDirectory(tempDir.toPath(), "otter-export").toFile()
+
+        sources
+            .map { it.path }
+            .distinct()
+            .forEach { source ->
+                // prepare source before copying into export file.
+                val newSource = prepareProjectSourceMedia(source, sourceTempDir)
+                fileWriter.copyFile(newSource, RcConstants.SOURCE_DIR)
+            }
     }
 
     fun initializeResourceContainerInDir(overwrite: Boolean = true) {
@@ -268,6 +299,52 @@ class ProjectFilesAccessor(
             rc.media?.projects = listOf()
             rc.writeMedia()
         }
+    }
+
+    /**
+     * Returns a new file containing source media of the given project only.
+     */
+    private fun prepareProjectSourceMedia(
+        source: File,
+        tempDir: File
+    ): File {
+        val newSourceFile = tempDir.resolve(source.nameWithoutExtension + ".zip")
+        val newSourceZip = ZipAccessor(newSourceFile)
+
+        ResourceContainer.load(source).use {
+            val inMap = it.accessor.getInputStreams(".", listOf())
+                .filterKeys { path ->
+                    if (path.contains("${RcConstants.SOURCE_MEDIA_DIR}/")) {
+                        path.contains("${RcConstants.SOURCE_MEDIA_DIR}/${project.slug}")
+                    } else {
+                        true
+                    }
+                }
+            val filesToWrite = inMap.mapValues {
+                { output: OutputStream ->
+                    it.value.copyTo(output)
+                    Unit
+                }
+            }
+            try {
+                newSourceZip.write(filesToWrite)
+            } catch (e: Exception) {
+                log.error("Error while copying source container to derived project.", e)
+            } finally {
+                newSourceZip.close()
+            }
+        }
+
+        // update media manifest
+        ResourceContainer.load(newSourceFile).use { rc ->
+            val singleProjectList = listOfNotNull(
+                rc.media?.projects?.find { it.identifier == project.slug }
+            )
+            rc.media?.projects = singleProjectList
+            rc.writeMedia()
+        }
+
+        return newSourceFile
     }
 
     fun selectedChapterFilePaths(workbook: Workbook, isBook: Boolean): Set<String> {

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/project/ProjectFilesAccessor.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/project/ProjectFilesAccessor.kt
@@ -41,7 +41,6 @@ import org.wycliffeassociates.resourcecontainer.ZipAccessor
 import org.wycliffeassociates.resourcecontainer.entity.Project
 import java.io.File
 import java.io.OutputStream
-import javax.inject.Inject
 import kotlin.io.path.createTempDirectory
 import kotlin.io.path.outputStream
 
@@ -146,7 +145,7 @@ class ProjectFilesAccessor(
             .distinct()
             .forEach { source ->
                 // prepare source before copying into export file.
-                val newSource = prepareProjectSourceMedia(source, sourceTempDir)
+                val newSource = filterSourceFileToContainProjectRelatedMedia(source, sourceTempDir)
                 fileWriter.copyFile(newSource, RcConstants.SOURCE_DIR)
             }
     }
@@ -302,9 +301,9 @@ class ProjectFilesAccessor(
     }
 
     /**
-     * Returns a new file containing source media of the given project only.
+     * Returns a new file containing source media of the corresponding project only.
      */
-    private fun prepareProjectSourceMedia(
+    private fun filterSourceFileToContainProjectRelatedMedia(
         source: File,
         tempDir: File
     ): File {
@@ -335,7 +334,7 @@ class ProjectFilesAccessor(
             }
         }
 
-        // update media manifest
+        // filter media projects that are not related to the current project
         ResourceContainer.load(newSourceFile).use { rc ->
             val singleProjectList = listOfNotNull(
                 rc.media?.projects?.find { it.identifier == project.slug }

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/project/ProjectFilesAccessor.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/project/ProjectFilesAccessor.kt
@@ -131,7 +131,7 @@ class ProjectFilesAccessor(
      * @param tempDir a temporary directory used to dump source file before copying.
      * @param linkedResource the associated resource file to the project's source.
      */
-    fun copySourceFilesOfProject(
+    fun copySourceFilesWithRelatedMedia(
         fileWriter: IFileWriter,
         tempDir: File,
         linkedResource: ResourceMetadata? = null

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/projectimportexport/BackupProjectExporter.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/projectimportexport/BackupProjectExporter.kt
@@ -71,7 +71,10 @@ class BackupProjectExporter @Inject constructor(
 
                     val linkedResource = workbook.source.linkedResources
                         .firstOrNull { it.identifier == projectMetadataToExport.identifier }
-                    projectFilesAccessor.copySourceFiles(fileWriter, linkedResource)
+
+                    projectFilesAccessor.copySourceFilesOfProject(
+                        fileWriter, directoryProvider.tempDirectory, linkedResource
+                    )
                     projectFilesAccessor.writeSelectedTakesFile(fileWriter, workbook, projectToExportIsBook)
                 }
 

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/projectimportexport/BackupProjectExporter.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/projectimportexport/BackupProjectExporter.kt
@@ -72,7 +72,7 @@ class BackupProjectExporter @Inject constructor(
                     val linkedResource = workbook.source.linkedResources
                         .firstOrNull { it.identifier == projectMetadataToExport.identifier }
 
-                    projectFilesAccessor.copySourceFilesOfProject(
+                    projectFilesAccessor.copySourceFilesWithRelatedMedia(
                         fileWriter, directoryProvider.tempDirectory, linkedResource
                     )
                     projectFilesAccessor.writeSelectedTakesFile(fileWriter, workbook, projectToExportIsBook)

--- a/common/src/test/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/project/ProjectFilesAccessorTest.kt
+++ b/common/src/test/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/project/ProjectFilesAccessorTest.kt
@@ -229,8 +229,8 @@ class ProjectFilesAccessorTest {
         }
         ZipFile(source).use { zip ->
             val pathsInZip = zip.entries().toList().map { it.name }
-            val mediaPaths = pathsInZip.filter { it.contains("${RcConstants.MEDIA_DIR}/") }
-            val isRelevantMedia = mediaPaths.all { it.contains("${RcConstants.MEDIA_DIR}/$jasProjectSlug") }
+            val mediaPaths = pathsInZip.filter { it.contains("${RcConstants.SOURCE_MEDIA_DIR}/") }
+            val isRelevantMedia = mediaPaths.all { it.contains("${RcConstants.SOURCE_MEDIA_DIR}/$jasProjectSlug") }
 
             assertTrue(mediaPaths.isNotEmpty())
             assertTrue(

--- a/common/src/test/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/project/ProjectFilesAccessorTest.kt
+++ b/common/src/test/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/project/ProjectFilesAccessorTest.kt
@@ -133,8 +133,6 @@ class ProjectFilesAccessorTest {
 
     @Test
     fun copySourceFiles_excludeMedia() {
-        val project = mock(Collection::class.java)
-        `when`(project.slug).thenReturn(jasProjectSlug)
         val projectFilesAccessor = buildProjectAccessor()
 
         projectFilesAccessor.copySourceFiles(excludeMedia = true)
@@ -219,6 +217,12 @@ class ProjectFilesAccessorTest {
         val source = projectSourceDir.listFiles().first()
         ResourceContainer.load(source).use { rc ->
             assertEquals(
+                "Media project of source should have 1 project.",
+                1,
+                rc.media?.projects?.size
+            )
+            assertEquals(
+                "Source audio project slug should match the target slug.",
                 jasProjectSlug,
                 rc.media?.projects?.single()?.identifier
             )
@@ -227,7 +231,12 @@ class ProjectFilesAccessorTest {
             val pathsInZip = zip.entries().toList().map { it.name }
             val mediaPaths = pathsInZip.filter { it.contains("${RcConstants.MEDIA_DIR}/") }
             val isRelevantMedia = mediaPaths.all { it.contains("${RcConstants.MEDIA_DIR}/$jasProjectSlug") }
-            assertTrue(isRelevantMedia)
+
+            assertTrue(mediaPaths.isNotEmpty())
+            assertTrue(
+                "Source media should only contain files related to the target project.",
+                isRelevantMedia
+            )
         }
     }
 

--- a/jvm/workbookapp/src/integration-test/kotlin/integrationtest/projects/TestProjectExport.kt
+++ b/jvm/workbookapp/src/integration-test/kotlin/integrationtest/projects/TestProjectExport.kt
@@ -70,9 +70,11 @@ class TestProjectExport {
     private lateinit var workbook: Workbook
     private lateinit var projectFilesAccessor: ProjectFilesAccessor
 
-    private val sourceMetadata = enUlbTestMetadata
+    private val sourceMetadata = enUlbTestMetadata.copy(
+        path = getResource("resource-containers/en_ulb.zip")
+    )
 
-    private val targetMetadata = sourceMetadata.copy(
+    private val targetMetadata = enUlbTestMetadata.copy(
         creator = "Orature",
         language = Language("en-x-demo1", "", "", "", true, "Europe")
     )
@@ -149,5 +151,9 @@ class TestProjectExport {
             projectFilesAccessor.getContributorInfo().size,
             contributorCount
         )
+    }
+
+    private fun getResource(name: String): File {
+        return File(javaClass.classLoader.getResource("resource-containers/en_ulb.zip").file)
     }
 }


### PR DESCRIPTION
Previously, `Export Backup` will copy the whole source file (including every source audio ever exists from other books).
This PR filters out to keep only the source audio of the target project to export.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/orature/685)
<!-- Reviewable:end -->
