### PR TITLE
Prevent creating project with existing language pair

### DIFF
--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/card/TranslationCard2.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/card/TranslationCard2.kt
@@ -21,12 +21,13 @@ import org.wycliffeassociates.otter.common.data.primitives.ProjectMode
 import org.wycliffeassociates.otter.jvm.controls.model.ProjectGroupKey
 import java.text.MessageFormat
 import tornadofx.*
+import tornadofx.FX.Companion.messages
 
 // TODO: remove number "2" suffix after deleting the original control. Same for css named translation-card-2.css
 class TranslationCard2(
     private val sourceLanguage: Language,
     private val targetLanguage: Language,
-    private val mode: ProjectMode,
+    val mode: ProjectMode,
     selectedProjectGroupProperty: ObservableValue<ProjectGroupKey>
 ) : ButtonBase() {
 
@@ -130,6 +131,13 @@ class ActiveTranslationCardSkin(card: TranslationCard2) : SkinBase<TranslationCa
             region { hgrow = Priority.ALWAYS }
             label {
                 graphic = FontIcon(MaterialDesign.MDI_INFORMATION_OUTLINE)
+                tooltip {
+                    this.text = when (card.mode) {
+                        ProjectMode.TRANSLATION -> messages["oralTranslationDesc"]
+                        ProjectMode.NARRATION -> messages["narrationDesc"]
+                        ProjectMode.DIALECT -> messages["dialectDesc"]
+                    }
+                }
             }
         }
         vbox {

--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/card/TranslationCard2.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/card/TranslationCard2.kt
@@ -27,15 +27,20 @@ import tornadofx.FX.Companion.messages
 class TranslationCard2(
     private val sourceLanguage: Language,
     private val targetLanguage: Language,
-    val mode: ProjectMode,
+    private val mode: ProjectMode,
     selectedProjectGroupProperty: ObservableValue<ProjectGroupKey>
 ) : ButtonBase() {
 
     val cardTitleProperty = SimpleStringProperty(
-        MessageFormat.format(FX.messages["translationMode"], FX.messages[mode.titleKey])
+        MessageFormat.format(messages["translationMode"], messages[mode.titleKey])
     )
     val sourceLanguageProperty = SimpleObjectProperty(sourceLanguage)
     val targetLanguageProperty = SimpleObjectProperty(targetLanguage)
+    val cardInfo: String = when (mode) {
+        ProjectMode.TRANSLATION -> messages["oralTranslationDesc"]
+        ProjectMode.NARRATION -> messages["narrationDesc"]
+        ProjectMode.DIALECT -> messages["dialectDesc"]
+    }
 
     init {
         addClass("translation-card-button")
@@ -131,13 +136,7 @@ class ActiveTranslationCardSkin(card: TranslationCard2) : SkinBase<TranslationCa
             region { hgrow = Priority.ALWAYS }
             label {
                 graphic = FontIcon(MaterialDesign.MDI_INFORMATION_OUTLINE)
-                tooltip {
-                    this.text = when (card.mode) {
-                        ProjectMode.TRANSLATION -> messages["oralTranslationDesc"]
-                        ProjectMode.NARRATION -> messages["narrationDesc"]
-                        ProjectMode.DIALECT -> messages["dialectDesc"]
-                    }
-                }
+                tooltip(card.cardInfo)
             }
         }
         vbox {

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/tableview/LanguageTableRow.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/tableview/LanguageTableRow.kt
@@ -1,11 +1,14 @@
 package org.wycliffeassociates.otter.jvm.workbookapp.ui.components.tableview
 
+import javafx.collections.ObservableList
 import javafx.scene.control.TableRow
 import org.wycliffeassociates.otter.common.data.primitives.Language
 import org.wycliffeassociates.otter.jvm.controls.event.LanguageSelectedEvent
 import tornadofx.*
 
-class LanguageTableRow : TableRow<Language>() {
+class LanguageTableRow(
+    private val unavailableLanguages: ObservableList<Language>
+) : TableRow<Language>() {
     override fun updateItem(item: Language?, empty: Boolean) {
         super.updateItem(item, empty)
 
@@ -14,7 +17,10 @@ class LanguageTableRow : TableRow<Language>() {
             return
         }
 
-        isMouseTransparent = false
+        isDisable = item in unavailableLanguages
+        isMouseTransparent = isDisable
+        isFocusTraversable = !isDisable
+
         setOnMouseClicked {
             if (it.clickCount == 1) { // avoid double fire()
                 FX.eventbus.fire(LanguageSelectedEvent(item))

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/tableview/LanguageTableView.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/tableview/LanguageTableView.kt
@@ -79,7 +79,7 @@ class LanguageTableView(
         }
 
         sortPolicy = CUSTOM_SORT_POLICY as (Callback<TableView<Language>, Boolean>)
-        setRowFactory { LanguageTableRow() }
+        setRowFactory { LanguageTableRow(disabledLanguages) }
 
         /* accessibility */
         focusedProperty().onChange {

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/tableview/LanguageTableView.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/tableview/LanguageTableView.kt
@@ -93,7 +93,9 @@ class LanguageTableView(
         addEventFilter(KeyEvent.KEY_PRESSED) { keyEvent ->
             if (keyEvent.code == KeyCode.SPACE || keyEvent.code == KeyCode.ENTER) {
                 selectedItem?.let { language ->
-                    FX.eventbus.fire(LanguageSelectedEvent(language))
+                    if (selectedItem !in disabledLanguages) {
+                        FX.eventbus.fire(LanguageSelectedEvent(language))
+                    }
                 }
                 keyEvent.consume()
             }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/tableview/LanguageTableView.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/tableview/LanguageTableView.kt
@@ -18,6 +18,8 @@ class LanguageTableView(
     languages: ObservableList<Language>
 ) : TableView<Language>(languages) {
 
+    val disabledLanguages = observableListOf<Language>()
+
     init {
         addClass("wa-table-view")
         vgrow = Priority.ALWAYS

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/HomePage2.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/HomePage2.kt
@@ -88,7 +88,8 @@ class HomePage2 : View() {
             projectWizardViewModel.sortedSourceLanguages,
             projectWizardViewModel.sortedTargetLanguages,
             projectWizardViewModel.selectedModeProperty,
-            projectWizardViewModel.selectedSourceLanguageProperty
+            projectWizardViewModel.selectedSourceLanguageProperty,
+            projectWizardViewModel.existingLanguagePairs
         ).apply {
 
             sourceLanguageSearchQueryProperty.bindBidirectional(projectWizardViewModel.sourceLanguageSearchQueryProperty)

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/home/ProjectWizardSection.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/home/ProjectWizardSection.kt
@@ -1,6 +1,7 @@
 package org.wycliffeassociates.otter.jvm.workbookapp.ui.screens.home
 
 import javafx.animation.TranslateTransition
+import javafx.beans.binding.Bindings
 import javafx.beans.property.SimpleIntegerProperty
 import javafx.beans.property.SimpleObjectProperty
 import javafx.beans.property.SimpleStringProperty
@@ -30,7 +31,8 @@ class ProjectWizardSection(
     sourceLanguages: ObservableList<Language>,
     targetLanguages: ObservableList<Language>,
     selectedModeProperty: SimpleObjectProperty<ProjectMode>,
-    selectedSourceLanguageProperty: SimpleObjectProperty<Language>
+    selectedSourceLanguageProperty: SimpleObjectProperty<Language>,
+    existingLanguagePairs: ObservableList<Pair<Language, Language>>
 ) : StackPane() {
     val sourceLanguageSearchQueryProperty =  SimpleStringProperty()
     val targetLanguageSearchQueryProperty = SimpleStringProperty()
@@ -138,6 +140,14 @@ class ProjectWizardSection(
         }
 
         languageTableView(targetLanguages) {
+            selectedSourceLanguageProperty.onChange {
+                it?.let { src ->
+                    disabledLanguages.setAll(
+                        existingLanguagePairs.filter { it.first == src }.map { it.second }
+                    )
+                } ?: disabledLanguages.clear()
+            }
+
             this@apply.visibleProperty().onChange {
                 if (it) customizeScrollbarSkin()
             }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/home/ProjectWizardSection.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/home/ProjectWizardSection.kt
@@ -142,10 +142,14 @@ class ProjectWizardSection(
         languageTableView(targetLanguages) {
             selectedSourceLanguageProperty.onChange {
                 it?.let { src ->
-                    disabledLanguages.setAll(
-                        existingLanguagePairs.filter { it.first == src }.map { it.second }
-                    )
-                } ?: disabledLanguages.clear()
+                    val duplicated = existingLanguagePairs
+                        .filter { it.first == src }
+                        .map { it.second }
+
+                    disabledLanguages.setAll(duplicated)
+                } ?: {
+                    disabledLanguages.clear()
+                }
             }
 
             this@apply.visibleProperty().onChange {

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/HomePageViewModel2.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/HomePageViewModel2.kt
@@ -59,6 +59,7 @@ class HomePageViewModel2 : ViewModel() {
     private val workbookDS: WorkbookDataStore by inject()
     private val navigator: NavigationMediator by inject()
     private val workbookDataStore: WorkbookDataStore by inject()
+    private val projectWizardViewModel: ProjectWizardViewModel by inject()
 
     val projectGroups = observableListOf<ProjectGroupCardModel>()
     val bookList = observableListOf<WorkbookDescriptor>()
@@ -172,6 +173,9 @@ class HomePageViewModel2 : ViewModel() {
                 .observeOnFx()
                 .doOnComplete {
                     logger.info("Deleted project group: ${cardModel.sourceLanguage.name} -> ${cardModel.targetLanguage.name}.")
+                    projectWizardViewModel.existingLanguagePairs.remove(
+                        Pair(cardModel.sourceLanguage, cardModel.targetLanguage)
+                    )
                     emitter.onComplete()
                 }
                 .subscribe()

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ProjectWizardViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ProjectWizardViewModel.kt
@@ -92,6 +92,7 @@ class ProjectWizardViewModel : ViewModel() {
             }
             .subscribe { collections ->
                 sourceLanguages.setAll(collections.map { it.language })
+                updateExistingLanguagePairs()
             }
     }
 
@@ -160,5 +161,13 @@ class ProjectWizardViewModel : ViewModel() {
         selectedTargetLanguageProperty.set(null)
         sourceLanguageSearchQueryProperty.set("")
         targetLanguageSearchQueryProperty.set("")
+    }
+
+    private fun updateExistingLanguagePairs() {
+        val homePageViewModel = find<HomePageViewModel2>()
+        val languagePairs = homePageViewModel.projectGroups.map {
+            Pair(it.sourceLanguage, it.targetLanguage)
+        }
+        existingLanguagePairs.setAll(languagePairs)
     }
 }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ProjectWizardViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ProjectWizardViewModel.kt
@@ -35,6 +35,7 @@ class ProjectWizardViewModel : ViewModel() {
     private val filteredTargetLanguage = FilteredList(targetLanguages)
     val sortedSourceLanguages = SortedList(filteredSourceLanguages)
     val sortedTargetLanguages = SortedList(filteredTargetLanguage)
+    val existingLanguagePairs = observableListOf<Pair<Language, Language>>()
 
     val selectedModeProperty = SimpleObjectProperty<ProjectMode>(null)
     val selectedSourceLanguageProperty = SimpleObjectProperty<Language>(null)
@@ -118,6 +119,7 @@ class ProjectWizardViewModel : ViewModel() {
                 )
                 .observeOnFx()
                 .subscribe {
+                    existingLanguagePairs.add(Pair(sourceLanguage, language))
                     reset()
                     onNavigateBack()
                 }


### PR DESCRIPTION
We decided to disable the creation of project that have the source and target language matched an existing project. This prevents, for example, a translation project of `en --> ar` co-exists with a dialect project `en --> ar`. Since the workbook currently doesn't differentiate project modes, they share the same data (!) should both projects exist.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/914)
<!-- Reviewable:end -->
