### PR TITLE
Fix Re-Record DISABLED button can be clicked (OT-785)

### DIFF
--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/narration/NarrationTextItem.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/narration/NarrationTextItem.kt
@@ -356,6 +356,8 @@ class NarrationTextItem : VBox() {
                                 stateProperty.isNotEqualTo(TeleprompterItemState.RECORDING_PAUSED)
                             )
                     )
+                ).or(
+                    stateProperty.isEqualTo(TeleprompterItemState.RECORD_AGAIN_DISABLED)
                 )
             }
             if (graphic != null) it.graphic = graphic


### PR DESCRIPTION
Handles the missing case when we pause the re-recording, the inactive "re-record" button can be clicked

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/926)
<!-- Reviewable:end -->
