### PR TITLE
Narration Reset chapter fix

### DIFF
--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/Narration.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/Narration.kt
@@ -19,6 +19,7 @@ import org.wycliffeassociates.otter.common.data.audio.AudioMarker
 import org.wycliffeassociates.otter.common.data.audio.VerseMarker
 import org.wycliffeassociates.otter.common.data.primitives.MimeType
 import org.wycliffeassociates.otter.common.data.workbook.Chapter
+import org.wycliffeassociates.otter.common.data.workbook.DateHolder
 import org.wycliffeassociates.otter.common.data.workbook.Take
 import org.wycliffeassociates.otter.common.data.workbook.Workbook
 import org.wycliffeassociates.otter.common.device.IAudioPlayer
@@ -243,7 +244,7 @@ class Narration @AssistedInject constructor(
     }
 
     fun onResetAll() {
-        val action = ResetAllAction()
+        val action = ResetAllAction(chapter.audio)
         execute(action)
     }
 

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/NarrationActions.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/NarrationActions.kt
@@ -251,7 +251,7 @@ internal class EditVerseAction(
  */
 internal class ResetAllAction(private val chapterAudio: AssociatedAudio) : NarrationAction {
     private val nodes = ArrayList<VerseNode>()
-    private lateinit var recoverableTake: Take
+    private var recoverableTake: Take? = null
 
     override fun execute(totalVerses: MutableList<VerseNode>, workingAudio: AudioFile) {
         // use copy to get nodes that won't share the same pointer otherwise clearing totalVerses will result in
@@ -269,12 +269,13 @@ internal class ResetAllAction(private val chapterAudio: AssociatedAudio) : Narra
         totalVerses.clear()
         // same as with execute; copy the nodes otherwise undo/redo will start erasing the data saved in nodes.
         totalVerses.addAll(nodes.map { it.copy() })
-        recoverableTake
-            .deletedTimestamp
-            .accept(DateHolder.empty)
-            .also {
-                chapterAudio.selectTake(recoverableTake)
-            }
+        recoverableTake?.let {
+            it.deletedTimestamp
+                .accept(DateHolder.empty)
+                .also {
+                    chapterAudio.selectTake(recoverableTake)
+                }
+        }
     }
 
     override fun redo(totalVerses: MutableList<VerseNode>) {

--- a/common/src/test/kotlin/org/wycliffeassociates/otter/common/domain/narration/ResetAllActionTest.kt
+++ b/common/src/test/kotlin/org/wycliffeassociates/otter/common/domain/narration/ResetAllActionTest.kt
@@ -1,16 +1,25 @@
 package org.wycliffeassociates.otter.common.domain.narration
 
+import com.nhaarman.mockitokotlin2.anyOrNull
+import com.nhaarman.mockitokotlin2.doAnswer
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
 import io.mockk.mockk
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
 import org.wycliffeassociates.otter.common.audio.AudioFile
 import org.wycliffeassociates.otter.common.data.audio.VerseMarker
+import org.wycliffeassociates.otter.common.data.workbook.AssociatedAudio
 
 class ResetAllActionTest {
     private val totalVerses: MutableList<VerseNode> = mutableListOf()
     lateinit var workingAudioFile: AudioFile
     val numTestVerses = 31
+    private val mockAssociatedAudio = mock<AssociatedAudio> {
+        on { getSelectedTake() } doReturn (null)
+        on { selectTake(anyOrNull()) } doAnswer { }
+    }
 
     @Before
     fun setup() {
@@ -43,7 +52,7 @@ class ResetAllActionTest {
         Assert.assertTrue(checkIfAnySectorsExists(totalVerses))
         Assert.assertTrue(checkIfAllVerseNodesArePlaced(totalVerses))
 
-        val resetAllAction = ResetAllAction()
+        val resetAllAction = ResetAllAction(mockAssociatedAudio)
 
         resetAllAction.execute(totalVerses, workingAudioFile)
 
@@ -72,7 +81,7 @@ class ResetAllActionTest {
         Assert.assertTrue(checkIfAnySectorsExists(totalVerses))
         Assert.assertTrue(checkIfAllVerseNodesArePlaced(totalVerses))
 
-        val resetAllAction = ResetAllAction()
+        val resetAllAction = ResetAllAction(mockAssociatedAudio)
 
         resetAllAction.execute(totalVerses, workingAudioFile)
 
@@ -93,7 +102,7 @@ class ResetAllActionTest {
         Assert.assertTrue(checkIfAnySectorsExists(totalVerses))
         Assert.assertTrue(checkIfAllVerseNodesArePlaced(totalVerses))
 
-        val resetAllAction = ResetAllAction()
+        val resetAllAction = ResetAllAction(mockAssociatedAudio)
 
         resetAllAction.execute(totalVerses, workingAudioFile)
 


### PR DESCRIPTION
Deletes chapter take upon reset. This correctly updates the completion status of the chapter shown in chapter selector

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/921)
<!-- Reviewable:end -->
