### PR TITLE
Fix: Immediately show progress modal when creating project

### DIFF
--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/HomePage2.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/HomePage2.kt
@@ -201,6 +201,9 @@ class HomePage2 : View() {
         subscribe<LanguageSelectedEvent> {
             if (projectWizardViewModel.selectedSourceLanguageProperty.value == null) {
                 wizardFragment.nextStep()
+            } else {
+                // open loading dialog when creating project
+                viewModel.isLoadingProperty.set(true)
             }
             projectWizardViewModel.onLanguageSelected(it.item) {
                 viewModel.loadProjects()


### PR DESCRIPTION
This PR resolves the crash after selecting a target language multiple times in project creation

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/856)
<!-- Reviewable:end -->
