### PR TITLE
Retain chunks created in chunks.json when import

### DIFF
--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/data/Chunkification.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/data/Chunkification.kt
@@ -2,4 +2,4 @@ package org.wycliffeassociates.otter.common.data
 
 import org.wycliffeassociates.otter.common.data.primitives.Content
 
-class ChunksMetadata : HashMap<Int, List<Content>>()
+typealias Chunkification = HashMap<Int, List<Content>>

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/data/ChunksMetadata.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/data/ChunksMetadata.kt
@@ -1,0 +1,5 @@
+package org.wycliffeassociates.otter.common.data
+
+import org.wycliffeassociates.otter.common.data.primitives.Content
+
+class ChunksMetadata : HashMap<Int, List<Content>>()

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/content/CreateChunks.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/content/CreateChunks.kt
@@ -3,20 +3,20 @@ package org.wycliffeassociates.otter.common.domain.content
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.core.JsonFactory
 import com.fasterxml.jackson.core.JsonGenerator
-import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.exc.MismatchedInputException
 import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.module.kotlin.readValue
 import java.io.File
 import org.slf4j.LoggerFactory
 import org.wycliffeassociates.otter.common.audio.AudioCue
+import org.wycliffeassociates.otter.common.data.ChunksMetadata
 import org.wycliffeassociates.otter.common.data.primitives.Content
 import org.wycliffeassociates.otter.common.data.primitives.ContentType
 import org.wycliffeassociates.otter.common.data.workbook.Book
 import org.wycliffeassociates.otter.common.domain.audio.SourceAudioFile
 import org.wycliffeassociates.otter.common.domain.resourcecontainer.SourceAudioAccessor
 import org.wycliffeassociates.otter.common.domain.resourcecontainer.project.ProjectFilesAccessor
-
 
 class CreateChunks(
     private val projectFilesAccessor: ProjectFilesAccessor,
@@ -115,9 +115,7 @@ class CreateChunks(
         }
         try {
             if (file.exists() && file.length() > 0) {
-                val typeRef: TypeReference<HashMap<Int, List<Content>>> =
-                    object : TypeReference<HashMap<Int, List<Content>>>() {}
-                val map: Map<Int, List<Content>> = mapper.readValue(file, typeRef)
+                val map: ChunksMetadata = mapper.readValue(file)
                 chunks.putAll(map)
                 logger.error("restoring chunks")
             }

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/content/CreateChunks.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/content/CreateChunks.kt
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import java.io.File
 import org.slf4j.LoggerFactory
 import org.wycliffeassociates.otter.common.audio.AudioCue
-import org.wycliffeassociates.otter.common.data.ChunksMetadata
+import org.wycliffeassociates.otter.common.data.Chunkification
 import org.wycliffeassociates.otter.common.data.primitives.Content
 import org.wycliffeassociates.otter.common.data.primitives.ContentType
 import org.wycliffeassociates.otter.common.data.workbook.Book
@@ -115,7 +115,7 @@ class CreateChunks(
         }
         try {
             if (file.exists() && file.length() > 0) {
-                val map: ChunksMetadata = mapper.readValue(file)
+                val map: Chunkification = mapper.readValue(file)
                 chunks.putAll(map)
                 logger.error("restoring chunks")
             }

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/content/ResetChunks.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/content/ResetChunks.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.core.JsonFactory
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.fasterxml.jackson.module.kotlin.readValue
-import org.wycliffeassociates.otter.common.data.ChunksMetadata
+import org.wycliffeassociates.otter.common.data.Chunkification
 import java.io.File
 import javax.inject.Inject
 import org.wycliffeassociates.otter.common.data.workbook.Chapter
@@ -48,7 +48,7 @@ class ResetChunks @Inject constructor() {
         }
 
         val mapper = ObjectMapper(JsonFactory()).registerModule(KotlinModule())
-        val chunks: ChunksMetadata = mapper.readValue(chunkFile)
+        val chunks: Chunkification = mapper.readValue(chunkFile)
         chunks.remove(chapterNumber)
 
         chunkFile.writer().use {

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/content/ResetChunks.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/content/ResetChunks.kt
@@ -15,7 +15,7 @@ class ResetChunks @Inject constructor() {
     fun resetChapter(accessor: ProjectFilesAccessor, chapter: Chapter) {
         markTakesForDeletion(chapter)
         deleteChunkedSourceAudio(accessor, chapter)
-        writeChunkFile(accessor, chapter.sort)
+        removeChapterFromChunkFile(accessor.getChunkFile(), chapter.sort)
         chapter.reset()
     }
 
@@ -42,8 +42,7 @@ class ResetChunks @Inject constructor() {
         }
     }
 
-    private fun writeChunkFile(accessor: ProjectFilesAccessor, chapterNumber: Int) {
-        val chunkFile = accessor.getChunkFile()
+    private fun removeChapterFromChunkFile(chunkFile: File, chapterNumber: Int) {
         if (!chunkFile.exists() || chunkFile.length() == 0L) {
             return
         }

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/projectimportexport/ProjectImporter.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/projectimportexport/ProjectImporter.kt
@@ -30,6 +30,7 @@ import io.reactivex.Maybe
 import io.reactivex.Observable
 import io.reactivex.Single
 import org.slf4j.LoggerFactory
+import org.wycliffeassociates.otter.common.data.ChunksMetadata
 import org.wycliffeassociates.otter.common.data.OratureFileFormat
 import org.wycliffeassociates.otter.common.data.primitives.Collection
 import org.wycliffeassociates.otter.common.data.primitives.ContainerType
@@ -233,18 +234,18 @@ class ProjectImporter @Inject constructor(
     }
 
     private fun resetChaptersWithoutTakes(fileReader: IFileReader, derivedProject: Collection) {
-        val chaptersHavingChunks = if (fileReader.exists(RcConstants.CHUNKS_FILE)) {
+        val chapterStarted = if (fileReader.exists(RcConstants.CHUNKS_FILE)) {
             fileReader.stream(RcConstants.CHUNKS_FILE).let { input ->
                 val mapper = ObjectMapper().registerModule(KotlinModule())
-                val map: Map<Int, List<Content>> = mapper.readValue(input)
-                map.map { it.key }
+                val chunks: ChunksMetadata = mapper.readValue(input)
+                chunks.map { it.key }
             }
         } else {
             listOf()
         }
         val chaptersNotStarted = collectionRepository
             .collectionsWithoutTakes(derivedProject).blockingGet()
-            .filterNot { chaptersHavingChunks.contains(it.sort) }
+            .filterNot { chapterStarted.contains(it.sort) }
 
         chaptersNotStarted.forEach { contentRepository.deleteForCollection(it).blockingGet() }
     }

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/projectimportexport/ProjectImporter.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/projectimportexport/ProjectImporter.kt
@@ -30,7 +30,7 @@ import io.reactivex.Maybe
 import io.reactivex.Observable
 import io.reactivex.Single
 import org.slf4j.LoggerFactory
-import org.wycliffeassociates.otter.common.data.ChunksMetadata
+import org.wycliffeassociates.otter.common.data.Chunkification
 import org.wycliffeassociates.otter.common.data.OratureFileFormat
 import org.wycliffeassociates.otter.common.data.primitives.Collection
 import org.wycliffeassociates.otter.common.data.primitives.ContainerType
@@ -241,7 +241,7 @@ class ProjectImporter @Inject constructor(
             try {
                 fileReader.stream(RcConstants.CHUNKS_FILE).let { input ->
                     val mapper = ObjectMapper(JsonFactory()).registerModule(KotlinModule())
-                    val chunks: ChunksMetadata = mapper.readValue(input)
+                    val chunks: Chunkification = mapper.readValue(input)
                     val chapters = chunks.map { it.key }
                     chapters
                 }


### PR DESCRIPTION
- When we import a project, the chapters that don't have takes will be reset. This also applied to chapters that have user-defined chunks but not yet have any recordings. 
- Additionally, when the user clicks Delete (reset chapter), the `chunks.json` is not updated.

This PR resolves these issues ^

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/701)
<!-- Reviewable:end -->
