### PR TITLE
Fix: seek after re-record

### DIFF
--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/Narration.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/Narration.kt
@@ -257,8 +257,8 @@ class Narration @AssistedInject constructor(
     }
 
     fun resumeRecordingAgain() {
-        // TODO: note, this seek is not correct when resuming from a re-record.
-        //player.seek(player.getDurationInFrames())
+        val lastRecordingPositon = chapterRepresentation.scratchAudio.totalFrames
+        player.seek(chapterRepresentation.absoluteToRelativeChapter(lastRecordingPositon))
         writer?.start()
         isRecording.set(true)
     }

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/Narration.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/Narration.kt
@@ -257,8 +257,9 @@ class Narration @AssistedInject constructor(
     }
 
     fun resumeRecordingAgain() {
-        val lastRecordingPositon = chapterRepresentation.scratchAudio.totalFrames
-        player.seek(chapterRepresentation.absoluteToRelativeChapter(lastRecordingPositon))
+        // Seeks to the end of the scratchAudio, since the re-record has not yet been finalized.
+        val lastRecordingPosition = chapterRepresentation.scratchAudio.totalFrames
+        player.seek(chapterRepresentation.absoluteToRelativeChapter(lastRecordingPosition))
         writer?.start()
         isRecording.set(true)
     }

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/Narration.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/Narration.kt
@@ -9,7 +9,6 @@ import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.disposables.Disposable
 import io.reactivex.schedulers.Schedulers
 import io.reactivex.subjects.PublishSubject
-import jdk.jshell.SourceCodeAnalysis.Completeness
 import org.slf4j.LoggerFactory
 import org.wycliffeassociates.otter.common.audio.AudioFile
 import org.wycliffeassociates.otter.common.audio.AudioFileFormat
@@ -25,7 +24,6 @@ import org.wycliffeassociates.otter.common.data.workbook.Workbook
 import org.wycliffeassociates.otter.common.device.IAudioPlayer
 import org.wycliffeassociates.otter.common.device.IAudioRecorder
 import org.wycliffeassociates.otter.common.domain.audio.OratureAudioFile
-import org.wycliffeassociates.otter.common.domain.content.FileNamer
 import org.wycliffeassociates.otter.common.domain.content.WorkbookFileNamerBuilder
 import org.wycliffeassociates.otter.common.recorder.WavFileWriter
 import java.io.File
@@ -254,6 +252,13 @@ class Narration @AssistedInject constructor(
 
     fun resumeRecording() {
         player.seek(player.getDurationInFrames())
+        writer?.start()
+        isRecording.set(true)
+    }
+
+    fun resumeRecordingAgain() {
+        // TODO: note, this seek is not correct when resuming from a re-record.
+        //player.seek(player.getDurationInFrames())
         writer?.start()
         isRecording.set(true)
     }

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/teleprompter/TeleprompterStateContext.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/teleprompter/TeleprompterStateContext.kt
@@ -14,12 +14,13 @@ class TeleprompterStateContext {
     }
 
     fun disable() {
-        temporarilyDisabledState = state
+        if (temporarilyDisabledState == null) {
+            temporarilyDisabledState = state
+        }
         state = state.disabledState
     }
 
     fun restore() {
         state = temporarilyDisabledState ?: state
-        temporarilyDisabledState = null
     }
 }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/NarrationViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/NarrationViewModel.kt
@@ -512,18 +512,13 @@ class NarrationViewModel : ViewModel() {
 
         narration.pauseRecording()
         narration.finalizeVerse(index)
-        // TODO: note, removing this line on pause recording for re-record removes the apparent offset when resuming
-        //  re-record
-//        renderer.clearActiveRecordingData()
         refreshTeleprompter()
-
     }
 
     fun resumeRecordingAgain() {
         stopPlayer()
 
         narration.resumeRecordingAgain()
-
         isRecording = true
         recordPause = false
 
@@ -679,8 +674,6 @@ class NarrationViewModel : ViewModel() {
                         }
                     }
 
-                    // NOTE: this is throwing an exception after undoing a re-record.
-                    // This also likely needs to be mapped to the verse space if we are locked to a verse.
                     reRecordLoc = recordedVerses[reRecordingIndex].location
                 }
 


### PR DESCRIPTION
Still need to seek to the "correct" position on resumeRecordingAgain and iron out some edge cases, but this should keep the markers from disappearing and keep the visualization more consistent.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/878)
<!-- Reviewable:end -->
