### PR TITLE
Fix potential bug with next verse

### DIFF
--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/NarrationTextCell.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/NarrationTextCell.kt
@@ -105,6 +105,7 @@ class NarrationTextCell(
 
             onNextVerseActionProperty.set(DebouncedEventHandler {
                 listView.apply {
+                    selectionModel.selectIndices(index)
                     selectionModel.selectNext()
 
                     // Scroll to the previous verse because scrolling to the active verse will cause
@@ -113,7 +114,11 @@ class NarrationTextCell(
                     // than the text needed to actively be narrated being off the screen.
                     scrollTo(selectionModel.selectedIndex - 1)
 
-                    FX.eventbus.fire(NextVerseEvent(selectionModel.selectedIndex, selectionModel.selectedItem.chunk))
+                    val nextVerseIndex = index + 1
+                    val nextVerse = items.getOrNull(nextVerseIndex)
+                    nextVerse?.let {
+                        FX.eventbus.fire(NextVerseEvent(nextVerseIndex, nextVerse.chunk))
+                    } ?: logger.error("Tried to select an invalid next verse! Tried to select: $nextVerseIndex from index $index")
                 }
             })
 


### PR DESCRIPTION
NextVerse can be pressed without the selected item being the Verse associated with the button click. This is most easily repeatable when resetting the chapter and scrolling back to verse 1 and recording again.

Instead, the Next Verse action fires based on the index value of the cell.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/843)
<!-- Reviewable:end -->
