### PR TITLE
Catch the ListView scroll bug, log and ignore it.

### DIFF
--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/NarrationTextCell.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/NarrationTextCell.kt
@@ -88,8 +88,6 @@ class NarrationTextCell(
             verseLabelProperty.set(item.chunk.title)
             verseTextProperty.set(item.chunk.textItem.text)
 
-            logger.info("Item $index hasRecording: ${item.hasRecording}")
-
             hasRecordingProperty.set(item.hasRecording)
             recordButtonTextProperty.bind(this@NarrationTextCell.recordButtonTextProperty)
             isRecordingProperty.bind(this@NarrationTextCell.isRecordingProperty)


### PR DESCRIPTION
Prevents arbitrary crashes when scrolling around the Teleprompter in the NarrationPage. A NullPointerException is thrown occasionally (rare, but often enough) but there is no place to use a try/catch.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/849)
<!-- Reviewable:end -->
