### PR TITLE
Handle table sort binding collisions

### DIFF
--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/tableview/CustomTableSortPolicy.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/tableview/CustomTableSortPolicy.kt
@@ -1,0 +1,63 @@
+package org.wycliffeassociates.otter.jvm.workbookapp.ui.components.tableview
+
+import javafx.collections.FXCollections
+import javafx.collections.transformation.SortedList
+import javafx.scene.control.TableColumn
+import javafx.scene.control.TableView
+import javafx.util.Callback
+import org.wycliffeassociates.otter.jvm.utils.onChangeAndDoNow
+import tornadofx.*
+
+/**
+ * Custom implementation of javafx DEFAULT_SORT_POLICY callback.
+ * This allows sorting from the backing collection and
+ * automatic sorting from the query filter.
+ *
+ * @see javafx.scene.control.TableView.DEFAULT_SORT_POLICY
+ */
+internal val CUSTOM_SORT_POLICY: Callback<TableView<Any>, Boolean> = Callback { table ->
+    try {
+        val itemsList = table.items
+        if (itemsList is SortedList<Any>) {
+            return@Callback true
+        } else {
+            if (itemsList == null || itemsList.isEmpty()) {
+                // sorting is not supported on null or empty lists
+                return@Callback true
+            }
+            val comparator = table.comparator ?: return@Callback true
+
+            // otherwise we attempt to do a manual sort, and if successful
+            // we return true
+            FXCollections.sort(itemsList, comparator)
+            return@Callback true
+        }
+    } catch (e: UnsupportedOperationException) {
+        return@Callback false
+    }
+}
+
+/**
+ * Updates the comparator when the user toggles sorting type on the column.
+ */
+fun <S, T> TableColumn<S, T>.bindColumnSortComparator() {
+    val list = tableView.items
+    sortTypeProperty().onChange {
+        if (list is SortedList<S>) {
+            list.comparator = tableView.comparator
+        }
+    }
+}
+
+/**
+ * Update the backing sorted list comparator when the table comparator changes.
+ * This handles the transition to "unsorted" state of the columns.
+ */
+fun <S> TableView<S>.bindTableSortComparator() {
+    val list = this.items
+    if (list is SortedList<S>) {
+        comparatorProperty().onChangeAndDoNow {
+            list.comparator = it
+        }
+    }
+}

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/tableview/CustomTableSortPolicy.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/tableview/CustomTableSortPolicy.kt
@@ -18,17 +18,10 @@ import tornadofx.*
 internal val CUSTOM_SORT_POLICY: Callback<TableView<Any>, Boolean> = Callback { table ->
     try {
         val itemsList = table.items
-        if (itemsList is SortedList<Any>) {
+        if (itemsList is SortedList<Any> || itemsList == null || itemsList.isEmpty()) {
             return@Callback true
         } else {
-            if (itemsList == null || itemsList.isEmpty()) {
-                // sorting is not supported on null or empty lists
-                return@Callback true
-            }
             val comparator = table.comparator ?: return@Callback true
-
-            // otherwise we attempt to do a manual sort, and if successful
-            // we return true
             FXCollections.sort(itemsList, comparator)
             return@Callback true
         }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/tableview/CustomTableSortPolicy.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/tableview/CustomTableSortPolicy.kt
@@ -38,7 +38,12 @@ internal val CUSTOM_SORT_POLICY: Callback<TableView<Any>, Boolean> = Callback { 
 }
 
 /**
- * Updates the comparator when the user toggles sorting type on the column.
+ * Updates the sort comparator when the user toggles between sorting types on the column.
+ * Use this method to allow sorting the table from the back-end, given the underlying
+ * table data is backed by a SortedList<T>.
+ *
+ * This method should be used in conjunction with [bindTableSortComparator] to handle
+ * the different states of the column sort.
  */
 fun <S, T> TableColumn<S, T>.bindColumnSortComparator() {
     val list = tableView.items
@@ -50,8 +55,11 @@ fun <S, T> TableColumn<S, T>.bindColumnSortComparator() {
 }
 
 /**
- * Update the backing sorted list comparator when the table comparator changes.
- * This handles the transition to "unsorted" state of the columns.
+ * Updates the backing sorted list comparator when the table comparator changes.
+ * This will handle the transition to "unsorted" state of the columns.
+ *
+ * Use this method in conjunction with [bindColumnSortComparator] to handle
+ * the different states of the column sort.
  */
 fun <S> TableView<S>.bindTableSortComparator() {
     val list = this.items

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/tableview/CustomTableSortPolicy.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/tableview/CustomTableSortPolicy.kt
@@ -10,8 +10,8 @@ import tornadofx.*
 
 /**
  * Custom implementation of javafx DEFAULT_SORT_POLICY callback.
- * This allows sorting from the backing collection and
- * automatic sorting from the query filter.
+ * This allows both manual sorting when then user clicks on the column
+ * and automatic sorting from the search filter.
  *
  * @see javafx.scene.control.TableView.DEFAULT_SORT_POLICY
  */

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/tableview/LanguageTableView.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/tableview/LanguageTableView.kt
@@ -1,10 +1,13 @@
 package org.wycliffeassociates.otter.jvm.workbookapp.ui.components.tableview
 
 import javafx.collections.ObservableList
+import javafx.collections.transformation.SortedList
 import javafx.event.EventTarget
 import javafx.scene.control.TableView
 import javafx.scene.layout.Priority
+import javafx.util.Callback
 import org.wycliffeassociates.otter.common.data.primitives.Language
+import org.wycliffeassociates.otter.jvm.utils.onChangeAndDoNow
 import tornadofx.*
 import tornadofx.FX.Companion.messages
 
@@ -26,6 +29,9 @@ class LanguageTableView(
                 }
             }
             isReorderable = false
+            isSortable = true
+
+            bindColumnSortComparator()
         }
         column(messages["anglicized"], String::class) {
             setCellValueFactory { it.value.anglicizedName.toProperty() }
@@ -36,6 +42,9 @@ class LanguageTableView(
                 }
             }
             isReorderable = false
+            isSortable = true
+
+            bindColumnSortComparator()
         }
         column(messages["code"], String::class) {
             setCellValueFactory { it.value.slug.toProperty() }
@@ -45,6 +54,9 @@ class LanguageTableView(
                 }
             }
             isReorderable = false
+            isSortable = true
+
+            bindColumnSortComparator()
         }
         column(messages["gateway"], Boolean::class) {
             setCellValueFactory { it.value.isGateway.toProperty() }
@@ -55,9 +67,15 @@ class LanguageTableView(
                 }
             }
             isReorderable = false
+            isSortable = true
+
+            bindColumnSortComparator()
         }
 
+        sortPolicy = CUSTOM_SORT_POLICY as (Callback<TableView<Language>, Boolean>)
         setRowFactory { LanguageTableRow() }
+
+        bindTableSortComparator()
     }
 }
 

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/tableview/WorkBookTableView.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/tableview/WorkBookTableView.kt
@@ -51,8 +51,11 @@ class WorkBookTableView(
             prefWidthProperty().bind(this@WorkBookTableView.widthProperty().multiply(0.25))
             minWidth = 120.0 // this may not be replaced with css
             isReorderable = false
+            isSortable = true
+
+            bindColumnSortComparator()
         }
-        column("", String::class).apply {
+        column(messages["code"], String::class).apply {
             addClass("table-view__column-header-row")
             setCellValueFactory { it.value.slug.toProperty() }
             cellFormat {
@@ -60,6 +63,9 @@ class WorkBookTableView(
             }
             minWidth = 70.0 // this may not be replaced with css
             isReorderable = false
+            isSortable = true
+
+            bindColumnSortComparator()
         }
         column(messages["anthology"], String::class).apply {
             addClass("table-view__column-header-row")
@@ -71,6 +77,9 @@ class WorkBookTableView(
                 }
             }
             isReorderable = false
+            isSortable = true
+
+            bindColumnSortComparator()
         }
         column(messages["progress"], Number::class) {
             setCellValueFactory { it.value.progress.toProperty() }
@@ -81,12 +90,18 @@ class WorkBookTableView(
                 }
             }
             isReorderable = false
+            isSortable = true
+
+            bindColumnSortComparator()
         }
         column("", Boolean::class) {
             addClass("table-column__status-icon-col")
             setCellValueFactory { SimpleBooleanProperty(it.value.hasSourceAudio) }
             setCellFactory { WorkbookSourceAudioTableCell() }
             isReorderable = false
+            isSortable = true
+
+            bindColumnSortComparator()
         }
         column("", WorkbookDescriptor::class) {
             setCellValueFactory { SimpleObjectProperty(it.value) }
@@ -100,6 +115,8 @@ class WorkBookTableView(
         setRowFactory {
             WorkbookTableRow()
         }
+
+        bindTableSortComparator()
     }
 }
 

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/HomePage2.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/HomePage2.kt
@@ -34,7 +34,7 @@ class HomePage2 : View() {
             fire(NavigationRequestEvent(this@HomePage2))
         }
     }
-    private val bookFragment = BookSection(viewModel.bookList, viewModel.filteredBooks).apply {
+    private val bookFragment = BookSection(viewModel.bookList, viewModel.sortedBooks).apply {
         bookSearchQueryProperty.bindBidirectional(viewModel.bookSearchQueryProperty)
     }
     private val wizardFragment: ProjectWizardSection by lazy {

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/HomePageViewModel2.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/HomePageViewModel2.kt
@@ -4,6 +4,7 @@ import com.github.thomasnield.rxkotlinfx.observeOnFx
 import javafx.beans.property.SimpleObjectProperty
 import javafx.beans.property.SimpleStringProperty
 import javafx.collections.transformation.FilteredList
+import javafx.collections.transformation.SortedList
 import org.slf4j.LoggerFactory
 import org.wycliffeassociates.otter.common.data.workbook.Workbook
 import org.wycliffeassociates.otter.common.data.workbook.WorkbookDescriptor
@@ -42,7 +43,8 @@ class HomePageViewModel2 : ViewModel() {
 
     val projectGroups = observableListOf<ProjectGroupCardModel>()
     val bookList = observableListOf<WorkbookDescriptor>()
-    val filteredBooks = FilteredList<WorkbookDescriptor>(bookList)
+    private val filteredBooks = FilteredList<WorkbookDescriptor>(bookList)
+    val sortedBooks = SortedList<WorkbookDescriptor>(filteredBooks)
 
     val selectedProjectGroup = SimpleObjectProperty<ProjectGroupKey>()
     val bookSearchQueryProperty = SimpleStringProperty("")


### PR DESCRIPTION
For search filter support which sorts the filtered items, we used a "burito" of `SortedList(FilteredList(ObservableList))` for the table data. However, this would cause some issue with the built-in sorting policy of javaFX TableView. This PR customizes the default sort policy to reconcile between the two ways of sorting.

https://github.com/openjdk/jfx/blob/master/modules/javafx.controls/src/main/java/javafx/scene/control/TableView.java#L573

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/757)
<!-- Reviewable:end -->
