### PR TITLE
Change the relay chunks structure in Chapter (#795)

### DIFF
--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/data/workbook/Chapter.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/data/workbook/Chapter.kt
@@ -18,13 +18,12 @@
  */
 package org.wycliffeassociates.otter.common.data.workbook
 
-import com.jakewharton.rxrelay2.ReplayRelay
+import com.jakewharton.rxrelay2.BehaviorRelay
+import io.reactivex.Maybe
 import io.reactivex.Observable
 import io.reactivex.Single
 import io.reactivex.rxkotlin.cast
-import io.reactivex.rxkotlin.toObservable
 import io.reactivex.schedulers.Schedulers
-import java.lang.Thread.sleep
 import java.util.*
 import org.wycliffeassociates.otter.common.data.primitives.Content
 import org.wycliffeassociates.otter.common.data.primitives.ContentType
@@ -39,14 +38,14 @@ class Chapter(
     override val audio: AssociatedAudio,
     override val resources: List<ResourceGroup>,
     override val subtreeResources: List<ResourceMetadata>,
-    private val lazychunks: Lazy<ReplayRelay<Chunk>>,
+    private val lazychunks: Lazy<BehaviorRelay<List<Chunk>>>,
     val chunkCount: Single<Int>,
     val addChunk: (List<Content>) -> Unit,
     val reset: () -> Unit
 ) : BookElement, BookElementContainer, Recordable {
 
     override val contentType: ContentType = ContentType.META
-    override val children: Observable<BookElement> = getDraft().cast()
+    override val children: Observable<BookElement> by lazy { getDraft().cast() }
 
     val chunks by lazychunks
 
@@ -60,29 +59,14 @@ class Chapter(
     fun getSelectedTake() = audio.selected.value?.value
 
     fun getDraft(): Observable<Chunk> {
-        return chunkCount
-            .toObservable()
-            .map {
-                (getLatestDraftFromRelay().blockingGet()).toObservable()
-            }
-            .flatMap { it }
+        return getLatestDraftFromRelay()
+            .flattenAsObservable { it }
+            .switchIfEmpty(Observable.empty<Chunk>())
             .subscribeOn(Schedulers.io())
     }
 
-    private fun getLatestDraftFromRelay(): Single<List<Chunk>> {
-        return Single.fromCallable {
-            val draft = mutableListOf<Chunk>()
-            val chunkTotal = chunkCount.blockingGet()
-            val disposable = chunks
-                .filter { it.draftNumber > 0 } // filter active drafts
-                .takeUntil { draft.size == chunkTotal }
-                .forEach { draft.add(it) }
-            while (draft.size != chunkTotal) {
-                sleep(50)
-            }
-            disposable.dispose()
-            draft.toList()
-        }.subscribeOn(Schedulers.io())
+    private fun getLatestDraftFromRelay(): Maybe<List<Chunk>> {
+        return Maybe.fromCallable { chunks.value }
     }
 
     private fun textItem(): TextItem {

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/content/ResetChunks.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/content/ResetChunks.kt
@@ -33,14 +33,15 @@ class ResetChunks @Inject constructor() {
     }
 
     private fun markTakesForDeletion(chapter: Chapter) {
-        chapter.chunks.getValues(emptyArray()).forEach { chunk ->
-            chunk.draftNumber = -1
-            chunk.audio.getAllTakes()
-                .filter { it.deletedTimestamp.value?.value == null }
-                .forEach { take ->
-                    take.deletedTimestamp.accept(DateHolder.now())
-                }
-        }
+        chapter.chunks.value
+            ?.forEach { chunk ->
+                chunk.draftNumber = -1
+                chunk.audio.getAllTakes()
+                    .filter { it.deletedTimestamp.value?.value == null }
+                    .forEach { take ->
+                        take.deletedTimestamp.accept(DateHolder.now())
+                    }
+            }
     }
 
     private fun removeChapterFromChunkFile(chunkFile: File, chapterNumber: Int) {

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/ChapterRepresentation.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/ChapterRepresentation.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.JsonMappingException
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import io.reactivex.rxkotlin.toObservable
 import io.reactivex.subjects.PublishSubject
 import org.slf4j.LoggerFactory
 import org.wycliffeassociates.otter.common.audio.AudioFileReader
@@ -69,7 +70,9 @@ internal class ChapterRepresentation(
 
     private fun initalizeActiveVerses(): MutableList<VerseNode> {
         return chapter
-            .getDraft()
+            .chunks
+            .take(1)
+            .flatMap { it.toObservable() }
             .map { chunk ->
                 VerseMarker(chunk.start, chunk.end, 0)
             }

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/project/exporter/resourcecontainer/RCProjectExporter.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/project/exporter/resourcecontainer/RCProjectExporter.kt
@@ -100,7 +100,7 @@ abstract class RCProjectExporter(
         return filterChaptersReadyToCompile(workbook.target.chapters)
             .flatMapCompletable { chapter ->
                 // compile the chapter
-                chapter.chunks.getValues(emptyArray())
+                chapter.chunks.value!! // available chunks after filtering
                     .mapNotNull { chunk -> chunk.audio.selected.value?.value?.file }
                     .let { takes ->
                         logger.info("Compiling chunk/verse takes for completed chapter #${chapter.sort}")
@@ -136,7 +136,11 @@ abstract class RCProjectExporter(
                 !chapter.hasSelectedAudio()
             }
             .filter { chapter ->
-                val chunks = chapter.chunks.getValues(emptyArray())
+                val chunks = if (chapter.chunks.hasValue()) {
+                    chapter.chunks.value!!
+                } else {
+                    return@filter false
+                }
 
                 // filter chapter where all its content are ready to compile
                 chunks.isNotEmpty() && chunks.all { chunk ->

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/project/importer/OngoingProjectImporter.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/project/importer/OngoingProjectImporter.kt
@@ -354,11 +354,9 @@ class OngoingProjectImporter @Inject constructor(
         val chapters = collectionRepository.getChildren(project).blockingGet()
         chapters.forEach { chapter ->
             if (chunks.containsKey(chapter.sort)) {
-                val contents = chunks[chapter.sort]
+                val contents = chunks[chapter.sort] ?: listOf()
                 contentRepository.deleteForCollection(chapter).blockingAwait()
-                contents?.forEach { content ->
-                    contentRepository.insertForCollection(content, chapter).blockingGet()
-                }
+                contentRepository.insertForCollection(contents, chapter).blockingGet()
             }
         }
     }

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/persistence/repositories/IContentRepository.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/persistence/repositories/IContentRepository.kt
@@ -27,10 +27,10 @@ import org.wycliffeassociates.otter.common.data.primitives.ContentType
 
 interface IContentRepository : IRepository<Content> {
     // Insert for a collection
-    fun insertForCollection(content: Content, collection: Collection): Single<Int>
+    fun insertForCollection(contentList: List<Content>, collection: Collection): Single<List<Content>>
     // Get all the chunks for a collection
     fun getByCollection(collection: Collection): Single<List<Content>>
-    fun getByCollectionWithPersistentConnection(collection: Collection): Observable<Content>
+    fun getByCollectionWithPersistentConnection(collection: Collection): Observable<List<Content>>
     // Get the collection meta-chunk
     fun getCollectionMetaContent(collection: Collection): Single<Content>
     // Get sources this content is derived from

--- a/common/src/test/kotlin/org/wycliffeassociates/otter/common/domain/content/ResetChunksTest.kt
+++ b/common/src/test/kotlin/org/wycliffeassociates/otter/common/domain/content/ResetChunksTest.kt
@@ -1,276 +1,272 @@
-//package org.wycliffeassociates.otter.common.domain.content
-//
-//import com.jakewharton.rxrelay2.ReplayRelay
-//import com.nhaarman.mockitokotlin2.any
-//import com.nhaarman.mockitokotlin2.doAnswer
-//import com.nhaarman.mockitokotlin2.mock
-//import com.nhaarman.mockitokotlin2.whenever
-//import io.reactivex.Completable
-//import io.reactivex.Single
-//import org.junit.Assert
-//import org.junit.Before
-//import org.junit.Rule
-//import org.junit.Test
-//import org.junit.rules.TemporaryFolder
-//import org.wycliffeassociates.otter.common.*
-//import org.wycliffeassociates.otter.common.audio.AudioCue
-//import org.wycliffeassociates.otter.common.domain.audio.OratureAudioFile
-//import org.wycliffeassociates.otter.common.data.primitives.*
-//import org.wycliffeassociates.otter.common.data.primitives.Collection
-//import org.wycliffeassociates.otter.common.data.workbook.Chapter
-//import org.wycliffeassociates.otter.common.data.workbook.Translation
-//import org.wycliffeassociates.otter.common.data.workbook.Workbook
-//import org.wycliffeassociates.otter.common.domain.resourcecontainer.SourceAudioAccessor
-//import org.wycliffeassociates.otter.common.domain.resourcecontainer.project.ProjectFilesAccessor
-//import org.wycliffeassociates.otter.common.domain.resourcecontainer.RcConstants
-//import org.wycliffeassociates.otter.common.persistence.IDirectoryProvider
-//import org.wycliffeassociates.otter.common.persistence.repositories.IWorkbookDatabaseAccessors
-//import org.wycliffeassociates.otter.common.persistence.repositories.WorkbookRepository
-//import org.wycliffeassociates.resourcecontainer.ResourceContainer
-//import org.wycliffeassociates.resourcecontainer.entity.DublinCore
-//import java.io.File
-//import java.time.LocalDate
-//
-//class ResetChunksTest {
-//
-//    @JvmField @Rule
-//    val tempDir = TemporaryFolder()
-//    @JvmField @Rule
-//    val projectDir = TemporaryFolder()
-//
-//    private val mockedDirectoryProvider = mock<IDirectoryProvider>()
-//    private val mockedDb = mock<IWorkbookDatabaseAccessors>()
-//
-//    private lateinit var projectFilesAccessor: ProjectFilesAccessor
-//    private lateinit var audioSourceAudioAccessor: SourceAudioAccessor
-//    private lateinit var sourceAudioDir: File
-//
-//    private var autoincrement: Int = 1
-//        get() = field++
-//
-//    private val english = getEnglishLanguage(autoincrement)
-//    private val spanish = getSpanishLanguage(autoincrement)
-//
-//    private val rcBase = getResourceMetadata(english)
-//    private lateinit var rcSource: ResourceMetadata
-//    private lateinit var rcTarget: ResourceMetadata
-//    private lateinit var dublinCore: DublinCore
-//
-//    private val collectionBase = getGenesisCollection()
-//    private lateinit var collSource: Collection
-//    private lateinit var collTarget: Collection
-//
-//    private lateinit var workbook: Workbook
-//    private lateinit var chapter: Chapter
-//    private lateinit var rc: ResourceContainer
-//
-//    private var clearContentForCollectionTriggered = false
-//
-//    private object BasicTestParams {
-//        const val chaptersPerBook = 3
-//        const val chunksPerChapter = 5
-//    }
-//
-//    @Before
-//    fun setup() {
-//        mockedDb.apply {
-//            whenever(
-//                getTranslation(any(), any())
-//            ).thenReturn(
-//                Single.just(
-//                    Translation(
-//                        english,
-//                        spanish,
-//                        null
-//                    )
-//                )
-//            )
-//            whenever(
-//                getChildren(any())
-//            ).thenAnswer { invocation ->
-//                val collection = invocation.getArgument<Collection>(0)!!
-//                Single.just(
-//                    when (collection.slug.count { it == '_' }) {
-//                        0 -> {
-//                            (1..BasicTestParams.chaptersPerBook).map { chapter ->
-//                                Collection(
-//                                    sort = chapter,
-//                                    slug = collection.slug + "_" + chapter,
-//                                    id = autoincrement,
-//                                    resourceContainer = collection.resourceContainer,
-//                                    titleKey = chapter.toString(),
-//                                    labelKey = ContentLabel.CHAPTER.value
-//                                )
-//                            }
-//                        }
-//                        else -> emptyList()
-//                    }
-//                )
-//            }
-//            whenever(
-//                getCollectionMetaContent(any())
-//            ).thenReturn(
-//                Single.just(
-//                    Content(
-//                        sort = 0,
-//                        labelKey = ContentLabel.CHAPTER.value,
-//                        start = 1,
-//                        end = BasicTestParams.chunksPerChapter,
-//                        selectedTake = null,
-//                        text = null,
-//                        format = "WAV",
-//                        type = ContentType.META,
-//                        id = autoincrement,
-//                        draftNumber = 1
-//                    )
-//                )
-//            )
-//            whenever(
-//                getTakeByContent(any())
-//            ).thenAnswer { invocation ->
-//                val content = invocation.getArgument<Content>(0)!!
-//                val take = if (content.format == "audio/wav") {
-//                    val id = autoincrement
-//                    Take(
-//                        id = id,
-//                        number = id,
-//                        path = File("."),
-//                        filename = ".",
-//                        markers = listOf(),
-//                        played = false,
-//                        created = LocalDate.now(),
-//                        deleted = null
-//                    )
-//                } else {
-//                    null
-//                }
-//                Single.just(listOfNotNull(take))
-//            }
-//            whenever(
-//                getChunkCount(any())
-//            ).thenAnswer { invocation ->
-//                val collection = invocation.getArgument<Collection>(0)!!
-//                when (collection.slug.count { it == '_' }) {
-//                    1 -> {
-//                        Single.just(BasicTestParams.chunksPerChapter)
-//                    }
-//                    else -> {
-//                        Single.just(0)
-//                    }
-//                }
-//            }
-//            whenever(getContentByCollectionActiveConnection(any())).thenAnswer { invocation ->
-//                val collection = invocation.getArgument<Collection>(0)!!
-//                val format = if (collection.resourceContainer == rcTarget) "audio/wav" else "text/usfm"
-//
-//                val rr = ReplayRelay.create<Content>()
-//                when (collection.slug.count { it == '_' }) {
-//                    1 -> {
-//                        listOf(
-//                            rr.accept(
-//                                Content(
-//                                    id = autoincrement,
-//                                    start = 1,
-//                                    end = 1,
-//                                    sort = 1,
-//                                    labelKey = ContentLabel.VERSE.value,
-//                                    type = ContentType.TEXT,
-//                                    format = format,
-//                                    text = "/v 1 but test everything; hold fast what is good.",
-//                                    selectedTake = null,
-//                                    draftNumber = 1
-//                                )
-//                            )
-//                        )
-//                    }
-//                    else -> {}
-//                }
-//                rr
-//            }
-//            whenever(clearContentForCollection(any(), any()))
-//                .doAnswer {
-//                    clearContentForCollectionTriggered = true
-//                    Single.just(emptyList())
-//                }
-//            whenever(addContentForCollection(any(), any())).thenReturn(Completable.complete())
-//        }
-//
-//        rcSource = rcBase.copy(id = autoincrement, language = english, path = projectDir.root)
-//        rcTarget = rcBase.copy(id = autoincrement, language = spanish)
-//
-//        collSource = collectionBase.copy(resourceContainer = rcSource, id = autoincrement)
-//        collTarget = collectionBase.copy(resourceContainer = rcTarget, id = autoincrement)
-//
-//        dublinCore = getDublinCore(rcSource)
-//
-//        sourceAudioDir = projectDir.newFolder(*RcConstants.SOURCE_AUDIO_DIR.split("/").toTypedArray())
-//
-//        mockedDirectoryProvider.apply {
-//            whenever(getProjectDirectory(any(), any(), any() as Collection)).thenReturn(projectDir.root)
-//            whenever(getProjectSourceAudioDirectory(any(), any(), any())).thenReturn(sourceAudioDir)
-//        }
-//
-//        projectFilesAccessor = ProjectFilesAccessor(mockedDirectoryProvider, rcSource, rcTarget, collTarget)
-//        audioSourceAudioAccessor = SourceAudioAccessor(mockedDirectoryProvider, rcSource, collSource.slug)
-//
-//        workbook = buildWorkbook(mockedDirectoryProvider, mockedDb, collSource, collTarget)
-//        chapter = workbook.target.chapters.blockingFirst()
-//
-//        rc = createRcWithAudio()
-//    }
-//
-//    @Test
-//    fun sourceFilesDeleted() {
-//        Assert.assertEquals(projectFilesAccessor.sourceAudioDir.listFiles()?.size ?: 0, 2)
-//        ResetChunks().resetChapter(projectFilesAccessor, chapter)
-//        Assert.assertEquals(projectFilesAccessor.sourceAudioDir.listFiles()?.size ?: 0, 0)
-//    }
-//
-//    @Test
-//    fun clearContentForCollectionTriggered() {
-//        ResetChunks().resetChapter(projectFilesAccessor, chapter)
-//        Assert.assertEquals(true, clearContentForCollectionTriggered)
-//
-//        chapter.chunks.getValues(emptyArray()).forEach {
-//            Assert.assertEquals(-1, it.draftNumber)
-//        }
-//    }
-//
-//    @Test
-//    fun takesMarkedForDeletion() {
-//        val takes = chapter.chunks.getValues(emptyArray()).map { chunk ->
-//            chunk.audio.getAllTakes().filter { it.deletedTimestamp.value?.value == null }
-//        }
-//        Assert.assertEquals(1, takes.size)
-//
-//        ResetChunks().resetChapter(projectFilesAccessor, chapter)
-//
-//        val deletedTakes = chapter.chunks.getValues(emptyArray()).map { chunk ->
-//            chunk.audio.getAllTakes().filter { it.deletedTimestamp.value?.value != null }
-//        }
-//        Assert.assertEquals(1, deletedTakes.size)
-//    }
-//
-//    private fun createRcWithAudio(): ResourceContainer {
-//        val fileName = templateAudioFileName(
-//            rcSource.language.slug, rcSource.identifier, collSource.slug, "{chapter}"
-//        )
-//        val sourceFile = createWavFile(tempDir.root, "${fileName.replace("{chapter}", "1")}.wav", "123456".toByteArray())
-//        val sourceCueFile = File(tempDir.root, "${fileName.replace("{chapter}", "1")}.cue").apply { createNewFile() }
-//
-//        val audio = OratureAudioFile(sourceFile)
-//        audio.clearCues()
-//        audio.update()
-//        val sourceCues = listOf(
-//            AudioCue(0, "1"),
-//            AudioCue(10, "2"),
-//            AudioCue(20, "3"),
-//            AudioCue(30, "4"),
-//            AudioCue(40, "5")
-//        )
-//        audio.importCues(sourceCues)
-//        audio.update()
-//
-//        return createTestRc(projectDir.root, dublinCore, listOf(sourceFile, sourceCueFile))
-//    }
-//}
+package org.wycliffeassociates.otter.common.domain.content
+
+import com.jakewharton.rxrelay2.BehaviorRelay
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.doAnswer
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import io.reactivex.Completable
+import io.reactivex.Single
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.wycliffeassociates.otter.common.*
+import org.wycliffeassociates.otter.common.audio.AudioCue
+import org.wycliffeassociates.otter.common.domain.audio.OratureAudioFile
+import org.wycliffeassociates.otter.common.data.primitives.*
+import org.wycliffeassociates.otter.common.data.primitives.Collection
+import org.wycliffeassociates.otter.common.data.workbook.Chapter
+import org.wycliffeassociates.otter.common.data.workbook.Translation
+import org.wycliffeassociates.otter.common.data.workbook.Workbook
+import org.wycliffeassociates.otter.common.domain.resourcecontainer.SourceAudioAccessor
+import org.wycliffeassociates.otter.common.domain.resourcecontainer.project.ProjectFilesAccessor
+import org.wycliffeassociates.otter.common.domain.resourcecontainer.RcConstants
+import org.wycliffeassociates.otter.common.persistence.IDirectoryProvider
+import org.wycliffeassociates.otter.common.persistence.repositories.IWorkbookDatabaseAccessors
+import org.wycliffeassociates.resourcecontainer.ResourceContainer
+import org.wycliffeassociates.resourcecontainer.entity.DublinCore
+import java.io.File
+import java.time.LocalDate
+
+class ResetChunksTest {
+
+    @JvmField @Rule
+    val tempDir = TemporaryFolder()
+    @JvmField @Rule
+    val projectDir = TemporaryFolder()
+
+    private val mockedDirectoryProvider = mock<IDirectoryProvider>()
+    private val mockedDb = mock<IWorkbookDatabaseAccessors>()
+
+    private lateinit var projectFilesAccessor: ProjectFilesAccessor
+    private lateinit var audioSourceAudioAccessor: SourceAudioAccessor
+    private lateinit var sourceAudioDir: File
+
+    private var autoincrement: Int = 1
+        get() = field++
+
+    private val english = getEnglishLanguage(autoincrement)
+    private val spanish = getSpanishLanguage(autoincrement)
+
+    private val rcBase = getResourceMetadata(english)
+    private lateinit var rcSource: ResourceMetadata
+    private lateinit var rcTarget: ResourceMetadata
+    private lateinit var dublinCore: DublinCore
+
+    private val collectionBase = getGenesisCollection()
+    private lateinit var collSource: Collection
+    private lateinit var collTarget: Collection
+
+    private lateinit var workbook: Workbook
+    private lateinit var chapter: Chapter
+    private lateinit var rc: ResourceContainer
+
+    private var clearContentForCollectionTriggered = false
+
+    private object BasicTestParams {
+        const val chaptersPerBook = 3
+        const val chunksPerChapter = 5
+    }
+
+    @Before
+    fun setup() {
+        mockedDb.apply {
+            whenever(
+                getTranslation(any(), any())
+            ).thenReturn(
+                Single.just(
+                    Translation(
+                        english,
+                        spanish,
+                        null
+                    )
+                )
+            )
+            whenever(
+                getChildren(any())
+            ).thenAnswer { invocation ->
+                val collection = invocation.getArgument<Collection>(0)!!
+                Single.just(
+                    when (collection.slug.count { it == '_' }) {
+                        0 -> {
+                            (1..BasicTestParams.chaptersPerBook).map { chapter ->
+                                Collection(
+                                    sort = chapter,
+                                    slug = collection.slug + "_" + chapter,
+                                    id = autoincrement,
+                                    resourceContainer = collection.resourceContainer,
+                                    titleKey = chapter.toString(),
+                                    labelKey = ContentLabel.CHAPTER.value
+                                )
+                            }
+                        }
+                        else -> emptyList()
+                    }
+                )
+            }
+            whenever(
+                getCollectionMetaContent(any())
+            ).thenReturn(
+                Single.just(
+                    Content(
+                        sort = 0,
+                        labelKey = ContentLabel.CHAPTER.value,
+                        start = 1,
+                        end = BasicTestParams.chunksPerChapter,
+                        selectedTake = null,
+                        text = null,
+                        format = "WAV",
+                        type = ContentType.META,
+                        id = autoincrement,
+                        draftNumber = 1
+                    )
+                )
+            )
+            whenever(
+                getTakeByContent(any())
+            ).thenAnswer { invocation ->
+                val content = invocation.getArgument<Content>(0)!!
+                val take = if (content.format == "audio/wav") {
+                    val id = autoincrement
+                    Take(
+                        id = id,
+                        number = id,
+                        path = File("."),
+                        filename = ".",
+                        markers = listOf(),
+                        played = false,
+                        created = LocalDate.now(),
+                        deleted = null
+                    )
+                } else {
+                    null
+                }
+                Single.just(listOfNotNull(take))
+            }
+            whenever(
+                getChunkCount(any())
+            ).thenAnswer { invocation ->
+                val collection = invocation.getArgument<Collection>(0)!!
+                when (collection.slug.count { it == '_' }) {
+                    1 -> {
+                        Single.just(BasicTestParams.chunksPerChapter)
+                    }
+                    else -> {
+                        Single.just(0)
+                    }
+                }
+            }
+            whenever(getContentByCollectionActiveConnection(any())).thenAnswer { invocation ->
+                val collection = invocation.getArgument<Collection>(0)!!
+                val format = if (collection.resourceContainer == rcTarget) "audio/wav" else "text/usfm"
+
+                val relay = BehaviorRelay.create<List<Content>>()
+                when (collection.slug.count { it == '_' }) {
+                    1 -> {
+                        val content = Content(
+                            id = autoincrement,
+                            start = 1,
+                            end = 1,
+                            sort = 1,
+                            labelKey = ContentLabel.VERSE.value,
+                            type = ContentType.TEXT,
+                            format = format,
+                            text = "/v 1 but test everything; hold fast what is good.",
+                            selectedTake = null,
+                            draftNumber = 1
+                        )
+                        relay.accept(listOf(content))
+                    }
+                    else -> {}
+                }
+                relay
+            }
+            whenever(clearContentForCollection(any(), any()))
+                .doAnswer {
+                    clearContentForCollectionTriggered = true
+                    Single.just(emptyList())
+                }
+            whenever(addContentForCollection(any(), any())).thenReturn(Completable.complete())
+        }
+
+        rcSource = rcBase.copy(id = autoincrement, language = english, path = projectDir.root)
+        rcTarget = rcBase.copy(id = autoincrement, language = spanish)
+
+        collSource = collectionBase.copy(resourceContainer = rcSource, id = autoincrement)
+        collTarget = collectionBase.copy(resourceContainer = rcTarget, id = autoincrement)
+
+        dublinCore = getDublinCore(rcSource)
+
+        sourceAudioDir = projectDir.newFolder(*RcConstants.SOURCE_AUDIO_DIR.split("/").toTypedArray())
+
+        mockedDirectoryProvider.apply {
+            whenever(getProjectDirectory(any(), any(), any() as Collection)).thenReturn(projectDir.root)
+            whenever(getProjectSourceAudioDirectory(any(), any(), any())).thenReturn(sourceAudioDir)
+        }
+
+        projectFilesAccessor = ProjectFilesAccessor(mockedDirectoryProvider, rcSource, rcTarget, collTarget)
+        audioSourceAudioAccessor = SourceAudioAccessor(mockedDirectoryProvider, rcSource, collSource.slug)
+
+        workbook = buildWorkbook(mockedDirectoryProvider, mockedDb, collSource, collTarget)
+        chapter = workbook.target.chapters.blockingFirst()
+
+        rc = createRcWithAudio()
+    }
+
+    @Test
+    fun sourceFilesDeleted() {
+        Assert.assertEquals(projectFilesAccessor.sourceAudioDir.listFiles()?.size ?: 0, 2)
+        ResetChunks().resetChapter(projectFilesAccessor, chapter)
+        Assert.assertEquals(projectFilesAccessor.sourceAudioDir.listFiles()?.size ?: 0, 0)
+    }
+
+    @Test
+    fun clearContentForCollectionTriggered() {
+        ResetChunks().resetChapter(projectFilesAccessor, chapter)
+        Assert.assertEquals(true, clearContentForCollectionTriggered)
+
+        chapter.chunks.take(1).blockingFirst().forEach {
+            Assert.assertEquals(-1, it.draftNumber)
+        }
+    }
+
+    @Test
+    fun takesMarkedForDeletion() {
+        val takes = chapter.chunks.take(1).blockingFirst().map { chunk ->
+            chunk.audio.getAllTakes().filter { it.deletedTimestamp.value?.value == null }
+        }
+        Assert.assertEquals(1, takes.size)
+
+        ResetChunks().resetChapter(projectFilesAccessor, chapter)
+
+        val deletedTakes = chapter.chunks.take(1).blockingFirst().map { chunk ->
+            chunk.audio.getAllTakes().filter { it.deletedTimestamp.value?.value != null }
+        }
+        Assert.assertEquals(1, deletedTakes.size)
+    }
+
+    private fun createRcWithAudio(): ResourceContainer {
+        val fileName = templateAudioFileName(
+            rcSource.language.slug, rcSource.identifier, collSource.slug, "{chapter}"
+        )
+        val sourceFile = createWavFile(tempDir.root, "${fileName.replace("{chapter}", "1")}.wav", "123456".toByteArray())
+        val sourceCueFile = File(tempDir.root, "${fileName.replace("{chapter}", "1")}.cue").apply { createNewFile() }
+
+        val audio = OratureAudioFile(sourceFile)
+        audio.clearCues()
+        audio.update()
+        val sourceCues = listOf(
+            AudioCue(0, "1"),
+            AudioCue(10, "2"),
+            AudioCue(20, "3"),
+            AudioCue(30, "4"),
+            AudioCue(40, "5")
+        )
+        audio.importCues(sourceCues)
+        audio.update()
+
+        return createTestRc(projectDir.root, dublinCore, listOf(sourceFile, sourceCueFile))
+    }
+}

--- a/jvm/workbookapp/src/integration-test/kotlin/integrationtest/projects/export/TestSourceProjectExporter.kt
+++ b/jvm/workbookapp/src/integration-test/kotlin/integrationtest/projects/export/TestSourceProjectExporter.kt
@@ -51,6 +51,7 @@ import org.wycliffeassociates.otter.common.persistence.repositories.IWorkbookRep
 import org.wycliffeassociates.resourcecontainer.ResourceContainer
 import java.io.File
 import java.time.LocalDate
+import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import javax.inject.Provider
 import kotlin.io.path.createTempDirectory
@@ -255,10 +256,13 @@ class TestSourceProjectExporter {
             LocalDate.now()
         )
         // select take for each chunk so that the chapter is ready to compile
-        workbook.target
+        val chapter = workbook.target
             .chapters.blockingFirst()
-            .chunks
-            .forEach {
+        chapter
+            .chunks.take(1)
+            .timeout(5, TimeUnit.SECONDS)
+            .blockingFirst()
+            ?.forEach {
                 it.audio.selectTake(take)
             }
 

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/NarrationHistory.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/NarrationHistory.kt
@@ -52,8 +52,8 @@ class NarrationHistory @Inject constructor(private val directoryProvider: IDirec
             }
         }
 
-        val chunks = chapter.chunks.getValues(emptyArray())
-            .associate { chunk ->
+        val chunks = chapter.chunks.value
+            ?.associate { chunk ->
                 val chunkTake = chunk.audio.lastTake()
                 chunkTake?.file?.let { file ->
                     val chunkTemp = directoryProvider.createTempFile(
@@ -63,7 +63,7 @@ class NarrationHistory @Inject constructor(private val directoryProvider: IDirec
                     file.copyTo(chunkTemp, true)
                     chunk.sort to chunkTemp
                 } ?: (chunk.sort to null)
-            }
+            } ?: mapOf()
 
         val snapshot = Snapshot(
             chapterTemp,
@@ -142,7 +142,7 @@ class NarrationHistory @Inject constructor(private val directoryProvider: IDirec
             chapter.audio.insertTake(take)
         }
 
-        val chunks = chapter.chunks.getValues(emptyArray())
+        val chunks = chapter.chunks.value ?: listOf()
         chunks.forEach { chunk ->
             val chunkTake = chunk.audio.lastTake()
             val chunkCached = snapshot.chunks[chunk.sort]

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/AudioPluginViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/AudioPluginViewModel.kt
@@ -97,8 +97,11 @@ class AudioPluginViewModel : ViewModel() {
         val chapterLabel = messages[workbookDataStore.activeChapterProperty.value.label]
         val chapterNumber = workbookDataStore.activeChapterProperty.value.sort
 
-        val verseLabels = workbookDataStore.getSourceChapter().map { it.getDraft() }.blockingGet().map { it.title }.toList().blockingGet()
-        val verseTotal =  workbookDataStore.getSourceChapter().map { it.chunkCount }.blockingGet().blockingGet()
+        val verseLabels = workbookDataStore.getSourceChapter()
+            .map { it.getDraft() }.blockingGet()
+            .map { it.title }.toList()
+            .blockingGet()
+        val verseTotal =  workbookDataStore.getSourceChapter().flatMapSingle { it.chunkCount }.blockingGet()
         val chunkLabel = workbookDataStore.activeChunkProperty.value?.let {
             messages[workbookDataStore.activeChunkProperty.value.label]
         }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ChapterPageViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ChapterPageViewModel.kt
@@ -19,6 +19,7 @@
 package org.wycliffeassociates.otter.jvm.workbookapp.ui.viewmodel
 
 import com.github.thomasnield.rxkotlinfx.observeOnFx
+import io.reactivex.Maybe
 import io.reactivex.Observable
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.schedulers.Schedulers
@@ -171,7 +172,9 @@ class ChapterPageViewModel : ViewModel() {
     }
 
     fun setWorkChunk() {
-        if (filteredContent.isEmpty()) { return }
+        if (filteredContent.isEmpty()) {
+            return
+        }
 
         val hasTakes = filteredContent.any { chunk ->
             chunk.chunkSource?.audio?.getAllTakes()
@@ -223,6 +226,7 @@ class ChapterPageViewModel : ViewModel() {
                         PluginActions.Result.SUCCESS -> {
                             updateOnSuccess.subscribe()
                         }
+
                         PluginActions.Result.NO_AUDIO -> {
                             /* no-op */
                         }
@@ -345,12 +349,15 @@ class ChapterPageViewModel : ViewModel() {
                     PluginType.RECORDER -> {
                         audioPluginViewModel.selectedRecorderProperty.value?.name
                     }
+
                     PluginType.EDITOR -> {
                         audioPluginViewModel.selectedEditorProperty.value?.name
                     }
+
                     PluginType.MARKER -> {
                         audioPluginViewModel.selectedMarkerProperty.value?.name
                     }
+
                     null -> throw IllegalStateException("Action is not supported!")
                 }
             },
@@ -371,9 +378,10 @@ class ChapterPageViewModel : ViewModel() {
         allContent.clear()
         loading = true
         return chapter.chunks
-            .map {
-                CardData(it)
+            .flatMap {
+                Observable.fromIterable(it)
             }
+            .map { CardData(it) }
             .map {
                 buildTakes(it)
                 it.player = getPlayer()
@@ -388,15 +396,15 @@ class ChapterPageViewModel : ViewModel() {
             .doOnError { e ->
                 logger.error("Error in loading chapter contents for chapter: $chapter", e)
             }
-            .map {
-                if (it.chunkSource != null) {
-                    if (it.chunkSource.draftNumber > 0) {
-                        if (filteredContent.find { cont -> it.sort == cont.sort } == null) {
-                            filteredContent.add(it)
+            .map { cardData ->
+                if (cardData.chunkSource != null) {
+                    if (cardData.chunkSource.draftNumber > 0) {
+                        if (filteredContent.find { cont -> cardData.sort == cont.sort } == null) {
+                            filteredContent.add(cardData)
                         }
                     }
                 } else {
-                    filteredContent.add(it)
+                    filteredContent.add(cardData)
                 }
 
                 filteredContent.removeIf { card ->
@@ -404,8 +412,9 @@ class ChapterPageViewModel : ViewModel() {
                 }
                 filteredContent.sortBy { it.sort }
                 setWorkChunk()
-                it
-            }.observeOnFx()
+                cardData
+            }
+            .observeOnFx()
     }
 
     private fun subscribeSelectedTakePropertyToRelay(audio: AssociatedAudio) {

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ExportProjectViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ExportProjectViewModel.kt
@@ -61,7 +61,7 @@ class ExportProjectViewModel : ViewModel() {
                             chapter.hasSelectedAudio() -> 1.0
                             chunkCount != 0 -> {
                                 // collect chunks from the relay as soon as it starts emitting (blocking)
-                                val chunkWithAudio = chapter.chunks.take(chunkCount.toLong()).blockingIterable()
+                                val chunkWithAudio = chapter.chunks.value!!
                                     .count { it.hasSelectedAudio() }
 
                                 chunkWithAudio.toDouble() / chunkCount

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/WorkbookDataStore.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/WorkbookDataStore.kt
@@ -193,13 +193,13 @@ class WorkbookDataStore : Component(), ScopedInstance {
 
     fun getSourceChunk(): Maybe<Chunk> {
         return getSourceChapter()
-            .flatMap { _chapter ->
+            .map { _chapter ->
                 _chapter
                     .chunks
-                    .filter { _chunk ->
+                    .value
+                    ?.find { _chunk ->
                         _chunk.sort == chunk?.sort
                     }
-                    .firstElement()
             }
     }
 }

--- a/jvm/workbookapp/src/test/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/AudioDataStoreTest.kt
+++ b/jvm/workbookapp/src/test/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/AudioDataStoreTest.kt
@@ -18,6 +18,7 @@
  */
 package org.wycliffeassociates.otter.jvm.workbookapp.ui.viewmodel
 
+import com.jakewharton.rxrelay2.BehaviorRelay
 import com.jakewharton.rxrelay2.ReplayRelay
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.doReturn
@@ -137,8 +138,8 @@ class AudioDataStoreTest {
         }
 
         private fun createChapter(chunk: Chunk): Chapter {
-            val chunks = ReplayRelay.create<Chunk>()
-            chunks.accept(chunk)
+            val chunks = BehaviorRelay.create<List<Chunk>>()
+            chunks.accept(listOf(chunk))
             return Chapter(
                 1,
                 "1",

--- a/jvm/workbookapp/src/test/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/RecordScriptureViewModelTest.kt
+++ b/jvm/workbookapp/src/test/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/RecordScriptureViewModelTest.kt
@@ -18,6 +18,7 @@
  */
 package org.wycliffeassociates.otter.jvm.workbookapp.ui.viewmodel
 
+import com.jakewharton.rxrelay2.BehaviorRelay
 import com.jakewharton.rxrelay2.ReplayRelay
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.doReturn
@@ -143,8 +144,8 @@ class RecordScriptureViewModelTest {
 
         private fun createChapter(): Chapter {
             chunk1 = createChunk()
-            val chunks = ReplayRelay.create<Chunk>()
-            chunks.accept(chunk1)
+            val chunks = BehaviorRelay.create<List<Chunk>>()
+            chunks.accept(listOf(chunk1))
             return Chapter(
                 1,
                 "1",

--- a/jvm/workbookapp/src/test/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/WorkbookDataStoreTest.kt
+++ b/jvm/workbookapp/src/test/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/WorkbookDataStoreTest.kt
@@ -18,6 +18,7 @@
  */
 package org.wycliffeassociates.otter.jvm.workbookapp.ui.viewmodel
 
+import com.jakewharton.rxrelay2.BehaviorRelay
 import com.jakewharton.rxrelay2.ReplayRelay
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.doReturn
@@ -50,7 +51,6 @@ import org.wycliffeassociates.otter.jvm.device.ConfigureAudioSystem
 import org.wycliffeassociates.otter.jvm.workbookapp.utils.writeWavFile
 import tornadofx.*
 import java.io.File
-import java.time.LocalDate
 import java.time.LocalDateTime
 
 class WorkbookDataStoreTest {
@@ -137,8 +137,8 @@ class WorkbookDataStoreTest {
         }
 
         private fun createChapter(chunk: Chunk): Chapter {
-            val chunks = ReplayRelay.create<Chunk>()
-            chunks.accept(chunk)
+            val chunks = BehaviorRelay.create<List<Chunk>>()
+            chunks.accept(listOf(chunk))
             return Chapter(
                 1,
                 "1",


### PR DESCRIPTION
Rather than have a Relay emitting Chunks one at a time, which has no terminal event (due to the need to keep the relay open for rechunking), we instead replace this to emit List<Chunk>. This allows each emission to carry with it all chunks in the chapter.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/847)
<!-- Reviewable:end -->
