### PR TITLE
RecordAgain from RecordActive is a valid state

### DIFF
--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/teleprompter/TeleprompterState.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/teleprompter/TeleprompterState.kt
@@ -102,6 +102,7 @@ object RecordActiveState : TeleprompterState {
 
     override val validStateTransitions = setOf(
         TeleprompterItemState.RECORDING_PAUSED,
+        TeleprompterItemState.RECORD_AGAIN,
         TeleprompterItemState.RECORD_AGAIN_DISABLED
     )
 
@@ -116,6 +117,7 @@ object RecordActiveState : TeleprompterState {
         return when (request) {
             // NarrationTextItemState.RECORD_ACTIVE -> RecordActiveState
             TeleprompterItemState.RECORDING_PAUSED -> RecordPausedState
+            TeleprompterItemState.RECORD_AGAIN -> RecordAgainState
             TeleprompterItemState.RECORD_AGAIN_DISABLED -> RecordAgainDisabledState
             else -> {
                 throw IllegalStateException("State: $type tried to transition to state: $request")


### PR DESCRIPTION
This state transition can happen from saving the last verse

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/873)
<!-- Reviewable:end -->
