### PR TITLE
Fix: navigating Home while recorder is active = crash

### DIFF
--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ChapterPageViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ChapterPageViewModel.kt
@@ -204,6 +204,7 @@ class ChapterPageViewModel : ViewModel() {
     fun recordChapter() {
         chapterCardProperty.value?.chapterSource?.let { rec ->
             contextProperty.set(PluginType.RECORDER)
+            val workbook = workbookDataStore.workbook
 
             rec.audio.getNewTakeNumber()
                 .flatMapMaybe { takeNumber ->
@@ -224,7 +225,7 @@ class ChapterPageViewModel : ViewModel() {
                     when (result) {
                         TakeActions.Result.NO_PLUGIN -> snackBarObservable.onNext(messages["noRecorder"])
                         TakeActions.Result.SUCCESS -> {
-                            workbookDataStore.updateSelectedTakesFile()
+                            workbookDataStore.updateSelectedTakesFile(workbook)
                         }
                         TakeActions.Result.NO_AUDIO -> {
                             /* no-op */

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ChapterPageViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ChapterPageViewModel.kt
@@ -204,7 +204,7 @@ class ChapterPageViewModel : ViewModel() {
     fun recordChapter() {
         chapterCardProperty.value?.chapterSource?.let { rec ->
             contextProperty.set(PluginType.RECORDER)
-            val updateOnSuccess = workbookDataStore.updateSelectedTakesFileAsync()
+            val updateOnSuccess = workbookDataStore.updateSelectedTakesFile()
 
             rec.audio.getNewTakeNumber()
                 .flatMapMaybe { takeNumber ->
@@ -432,7 +432,7 @@ class ChapterPageViewModel : ViewModel() {
 
     private fun onTakeSelected(chunk: CardData, take: TakeModel) {
         chunk.chunkSource?.audio?.selectTake(take.take)
-        workbookDataStore.updateSelectedTakesFile()
+        workbookDataStore.updateSelectedTakesFile().subscribe()
         take.take.file.setLastModified(System.currentTimeMillis())
         buildTakes(chunk)
     }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ChapterPageViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ChapterPageViewModel.kt
@@ -204,7 +204,7 @@ class ChapterPageViewModel : ViewModel() {
     fun recordChapter() {
         chapterCardProperty.value?.chapterSource?.let { rec ->
             contextProperty.set(PluginType.RECORDER)
-            val workbook = workbookDataStore.workbook
+            val updateOnSuccess = workbookDataStore.updateSelectedTakesFileAsync()
 
             rec.audio.getNewTakeNumber()
                 .flatMapMaybe { takeNumber ->
@@ -225,7 +225,7 @@ class ChapterPageViewModel : ViewModel() {
                     when (result) {
                         TakeActions.Result.NO_PLUGIN -> snackBarObservable.onNext(messages["noRecorder"])
                         TakeActions.Result.SUCCESS -> {
-                            workbookDataStore.updateSelectedTakesFile(workbook)
+                            updateOnSuccess.subscribe()
                         }
                         TakeActions.Result.NO_AUDIO -> {
                             /* no-op */

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/RecordScriptureViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/RecordScriptureViewModel.kt
@@ -383,6 +383,8 @@ class RecordScriptureViewModel : ViewModel() {
         closePlayers()
         recordable?.let { rec ->
             contextProperty.set(PluginType.RECORDER)
+            val workbook = workbookDataStore.workbook
+
             rec.audio.getNewTakeNumber()
                 .flatMapMaybe { takeNumber ->
                     workbookDataStore.activeTakeNumberProperty.set(takeNumber)
@@ -404,7 +406,7 @@ class RecordScriptureViewModel : ViewModel() {
                         TakeActions.Result.SUCCESS -> {
                             setMarker()
                             loadTakes()
-                            workbookDataStore.updateSelectedTakesFile()
+                            workbookDataStore.updateSelectedTakesFile(workbook)
                         }
                         TakeActions.Result.NO_AUDIO -> {
                             setMarker()

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/RecordScriptureViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/RecordScriptureViewModel.kt
@@ -383,7 +383,7 @@ class RecordScriptureViewModel : ViewModel() {
         closePlayers()
         recordable?.let { rec ->
             contextProperty.set(PluginType.RECORDER)
-            val updateOnSuccess = workbookDataStore.updateSelectedTakesFileAsync()
+            val updateOnSuccess = workbookDataStore.updateSelectedTakesFile()
 
             rec.audio.getNewTakeNumber()
                 .flatMapMaybe { takeNumber ->
@@ -450,7 +450,7 @@ class RecordScriptureViewModel : ViewModel() {
 
     fun selectTake(take: Take) {
         recordable?.audio?.selectTake(take) ?: throw IllegalStateException("Recordable is null")
-        workbookDataStore.updateSelectedTakesFile()
+        workbookDataStore.updateSelectedTakesFile().subscribe()
         take.file.setLastModified(System.currentTimeMillis())
     }
 

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/RecordScriptureViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/RecordScriptureViewModel.kt
@@ -383,7 +383,7 @@ class RecordScriptureViewModel : ViewModel() {
         closePlayers()
         recordable?.let { rec ->
             contextProperty.set(PluginType.RECORDER)
-            val workbook = workbookDataStore.workbook
+            val updateOnSuccess = workbookDataStore.updateSelectedTakesFileAsync()
 
             rec.audio.getNewTakeNumber()
                 .flatMapMaybe { takeNumber ->
@@ -406,7 +406,7 @@ class RecordScriptureViewModel : ViewModel() {
                         TakeActions.Result.SUCCESS -> {
                             setMarker()
                             loadTakes()
-                            workbookDataStore.updateSelectedTakesFile(workbook)
+                            updateOnSuccess.subscribe()
                         }
                         TakeActions.Result.NO_AUDIO -> {
                             setMarker()

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/RecordableViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/RecordableViewModel.kt
@@ -189,7 +189,7 @@ open class RecordableViewModel(
         }
         found?.let { takeModel ->
             recordable?.audio?.selectTake(takeModel.take) ?: throw IllegalStateException("Recordable is null")
-            workbookDataStore.updateSelectedTakesFile()
+            workbookDataStore.updateSelectedTakesFile().subscribe()
             take.file.setLastModified(System.currentTimeMillis())
             loadTakes()
         }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/WorkbookDataStore.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/WorkbookDataStore.kt
@@ -146,14 +146,20 @@ class WorkbookDataStore : Component(), ScopedInstance {
         activeProjectFilesAccessorProperty.set(projectFilesAccessor)
     }
 
-    fun updateSelectedTakesFile(wb: Workbook = this.workbook) {
-        Completable
+    fun updateSelectedTakesFile() {
+        updateSelectedTakesFileAsync().subscribe()
+    }
+
+    fun updateSelectedTakesFileAsync(): Completable {
+        val wb = workbook
+        val projectIsBook = activeResourceMetadata.identifier == wb.target.resourceMetadata.identifier
+        val projectFilesAccessor = activeProjectFilesAccessor
+
+        return Completable
             .fromCallable {
-                val projectIsBook = activeResourceMetadata.identifier == wb.target.resourceMetadata.identifier
-                activeProjectFilesAccessor.writeSelectedTakesFile(wb, projectIsBook)
+                projectFilesAccessor.writeSelectedTakesFile(wb, projectIsBook)
             }
             .subscribeOn(Schedulers.io())
-            .subscribe()
     }
 
     fun updateSourceAudio() {

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/WorkbookDataStore.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/WorkbookDataStore.kt
@@ -146,11 +146,11 @@ class WorkbookDataStore : Component(), ScopedInstance {
         activeProjectFilesAccessorProperty.set(projectFilesAccessor)
     }
 
-    fun updateSelectedTakesFile() {
+    fun updateSelectedTakesFile(wb: Workbook = this.workbook) {
         Completable
             .fromCallable {
-                val projectIsBook = activeResourceMetadata.identifier == workbook.target.resourceMetadata.identifier
-                activeProjectFilesAccessor.writeSelectedTakesFile(workbook, projectIsBook)
+                val projectIsBook = activeResourceMetadata.identifier == wb.target.resourceMetadata.identifier
+                activeProjectFilesAccessor.writeSelectedTakesFile(wb, projectIsBook)
             }
             .subscribeOn(Schedulers.io())
             .subscribe()

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/WorkbookDataStore.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/WorkbookDataStore.kt
@@ -146,11 +146,7 @@ class WorkbookDataStore : Component(), ScopedInstance {
         activeProjectFilesAccessorProperty.set(projectFilesAccessor)
     }
 
-    fun updateSelectedTakesFile() {
-        updateSelectedTakesFileAsync().subscribe()
-    }
-
-    fun updateSelectedTakesFileAsync(): Completable {
+    fun updateSelectedTakesFile(): Completable {
         val wb = workbook
         val projectIsBook = activeResourceMetadata.identifier == wb.target.resourceMetadata.identifier
         val projectFilesAccessor = activeProjectFilesAccessor


### PR DESCRIPTION
When we are recording (either chapter or verse/chunk), click on "Project" breadcrumb will navigate home and cause a crash.

The problem was that the view model was trying to update the selected.txt file, after the plugin returns SUCCESS, using the "activeWorkbookProperty". This property is set to null when HomePage is docked. Thus, we have a null pointer exception

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/704)
<!-- Reviewable:end -->
