### PR TITLE
Fix: seekPrevious crashes when no marker placed

### DIFF
--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/model/VerseMarkerModel.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/model/VerseMarkerModel.kt
@@ -137,7 +137,11 @@ class VerseMarkerModel(
 
     fun seekPrevious(location: Int): Int {
         val filtered = markers.filter { it.placed }
-        return findMarkerPrecedingPosition(location, filtered).frame
+        return if (filtered.isNotEmpty()) {
+            findMarkerPrecedingPosition(location, filtered).frame
+        } else {
+            0
+        }
     }
 
     private fun findMarkerPrecedingPosition(


### PR DESCRIPTION
Translation - placing marker

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/861)
<!-- Reviewable:end -->
