### PR TITLE
Bugfix: don't count RIFF as a pre-data chunk

### DIFF
--- a/common/audio/build.gradle
+++ b/common/audio/build.gradle
@@ -1,5 +1,5 @@
 group = 'org.wycliffeassociates.otter.common'
-version = '0.4.0'
+version = '0.4.1'
 
 dependencies {
     testImplementation "junit:junit:$junitVer"

--- a/common/audio/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/WavHeader.kt
+++ b/common/audio/src/main/kotlin/org/wycliffeassociates/otter/common/audio/wav/WavHeader.kt
@@ -82,7 +82,7 @@ class WavHeader {
         computeTotalAudioSize()
 
         // The fmt chunk is required in all WAV files, WAVs with extensions will have additional pre-data chunks.
-        preDataChunk.removeAll { it.label == FMT }
+        preDataChunk.removeAll { it.label == FMT || it.label == RIFF }
 
         val chunkLabels: List<String> = chunks.map { it.label }
         if (!chunkLabels.containsAll(listOf(FMT, DATA))) {


### PR DESCRIPTION
The riff chunk shows up in the list of pre-data chunks which, means that the wav type will always be of type WAV_WITH_EXTENSION.

The riff chunk should not be considered in determining this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/orature/690)
<!-- Reviewable:end -->
