### PR TITLE
Return from setProjectInfo for imports with multiple projects

### DIFF
--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/AddFilesViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/AddFilesViewModel.kt
@@ -166,9 +166,21 @@ class AddFilesViewModel : ViewModel() {
         }
     }
 
+    /**
+     * Sets the project title and cover art for the import dialog
+     *
+     * if the resource container has more than one project, the title and cover art will not be set
+     *
+     * @param rc The resource container file being imported
+     */
     private fun setProjectInfo(rc: File) {
         try {
-            val project = ResourceContainer.load(rc, true).use { it.project() }
+            val project = ResourceContainer.load(rc, true).use {
+                if (it.manifest.projects.size != 1) {
+                    return@use null
+                }
+                it.project()
+            }
             project?.let {
                 importProvider.get()
                     .getSourceMetadata(rc)


### PR DESCRIPTION
Rather than throw and catch an exception (thus spamming the logger), this just returns if the imported project has multiple projects.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/726)
<!-- Reviewable:end -->
