### PR TITLE
Fix recorder showing old data

### DIFF
--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/BlindDraft.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/BlindDraft.kt
@@ -158,7 +158,9 @@ class BlindDraft : View() {
         logger.info("Blind Draft undocked.")
         unsubscribeEvents()
         viewModel.undockBlindDraft()
-        recorderViewModel.cancel()
+        if (mainSectionProperty.value == recordingView) {
+            recorderViewModel.cancel()
+        }
     }
 
     private fun subscribeEvents() {

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/BlindDraft.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/BlindDraft.kt
@@ -3,12 +3,14 @@ package org.wycliffeassociates.otter.jvm.workbookapp.ui.screens.translation
 import javafx.beans.property.SimpleBooleanProperty
 import javafx.beans.property.SimpleObjectProperty
 import javafx.scene.Node
+import javafx.scene.control.ScrollPane
 import javafx.scene.layout.Priority
 import javafx.scene.layout.VBox
 import org.kordamp.ikonli.javafx.FontIcon
 import org.kordamp.ikonli.materialdesign.MaterialDesign
 import org.slf4j.LoggerFactory
 import org.wycliffeassociates.otter.jvm.controls.TakeSelectionAnimationMediator
+import org.wycliffeassociates.otter.jvm.controls.customizeScrollbarSkin
 import org.wycliffeassociates.otter.jvm.controls.media.simpleaudioplayer
 import org.wycliffeassociates.otter.jvm.controls.styles.tryImportStylesheet
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.components.ChunkTakeCard
@@ -80,14 +82,22 @@ class BlindDraft : View() {
                 label(messages["available_takes"]).addClass("h5", "h5--60")
                 vgrow = Priority.ALWAYS
 
-                vbox {
-                    addClass("take-list")
-                    animationMediator.nodeList = childrenUnmodifiable
-                    bindChildren(viewModel.availableTakes) { take ->
-                        ChunkTakeCard(take).apply {
-                            animationMediatorProperty.set(animationMediator)
+                scrollpane {
+                    vgrow = Priority.ALWAYS
+                    isFitToWidth = true
+                    hbarPolicy = ScrollPane.ScrollBarPolicy.NEVER
+
+                    vbox {
+                        addClass("take-list")
+                        animationMediator.nodeList = childrenUnmodifiable
+                        bindChildren(viewModel.availableTakes) { take ->
+                            ChunkTakeCard(take).apply {
+                                animationMediatorProperty.set(animationMediator)
+                            }
                         }
                     }
+
+                    runLater { customizeScrollbarSkin() }
                 }
             }
             hbox {

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/BlindDraft.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/BlindDraft.kt
@@ -30,7 +30,7 @@ class BlindDraft : View() {
     private val mainSectionProperty = SimpleObjectProperty<Node>(null)
     private val takesView = buildTakesArea()
     private val recordingView = buildRecordingArea()
-    private val hideSourceAudio = SimpleBooleanProperty(false)
+    private val hideSourceAudio = mainSectionProperty.booleanBinding { it == recordingView }
     private val eventSubscriptions = mutableListOf<EventRegistration>()
 
     override val root = borderpane {
@@ -101,7 +101,6 @@ class BlindDraft : View() {
                         mainSectionProperty.set(recordingView)
                         recorderViewModel.onViewReady(takesView.width.toInt()) // use the width of the existing component
                         recorderViewModel.toggle()
-                        hideSourceAudio.set(true)
                     }
                 }
             }
@@ -122,14 +121,12 @@ class BlindDraft : View() {
                 recorderViewModel.cancel()
                 viewModel.onRecordFinish(RecorderViewModel.Result.CANCELLED)
                 mainSectionProperty.set(takesView)
-                hideSourceAudio.set(false)
             }
 
             setSaveAction {
                 val result = recorderViewModel.saveAndQuit()
                 viewModel.onRecordFinish(result)
                 mainSectionProperty.set(takesView)
-                hideSourceAudio.set(false)
             }
         }
     }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/PeerEdit.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/PeerEdit.kt
@@ -189,7 +189,9 @@ open class PeerEdit : View() {
         timer?.stop()
         unsubscribeEvents()
         viewModel.undock()
-        recorderViewModel.cancel()
+        if (mainSectionProperty.value == recordingView) {
+            recorderViewModel.cancel()
+        }
     }
 
     private fun subscribeEvents() {

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/PeerEditViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/PeerEditViewModel.kt
@@ -94,6 +94,7 @@ class PeerEditViewModel : ViewModel(), IWaveformViewModel {
 
     fun undock() {
         sourcePlayerProperty.unbind()
+        currentChunkProperty.set(null)
         selectedTakeDisposable.clear()
         disposable.clear()
         disposableListeners.forEach { it.dispose() }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/RecorderViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/RecorderViewModel.kt
@@ -38,8 +38,13 @@ class RecorderViewModel : ViewModel() {
     var isRecording by recordingProperty
     lateinit var recorder: IAudioRecorder
 
+    /**
+     * These property must be assigned everytime the view is docked, since it could be dirty
+     * from the other View(s) that share this ViewModel.
+     * */
     lateinit var waveformCanvas: CanvasFragment
     lateinit var volumeCanvas: CanvasFragment
+
     val timerTextProperty = SimpleStringProperty("00:00:00")
     lateinit var tempTake: File
     lateinit var wavAudio: OratureAudioFile

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/RecorderViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/RecorderViewModel.kt
@@ -124,6 +124,7 @@ class RecorderViewModel : ViewModel() {
 
     fun cancel() {
         pause()
+        isRecording = false
         at.stop()
         recorder.stop()
         waveformCanvas.clearDrawables()

--- a/jvm/workbookapp/src/main/resources/css/blind-draft-page.css
+++ b/jvm/workbookapp/src/main/resources/css/blind-draft-page.css
@@ -15,6 +15,7 @@
 
 .take-list {
     -fx-spacing: 32;
+    -fx-padding: 0 16 0 0;
 }
 
 .take-card {


### PR DESCRIPTION
Cleans up RecorderViewModel when undocking, especially while actively recording and then navigating to another view.
Updates the waveform & volume canvas of RecorderVM whenever docking a new view to avoid rendering old data.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/893)
<!-- Reviewable:end -->
