### PR TITLE
Fix for premature creation of chapter take

### DIFF
--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/Narration.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/Narration.kt
@@ -230,6 +230,10 @@ class Narration @AssistedInject constructor(
         writer?.pause()
         uncommittedRecordedFrames.set(0)
         isRecording.set(false)
+
+        if(hasChapterTake) {
+            bounceAudio(chapter.getSelectedTake()!!.file)
+        }
     }
 
     fun onVerseMarkerMoved(verseIndex: Int, delta: Int) {

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/Narration.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/Narration.kt
@@ -93,6 +93,11 @@ class Narration @AssistedInject constructor(
 
     private var lockedVerseIndex: Int? = null
 
+    private val hasChapterTake: Boolean
+        get() {
+            return chapter.getSelectedTake() != null
+        }
+
     init {
         val writer = initializeWavWriter()
 
@@ -230,6 +235,11 @@ class Narration @AssistedInject constructor(
     fun onVerseMarkerMoved(verseIndex: Int, delta: Int) {
         val action = MoveMarkerAction(verseIndex, delta)
         execute(action)
+
+        if(hasChapterTake) {
+            val takeAudioModifier = NarrationTakeAudioModifier(chapter.getSelectedTake()!!)
+            takeAudioModifier.modifyMetaData(activeVerses)
+        }
     }
 
     fun onEditVerse(verseIndex: Int, editedFile: File) {

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/NarrationTakeAudioModifier.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/NarrationTakeAudioModifier.kt
@@ -1,8 +1,5 @@
 package org.wycliffeassociates.otter.common.domain.narration
 
-import org.wycliffeassociates.otter.common.audio.DEFAULT_BITS_PER_SAMPLE
-import org.wycliffeassociates.otter.common.audio.DEFAULT_CHANNELS
-import org.wycliffeassociates.otter.common.audio.DEFAULT_SAMPLE_RATE
 import org.wycliffeassociates.otter.common.data.audio.AudioMarker
 import org.wycliffeassociates.otter.common.data.audio.BookMarker
 import org.wycliffeassociates.otter.common.data.audio.ChapterMarker
@@ -10,7 +7,7 @@ import org.wycliffeassociates.otter.common.data.audio.VerseMarker
 import org.wycliffeassociates.otter.common.data.workbook.Take
 import org.wycliffeassociates.otter.common.domain.audio.OratureAudioFile
 
-class NarrationTakeModifier(take: Take) {
+class NarrationTakeAudioModifier(take: Take) {
 
     lateinit var audioFile : OratureAudioFile
 

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/NarrationTakeModifier.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/NarrationTakeModifier.kt
@@ -15,7 +15,7 @@ class NarrationTakeModifier(take: Take) {
     lateinit var audioFile : OratureAudioFile
 
     init {
-        audioFile = OratureAudioFile(take.file, DEFAULT_CHANNELS, DEFAULT_SAMPLE_RATE, DEFAULT_BITS_PER_SAMPLE)
+        audioFile = OratureAudioFile(take.file)
     }
 
     fun modifyAudioData() {

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/NarrationTakeModifier.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/NarrationTakeModifier.kt
@@ -1,0 +1,42 @@
+package org.wycliffeassociates.otter.common.domain.narration
+
+import org.wycliffeassociates.otter.common.audio.DEFAULT_BITS_PER_SAMPLE
+import org.wycliffeassociates.otter.common.audio.DEFAULT_CHANNELS
+import org.wycliffeassociates.otter.common.audio.DEFAULT_SAMPLE_RATE
+import org.wycliffeassociates.otter.common.data.audio.AudioMarker
+import org.wycliffeassociates.otter.common.data.audio.BookMarker
+import org.wycliffeassociates.otter.common.data.audio.ChapterMarker
+import org.wycliffeassociates.otter.common.data.audio.VerseMarker
+import org.wycliffeassociates.otter.common.data.workbook.Take
+import org.wycliffeassociates.otter.common.domain.audio.OratureAudioFile
+
+class NarrationTakeModifier(take: Take) {
+
+    lateinit var audioFile : OratureAudioFile
+
+    init {
+        audioFile = OratureAudioFile(take.file, DEFAULT_CHANNELS, DEFAULT_SAMPLE_RATE, DEFAULT_BITS_PER_SAMPLE)
+    }
+
+    fun modifyAudioData() {
+        // TODO: finish
+    }
+
+    fun modifyMetaData(markers: List<AudioMarker>) {
+        clearNarrationMarkers()
+        addNarrationMarkers(markers)
+        audioFile.update()
+    }
+
+    private fun clearNarrationMarkers() {
+        audioFile.clearMarkersOfType<VerseMarker>()
+        audioFile.clearMarkersOfType<ChapterMarker>()
+        audioFile.clearMarkersOfType<BookMarker>()
+    }
+
+    private fun addNarrationMarkers(markers: List<AudioMarker>) {
+        markers.forEach { marker ->
+            audioFile.addMarker(marker)
+        }
+    }
+}

--- a/common/src/test/kotlin/org/wycliffeassociates/otter/common/domain/narration/NarrationTakeModifierTest.kt
+++ b/common/src/test/kotlin/org/wycliffeassociates/otter/common/domain/narration/NarrationTakeModifierTest.kt
@@ -1,0 +1,140 @@
+package org.wycliffeassociates.otter.common.domain.narration
+
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.wycliffeassociates.otter.common.audio.DEFAULT_SAMPLE_RATE
+import org.wycliffeassociates.otter.common.data.audio.AudioMarker
+import org.wycliffeassociates.otter.common.data.audio.BookMarker
+import org.wycliffeassociates.otter.common.data.audio.ChapterMarker
+import org.wycliffeassociates.otter.common.data.audio.VerseMarker
+import org.wycliffeassociates.otter.common.data.primitives.MimeType
+import org.wycliffeassociates.otter.common.data.workbook.Take
+import org.wycliffeassociates.otter.common.domain.audio.OratureAudioFile
+import org.wycliffeassociates.otter.common.persistence.IDirectoryProvider
+import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
+import java.nio.file.Files
+import java.nio.file.Paths
+
+
+val chapterTakeAudioFile = File(testDirWithAudio, "testChapterTake.wav")
+val tempAudioFile = File(testDirWithAudio, "tempAudio.pcm")
+
+class NarrationTakeModifierTest {
+    lateinit var chapterTake : Take
+
+    private fun mockTake() : Take {
+        return mockk<Take> {
+            every { format } returns MimeType.WAV
+            every { file } returns chapterTakeAudioFile
+        }
+    }
+
+    private fun mockDirectoryProvider() : IDirectoryProvider {
+        return mockk<IDirectoryProvider> {}
+    }
+
+    @Before
+    fun setup() {
+        createTestAudioFolders()
+        chapterTake = mockTake()
+    }
+
+    @After
+    fun cleanup() {
+        try {
+            testDirWithAudio.deleteRecursively()
+        } catch (e: IOException) {
+            println("Failed to delete test audio folders at '$testDataRootFilePath': ${e.message}")
+        }
+    }
+
+
+    private fun createTestAudioFolders() {
+        val testProjectChapterDirWithAudio = "testProjectChapterDirWithAudio"
+
+        val withAudioPath = Paths.get(testDataRootFilePath, testProjectChapterDirWithAudio)
+
+        try {
+            Files.createDirectories(withAudioPath)
+        } catch (e: Exception) {
+            println("Failed to create test audio folders or WAV file at '$testDataRootFilePath': ${e.message}")
+        }
+    }
+
+
+    fun addBytesToFile(file: File, numberOfBytes: Int) {
+        try {
+            val outputStream = FileOutputStream(file, false)
+
+            val byteArray = ByteArray(numberOfBytes) { 1 }
+            outputStream.write(byteArray)
+
+            outputStream.close()
+        } catch (e: Exception) {
+            println("Error: ${e.message}")
+        }
+    }
+
+    private fun makeTestChapterTakeRecording(audioFile: OratureAudioFile, secondsOfAudio: Int, markers: List<AudioMarker>) {
+        addBytesToFile(tempAudioFile, DEFAULT_SAMPLE_RATE * 2 * secondsOfAudio)
+        val audioFileUtils = AudioFileUtils(mockDirectoryProvider())
+        audioFileUtils.appendFile(audioFile, tempAudioFile)
+
+        audioFile.clearCues()
+        markers.forEach { marker ->
+            audioFile.addMarker(marker)
+        }
+        audioFile.update()
+    }
+
+
+
+    @Test
+    fun `modifyMetadata with same amount of markers, same labels, and with different locations`() {
+        val takeModifier = NarrationTakeModifier(chapterTake)
+        val secondsOfAudio = 10
+
+        val originalAudioMarkers = listOf<AudioMarker>(
+            BookMarker("gen", 0),
+            ChapterMarker(1, 44100),
+            VerseMarker(1, 1, 88200),
+            VerseMarker(2, 2, 132300),
+            VerseMarker(3, 3, 176400)
+        )
+
+        makeTestChapterTakeRecording(
+            takeModifier.audioFile,
+            secondsOfAudio,
+            originalAudioMarkers
+        )
+
+        // Verifies that we have the expected amount of audio data
+        Assert.assertEquals(takeModifier.audioFile.totalFrames, secondsOfAudio * DEFAULT_SAMPLE_RATE)
+
+        // Verifies that we have the expected cues specified by originalAudioMarkers
+        takeModifier.audioFile.getCues().forEachIndexed { idx, cue ->
+            Assert.assertEquals(originalAudioMarkers[idx].toCue(), cue)
+        }
+
+        val newAudioMarkers = listOf<AudioMarker>(
+            BookMarker("gen", 100),
+            ChapterMarker(1, 44200),
+            VerseMarker(1, 1, 88300),
+            VerseMarker(2, 2, 132400),
+            VerseMarker(3, 3, 176500)
+        )
+
+        takeModifier.modifyMetaData(newAudioMarkers)
+
+        // Verifies that we have the expected cues specified by newAudioMarkers
+        takeModifier.audioFile.getCues().forEachIndexed { idx, cue ->
+            Assert.assertEquals(newAudioMarkers[idx].toCue(), cue)
+        }
+    }
+}

--- a/common/src/test/kotlin/org/wycliffeassociates/otter/common/domain/narration/NarrationTakeModifierTest.kt
+++ b/common/src/test/kotlin/org/wycliffeassociates/otter/common/domain/narration/NarrationTakeModifierTest.kt
@@ -97,7 +97,7 @@ class NarrationTakeModifierTest {
 
     @Test
     fun `modifyMetadata with same amount of markers, same labels, and with different locations`() {
-        val takeModifier = NarrationTakeModifier(chapterTake)
+        val takeModifier = NarrationTakeAudioModifier(chapterTake)
         val secondsOfAudio = 10
 
         val originalAudioMarkers = listOf<AudioMarker>(

--- a/common/src/test/kotlin/org/wycliffeassociates/otter/common/domain/narration/NarrationTakeModifierTest.kt
+++ b/common/src/test/kotlin/org/wycliffeassociates/otter/common/domain/narration/NarrationTakeModifierTest.kt
@@ -130,10 +130,10 @@ class NarrationTakeModifierTest {
 
         val newAudioMarkers = listOf<AudioMarker>(
             BookMarker("gen", 100),
-            ChapterMarker(1, 44200),
-            VerseMarker(1, 1, 88300),
-            VerseMarker(2, 2, 132400),
-            VerseMarker(3, 3, 176500)
+            ChapterMarker(1, 44500),
+            VerseMarker(1, 1, 88600),
+            VerseMarker(2, 2, 132700),
+            VerseMarker(3, 3, 176800)
         )
 
         takeModifier.modifyMetaData(newAudioMarkers)

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/NarrationViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/NarrationViewModel.kt
@@ -107,7 +107,6 @@ class NarrationViewModel : ViewModel() {
     val chapterTakeBusyProperty = SimpleBooleanProperty()
 
     val chunkTotalProperty = SimpleIntegerProperty(0)
-    var numberOfTitlesProperty = SimpleIntegerProperty(0)
     val chunksList: ObservableList<Chunk> = observableListOf()
     val narratableList: ObservableList<NarrationTextItemData> = observableListOf()
     val recordedVerses = observableListOf<AudioMarker>()
@@ -117,7 +116,10 @@ class NarrationViewModel : ViewModel() {
     val totalAudioSizeProperty = SimpleIntegerProperty()
 
     //FIXME: Refactor this if and when Chunk entries are officially added for Titles in the Workbook
-    val potentiallyFinishedProperty = chunkTotalProperty.eq(recordedVerses.sizeProperty.minus(numberOfTitlesProperty))
+    var numberOfTitlesProperty = SimpleIntegerProperty(0)
+    val potentiallyFinishedProperty = chunkTotalProperty
+        .eq(recordedVerses.sizeProperty.minus(numberOfTitlesProperty))
+        .and(!isRecording)
     val potentiallyFinished by potentiallyFinishedProperty
 
     val pluginContextProperty = SimpleObjectProperty(PluginType.EDITOR)
@@ -294,7 +296,7 @@ class NarrationViewModel : ViewModel() {
     }
 
     private fun createPotentiallyFinishedChapterTake() {
-        if (potentiallyFinished && isRecording == false) {
+        if (potentiallyFinished) {
             chapterTakeBusyProperty.set(true)
             logger.info("Chapter is potentially finished, creating a chapter take")
             narration

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/NarrationViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/NarrationViewModel.kt
@@ -120,6 +120,7 @@ class NarrationViewModel : ViewModel() {
     val potentiallyFinishedProperty = chunkTotalProperty
         .eq(recordedVerses.sizeProperty.minus(numberOfTitlesProperty))
         .and(!isRecording)
+        .and(chapterTakeProperty.isNotNull)
     val potentiallyFinished by potentiallyFinishedProperty
 
     val pluginContextProperty = SimpleObjectProperty(PluginType.EDITOR)


### PR DESCRIPTION
Potentially creates a chapter take on save, and not on activeVerses change

Is potentially finished when all verses and titles have been recorded. Previously was not taking into account having to record titles

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/908)
<!-- Reviewable:end -->
