### PR TITLE
Avoid double click on table row

### DIFF
--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/tableview/LanguageTableRow.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/tableview/LanguageTableRow.kt
@@ -3,7 +3,7 @@ package org.wycliffeassociates.otter.jvm.workbookapp.ui.components.tableview
 import javafx.scene.control.TableRow
 import org.wycliffeassociates.otter.common.data.primitives.Language
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.events.LanguageSelectedEvent
-import tornadofx.FX
+import tornadofx.*
 
 class LanguageTableRow : TableRow<Language>() {
     override fun updateItem(item: Language?, empty: Boolean) {
@@ -16,7 +16,9 @@ class LanguageTableRow : TableRow<Language>() {
 
         isMouseTransparent = false
         setOnMouseClicked {
-            FX.eventbus.fire(LanguageSelectedEvent(item))
+            if (it.clickCount == 1) { // avoid double fire()
+                FX.eventbus.fire(LanguageSelectedEvent(item))
+            }
         }
     }
 }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/tableview/WorkbookTableRow.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/tableview/WorkbookTableRow.kt
@@ -37,7 +37,9 @@ class WorkbookTableRow : TableRow<WorkbookDescriptor>() {
         isFocusTraversable = false
 
         setOnMouseClicked {
-            FX.eventbus.fire(WorkbookOpenEvent(item))
+            if (it.clickCount == 1) {
+                FX.eventbus.fire(WorkbookOpenEvent(item))
+            }
         }
     }
 }


### PR DESCRIPTION
Crashed when double-clicking when selecting the target language in project wizard

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/797)
<!-- Reviewable:end -->
