### PR TITLE
Guard writing chunks file

### DIFF
--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/project/ProjectFilesAccessor.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/project/ProjectFilesAccessor.kt
@@ -281,9 +281,11 @@ class ProjectFilesAccessor(
     fun writeChunksFile(fileWriter: IFileWriter) {
         val inFile = projectDir.resolve(RcConstants.CHUNKS_FILE)
 
-        fileWriter.bufferedWriter(RcConstants.CHUNKS_FILE).use { _fileWriter ->
-            inFile.reader().use { _fileReader ->
-                _fileReader.transferTo(_fileWriter)
+        if (inFile.exists()) {
+            fileWriter.bufferedWriter(RcConstants.CHUNKS_FILE).use { _fileWriter ->
+                inFile.reader().use { _fileReader ->
+                    _fileReader.transferTo(_fileWriter)
+                }
             }
         }
     }


### PR DESCRIPTION
Exporting a chapter that was chunked verse by verse won't have a chunks file, which was causing a failure on export

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/710)
<!-- Reviewable:end -->
