### PR TITLE
Fix crash when placing chunk marker

### DIFF
--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/model/VerseMarkerModel.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/model/VerseMarkerModel.kt
@@ -56,7 +56,10 @@ class VerseMarkerModel(
 
     init {
         cues as MutableList
-        if (cues.isEmpty() && markerLabels.isNotEmpty()) cues.add(AudioCue(0, markerLabels.first()))
+        if (cues.isEmpty()) {
+            cues.add(AudioCue(0, markerLabels.firstOrNull() ?: "1"))
+            labelIndex++
+        }
         cues.sortBy { it.location }
         markerCountProperty.value = cues.size
 
@@ -67,7 +70,8 @@ class VerseMarkerModel(
         if (markers.size < markerTotal) {
             changesSaved = false
 
-            val marker = ChunkMarkerModel(AudioCue(location, "${markerLabels[labelIndex]}}"))
+            val label = markerLabels.getOrElse(labelIndex) { labelIndex + 1 }.toString()
+            val marker = ChunkMarkerModel(AudioCue(location, label))
             val op = Add(marker)
             undoStack.push(op)
             op.apply()


### PR DESCRIPTION
When adding a chunk marker, the marker labels are empty and, thus, it throws IndexOutOfBound exception. This PR fixes the crash and also address the first marker automatically added
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/819)
<!-- Reviewable:end -->
