### PR TITLE
Shows narration verse and titles correctly

### DIFF
--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/NarrationTextCell.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/NarrationTextCell.kt
@@ -26,6 +26,7 @@ import javafx.scene.control.ListCell
 import org.slf4j.LoggerFactory
 import org.wycliffeassociates.otter.common.data.audio.AudioMarker
 import org.wycliffeassociates.otter.common.data.audio.VerseMarker
+import org.wycliffeassociates.otter.common.data.primitives.ContentLabel
 import org.wycliffeassociates.otter.common.data.workbook.Chunk
 import org.wycliffeassociates.otter.common.domain.narration.teleprompter.TeleprompterItemState
 import org.wycliffeassociates.otter.jvm.controls.event.BeginRecordingEvent
@@ -88,7 +89,7 @@ class NarrationTextCell(
 
         graphic = view.apply {
 
-            val title = if (item.marker is VerseMarker) item.chunk.title else ""
+            val title = if (item.chunk.label == "verse") item.chunk.title else ""
 
             verseLabelProperty.set(title)
 

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/TeleprompterView.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/TeleprompterView.kt
@@ -70,15 +70,20 @@ class TeleprompterViewModel : ViewModel() {
     fun currentVerseTextBinding(): StringBinding {
         return Bindings.createStringBinding(
             {
-                val title = messages["currentVerseTitle"]
-                val verseTitle = messages["verse"]
-                val stickyVerseLabel = stickyVerseProperty.value?.chunk?.title
-
-                MessageFormat.format(
-                    title,
-                    verseTitle,
-                    stickyVerseLabel
-                )
+                stickyVerseProperty.value?.let { itemData ->
+                    if (itemData.chunk.label == "verse") {
+                        MessageFormat.format(
+                            messages["currentVerseTitle"],
+                            messages["verse"],
+                            itemData.chunk.title
+                        )
+                    } else {
+                        MessageFormat.format(
+                            messages["currentTitle"],
+                            itemData.chunk.textItem.text
+                        )
+                    }
+                }
             },
             stickyVerseProperty
         )

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/TeleprompterView.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/TeleprompterView.kt
@@ -111,11 +111,13 @@ class TeleprompterViewModel : ViewModel() {
     fun updateStickyVerse() {
         val verse = narrationViewModel.narratableList
                 .firstOrNull {
-                    it.state == TeleprompterItemState.RECORD_ACTIVE ||
-                    it.state == TeleprompterItemState.RECORD_AGAIN_ACTIVE ||
-                    it.state == TeleprompterItemState.RECORDING_PAUSED ||
-                    it.state == TeleprompterItemState.RECORD_AGAIN_PAUSED ||
-                    !it.hasRecording 
+                    val activeStates = listOf(
+                        TeleprompterItemState.RECORD_ACTIVE,
+                        TeleprompterItemState.RECORD_AGAIN_ACTIVE,
+                        TeleprompterItemState.RECORDING_PAUSED,
+                        TeleprompterItemState.RECORD_AGAIN_PAUSED
+                    )
+                    it.state in activeStates || !it.hasRecording
                 }
 
         stickyVerseProperty.set(verse)

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/TeleprompterView.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/TeleprompterView.kt
@@ -11,6 +11,7 @@ import javafx.beans.property.SimpleObjectProperty
 import javafx.scene.layout.Priority
 import javafx.util.Duration
 import org.slf4j.LoggerFactory
+import org.wycliffeassociates.otter.common.domain.narration.teleprompter.TeleprompterItemState
 import org.wycliffeassociates.otter.jvm.controls.customizeScrollbarSkin
 import org.wycliffeassociates.otter.jvm.controls.event.RecordAgainEvent
 import org.wycliffeassociates.otter.jvm.controls.narration.*
@@ -109,7 +110,13 @@ class TeleprompterViewModel : ViewModel() {
 
     fun updateStickyVerse() {
         val verse = narrationViewModel.narratableList
-                .firstOrNull { !it.hasRecording }
+                .firstOrNull {
+                    it.state == TeleprompterItemState.RECORD_ACTIVE ||
+                    it.state == TeleprompterItemState.RECORD_AGAIN_ACTIVE ||
+                    it.state == TeleprompterItemState.RECORDING_PAUSED ||
+                    it.state == TeleprompterItemState.RECORD_AGAIN_PAUSED ||
+                    !it.hasRecording 
+                }
 
         stickyVerseProperty.set(verse)
     }

--- a/jvm/workbookapp/src/main/resources/Messages_en.properties
+++ b/jvm/workbookapp/src/main/resources/Messages_en.properties
@@ -79,6 +79,7 @@ restartChapter = Restart Chapter
 narrationTitle = Narrating: {0}
 # 0 - Verse label, 1 - verse number. Example: Current: Verse 1
 currentVerseTitle = Current: {0} {1}
+currentTitle = Current: {0}
 
 # General Actions
 open = Open


### PR DESCRIPTION
- Show verse number for all verses. Previously, some were missing
- Sticky verse label text will render correctly for chapter and book titles instead of `Verse 1 - n`

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/924)
<!-- Reviewable:end -->
