### PR TITLE
Save action fix

### DIFF
--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/teleprompter/TeleprompterStateTransition.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/teleprompter/TeleprompterStateTransition.kt
@@ -140,6 +140,11 @@ object SaveRecordingAction {
         if (index != 0) {
             for (i in 0 until index) {
                 contexts[i].restore()
+                if (contexts[i].state.type == TeleprompterItemState.RECORD_AGAIN_DISABLED) {
+                    contexts[i].changeState(TeleprompterItemState.RECORD_AGAIN)
+                } else if (contexts[i].state.type == TeleprompterItemState.RECORD_DISABLED) {
+                    contexts[i].changeState(TeleprompterItemState.RECORD)
+                }
             }
         }
 
@@ -148,6 +153,11 @@ object SaveRecordingAction {
         if (index < contexts.lastIndex) {
             for (i in index + 1..contexts.lastIndex) {
                 contexts[i].restore()
+                if (contexts[i].state.type == TeleprompterItemState.RECORD_AGAIN_DISABLED) {
+                    contexts[i].changeState(TeleprompterItemState.RECORD_AGAIN)
+                } else if (contexts[i].state.type == TeleprompterItemState.RECORD_DISABLED) {
+                    contexts[i].changeState(TeleprompterItemState.RECORD)
+                }
             }
         }
     }

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/teleprompter/TeleprompterStateTransition.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/teleprompter/TeleprompterStateTransition.kt
@@ -153,11 +153,6 @@ object SaveRecordingAction {
         if (index < contexts.lastIndex) {
             for (i in index + 1..contexts.lastIndex) {
                 contexts[i].restore()
-                if (contexts[i].state.type == TeleprompterItemState.RECORD_AGAIN_DISABLED) {
-                    contexts[i].changeState(TeleprompterItemState.RECORD_AGAIN)
-                } else if (contexts[i].state.type == TeleprompterItemState.RECORD_DISABLED) {
-                    contexts[i].changeState(TeleprompterItemState.RECORD)
-                }
             }
         }
     }


### PR DESCRIPTION
Make sure verse actions are enabled after a save action for verses prior to the verse being saved.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/874)
<!-- Reviewable:end -->
