### PR TITLE
Load audio connection state when seek()

### DIFF
--- a/jvm/device/src/main/kotlin/org/wycliffeassociates/otter/jvm/device/audio/AudioPlayerConnection.kt
+++ b/jvm/device/src/main/kotlin/org/wycliffeassociates/otter/jvm/device/audio/AudioPlayerConnection.kt
@@ -112,6 +112,7 @@ internal class AudioPlayerConnection(
     }
 
     override fun pause() {
+        connectionFactory.load(state)
         connectionFactory.currentConnection?.id?.let {
             if (it == id) {
                 state.position = connectionFactory.player.getLocationInFrames()

--- a/jvm/device/src/main/kotlin/org/wycliffeassociates/otter/jvm/device/audio/AudioPlayerConnection.kt
+++ b/jvm/device/src/main/kotlin/org/wycliffeassociates/otter/jvm/device/audio/AudioPlayerConnection.kt
@@ -112,7 +112,6 @@ internal class AudioPlayerConnection(
     }
 
     override fun pause() {
-        connectionFactory.load(state)
         connectionFactory.currentConnection?.id?.let {
             if (it == id) {
                 state.position = connectionFactory.player.getLocationInFrames()
@@ -152,6 +151,9 @@ internal class AudioPlayerConnection(
     }
 
     override fun seek(position: Int) {
+        if (connectionFactory.currentConnection?.id != id) {
+            connectionFactory.load(state)
+        }
         connectionFactory.player.seek(position)
     }
 


### PR DESCRIPTION
Issue: waveform drag didn't work until playing audio. This is because the `currentConnection` is loaded with another player.

Context: derived from #884 where we removed `.load(state)` calls in `AudioPlayerConnection.seek( )`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/895)
<!-- Reviewable:end -->
