### PR TITLE
Sets all items prior to RECORD_AGAIN

### DIFF
--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/teleprompter/TeleprompterStateTransition.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/teleprompter/TeleprompterStateTransition.kt
@@ -80,7 +80,11 @@ object NextVerseAction {
             contexts[index - 1].changeState(TeleprompterItemState.RECORD_AGAIN_DISABLED)
             contexts[index].changeState(TeleprompterItemState.RECORD_ACTIVE)
         } else {
-            contexts[index - 1].changeState(TeleprompterItemState.RECORD_AGAIN)
+            for(i in 0 until index) {
+                if(contexts[i].state != RecordAgainState) {
+                    contexts[i].changeState(TeleprompterItemState.RECORD_AGAIN)
+                }
+            }
             contexts[index].changeState(TeleprompterItemState.RECORD)
         }
     }


### PR DESCRIPTION
Resolves error where some items are stuck in the RECORD_AGAIN_DISABLED when transitioning from RECORD_AGAIN, RECORD_AGAIN_PAUSED, then NEXT starting from verse > 1

Not necessarily a problem now, because the current UI replaces the "Next" button with "Save", however, we should be handling it correctly since being able to transition from RECORD_AGAIN_PAUSED to NEXT does not throw an exception.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/889)
<!-- Reviewable:end -->
