### PR TITLE
Fixed waveform scrolling bugs (OT-761)

### DIFF
--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/Narration.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/Narration.kt
@@ -184,13 +184,19 @@ class Narration @AssistedInject constructor(
     fun finalizeVerse(verseIndex: Int) {
         val loc = chapterRepresentation.finalizeVerse(verseIndex, history)
         val relLoc = chapterRepresentation.absoluteToRelativeChapter(loc)
+
+        audioLoaded = false
+        loadChapterIntoPlayer()
+
         seek(relLoc)
     }
 
     fun onNewVerse(verseIndex: Int) {
-        loadChapterIntoPlayer()
         val action = NewVerseAction(verseIndex)
         execute(action)
+
+        audioLoaded = false
+        loadChapterIntoPlayer()
 
         player.seek(player.getDurationInFrames())
         writer?.start()
@@ -198,9 +204,11 @@ class Narration @AssistedInject constructor(
     }
 
     fun onRecordAgain(verseIndex: Int) {
-        loadChapterIntoPlayer()
         val action = RecordAgainAction(verseIndex)
         execute(action)
+
+        audioLoaded = false
+        loadChapterIntoPlayer()
 
         seek(activeVerses[verseIndex].location)
         writer?.start()
@@ -208,10 +216,12 @@ class Narration @AssistedInject constructor(
     }
 
     fun onSaveRecording(verseIndex: Int) {
-        loadChapterIntoPlayer()
-
         val loc = chapterRepresentation.finalizeVerse(verseIndex, history)
         val relLoc = chapterRepresentation.absoluteToRelativeChapter(loc)
+
+        audioLoaded = false
+        loadChapterIntoPlayer()
+
         seek(relLoc)
 
         writer?.pause()

--- a/jvm/device/src/main/kotlin/org/wycliffeassociates/otter/jvm/device/audio/AudioPlayerConnection.kt
+++ b/jvm/device/src/main/kotlin/org/wycliffeassociates/otter/jvm/device/audio/AudioPlayerConnection.kt
@@ -151,9 +151,7 @@ internal class AudioPlayerConnection(
     }
 
     override fun seek(position: Int) {
-        connectionFactory.load(state)
         connectionFactory.player.seek(position)
-        connectionFactory.load(state)
     }
 
     override fun isPlaying(): Boolean {

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/AudioWorkspaceView.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/AudioWorkspaceView.kt
@@ -11,11 +11,8 @@ import org.slf4j.LoggerFactory
 import org.wycliffeassociates.otter.common.data.audio.VerseMarker
 import org.wycliffeassociates.otter.jvm.controls.customizeScrollbarSkin
 import org.wycliffeassociates.otter.jvm.controls.event.AppCloseRequestEvent
-import org.wycliffeassociates.otter.jvm.controls.model.framesToPixels
-import org.wycliffeassociates.otter.jvm.controls.model.pixelsToFrames
 import org.wycliffeassociates.otter.jvm.controls.styles.tryImportStylesheet
 import org.wycliffeassociates.otter.jvm.controls.waveform.Drawable
-import org.wycliffeassociates.otter.jvm.workbookapp.ui.narration.markers.NarrationMarkerChangedEvent
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.narration.markers.VerseMarkerControl
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.narration.markers.verse_markers_layer
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.narration.waveform.WaveformLayer
@@ -126,10 +123,21 @@ class AudioWorkspaceView : View() {
                 }
                 verse_markers_layer {
                     verseMarkersControls.bind(markerNodes) { it }
+
+                    var pos = 0
+
+                    setOnDragStarted {
+                        // caching current position on drag start
+                        // to add delta to it later on drag continue
+                        pos = viewModel.audioPositionProperty.value
+                    }
+
                     setOnLayerScroll { delta ->
-                        val pos = viewModel.audioPositionProperty.value
                         val seekTo = pos + delta
-                        viewModel.seekTo(seekTo)
+                        // Keep position inside audio bounds
+                        if (seekTo in 0..viewModel.totalAudioSizeProperty.value) {
+                            viewModel.seekTo(seekTo)
+                        }
                     }
                 }
             }


### PR DESCRIPTION
1. Correctly use scroll delta to change current position (otherwise scroll speed is slow and occasionally verse markers freeze or move unexpectedly)
2. Correctly consume mouse/drag events to prevent propagation (dragging marker 1 drags waveform instead)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/884)
<!-- Reviewable:end -->
