### PR TITLE
Bug 734: narration menu options disabled after save

### DIFF
--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/NarrationViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/NarrationViewModel.kt
@@ -606,6 +606,7 @@ class NarrationViewModel : ViewModel() {
                             .subscribeOn(Schedulers.io())
                             .subscribe(
                                 {
+                                    chapterTakeProperty.set(workbookDataStore.chapter.getSelectedTake())
                                     logger.info("Created a chapter take for ${chapterTitleProperty.value}")
                                 }, { e ->
                                     logger.error(


### PR DESCRIPTION
Updates the chapterTakeProperty when a new take is finished being created so that the UI can react accordingly.

Sets the chapterTakeProperty equal to workbookDataStore.chapter.getSelectedTake to account for if a user goes to the next chapter before the chapter take is finished being created.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/863)
<!-- Reviewable:end -->
