### PR TITLE
Improve recorder button hitbox

### DIFF
--- a/jvm/recorderapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/recorder/app/view/ControlFragment.kt
+++ b/jvm/recorderapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/recorder/app/view/ControlFragment.kt
@@ -72,7 +72,7 @@ class ControlFragment : Fragment() {
         }
 
         recordBtn.apply {
-            addClass("btn", "btn--icon", "btn--borderless", "record-button")
+            addClass("btn", "btn--cta", "record-button")
             graphic = FontIcon("gmi-mic")
             tooltip {
                 textProperty().bind(

--- a/jvm/recorderapp/src/main/resources/css/recorder.css
+++ b/jvm/recorderapp/src/main/resources/css/recorder.css
@@ -51,12 +51,11 @@
 }
 
 .record-button {
-    -fx-padding: 5 10;
+    -fx-padding: 5 12;
 }
 
 .record-button .ikonli-font-icon {
-    -fx-icon-color: -wa-white;
-    -fx-icon-size: 48px;
+    -fx-icon-size: 36px;
 }
 
 .reset-button {

--- a/jvm/recorderapp/src/main/resources/css/recorder.css
+++ b/jvm/recorderapp/src/main/resources/css/recorder.css
@@ -50,6 +50,10 @@
     -fx-padding: 0 0 0 5px;
 }
 
+.record-button {
+    -fx-padding: 5 10;
+}
+
 .record-button .ikonli-font-icon {
     -fx-icon-color: -wa-white;
     -fx-icon-size: 48px;


### PR DESCRIPTION
Screenshots are captured when `button:hover`
Before:
![image](https://user-images.githubusercontent.com/34975907/195393195-0a70ff72-b57f-45d3-abb8-f1d199e477d4.png)

After:
![image](https://user-images.githubusercontent.com/34975907/195611871-9eaa4256-e1de-4416-8dff-1e8dd9af1987.png)
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/orature/689)
<!-- Reviewable:end -->
