### PR TITLE
Premature chapter take fix (OT-771)

### DIFF
--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/NarrationViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/NarrationViewModel.kt
@@ -107,7 +107,6 @@ class NarrationViewModel : ViewModel() {
     val chapterTakeBusyProperty = SimpleBooleanProperty()
 
     val chunkTotalProperty = SimpleIntegerProperty(0)
-    var numberOfTitlesProperty = SimpleIntegerProperty(0)
     val chunksList: ObservableList<Chunk> = observableListOf()
     val narratableList: ObservableList<NarrationTextItemData> = observableListOf()
     val recordedVerses = observableListOf<AudioMarker>()
@@ -117,7 +116,10 @@ class NarrationViewModel : ViewModel() {
     val totalAudioSizeProperty = SimpleIntegerProperty()
 
     //FIXME: Refactor this if and when Chunk entries are officially added for Titles in the Workbook
-    val potentiallyFinishedProperty = chunkTotalProperty.eq(recordedVerses.sizeProperty.minus(numberOfTitlesProperty))
+    var numberOfTitlesProperty = SimpleIntegerProperty(0)
+    val potentiallyFinishedProperty = chunkTotalProperty
+        .eq(recordedVerses.sizeProperty.minus(numberOfTitlesProperty))
+        .and(!isRecording)
     val potentiallyFinished by potentiallyFinishedProperty
 
     val pluginContextProperty = SimpleObjectProperty(PluginType.EDITOR)
@@ -294,7 +296,7 @@ class NarrationViewModel : ViewModel() {
     }
 
     private fun createPotentiallyFinishedChapterTake() {
-        if (potentiallyFinished && isRecording == false) {
+        if (potentiallyFinished) {
             chapterTakeBusyProperty.set(true)
             logger.info("Chapter is potentially finished, creating a chapter take")
             narration

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/NarrationViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/NarrationViewModel.kt
@@ -119,7 +119,8 @@ class NarrationViewModel : ViewModel() {
     var numberOfTitlesProperty = SimpleIntegerProperty(0)
     val potentiallyFinishedProperty = chunkTotalProperty
         .eq(recordedVerses.sizeProperty.minus(numberOfTitlesProperty))
-        .and(!isRecording)
+        .and(isRecordingProperty.not())
+        .and(isRecordingAgainProperty.not())
     val potentiallyFinished by potentiallyFinishedProperty
 
     val pluginContextProperty = SimpleObjectProperty(PluginType.EDITOR)
@@ -721,6 +722,7 @@ class NarrationViewModel : ViewModel() {
 
                     recordStart = recordedVerses.isEmpty()
                     recordResume = recordedVerses.isNotEmpty()
+                    createPotentiallyFinishedChapterTake()
                 },
                 { e ->
                     logger.error("Error in active verses subscription", e)


### PR DESCRIPTION
Does not address the issue of creating numerous unnecessary takes, however, it does keep into account book/chapter titles when updating the potentiallyFinished property. 

Planning on making another PR that addresses the unnecessary takes once this is resolved. 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/931)
<!-- Reviewable:end -->
