### PR TITLE
Finish the current verse before beginning record-again

### DIFF
--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/teleprompter/TeleprompterStateContext.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/teleprompter/TeleprompterStateContext.kt
@@ -14,12 +14,13 @@ class TeleprompterStateContext {
     }
 
     fun disable() {
-        temporarilyDisabledState = state
+        if (temporarilyDisabledState == null) {
+            temporarilyDisabledState = state
+        }
         state = state.disabledState
     }
 
     fun restore() {
         state = temporarilyDisabledState ?: state
-        temporarilyDisabledState = null
     }
 }


### PR DESCRIPTION
Before proceeding with Record Again, we should first "close" the paused verse by moving its state to "record-again" and enabling the next verse so that the disable and restore functionality will work when we actually perform Record Again.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/877)
<!-- Reviewable:end -->
