### PR TITLE
Source langnames from biel not td

### DIFF
--- a/assets/build.gradle
+++ b/assets/build.gradle
@@ -10,7 +10,7 @@ repositories {
         metadataSources { artifact() }
     }
     ivy {
-        url 'https://td.unfoldingword.org/exports/'
+        url 'https://langnames.bibleineverylanguage.org/'
         patternLayout {
             artifact '[artifact].[ext]'
         }
@@ -39,12 +39,12 @@ configurations {
 dependencies {
     content 'bible-translation-tools:en_art_wa:2.0.0@zip'
     content 'bible-translation-tools:en_art_sp:2.0.0@zip'
-    content 'wa-catalog:en_ulb:V21-05@zip'
-    content 'unfoldingword:langnames@json'
     content 'bible-translation-tools:bible_artwork@zip'
-    implementation "io.reactivex.rxjava2:rxkotlin:$rxkotlinVer"
-    implementation project(":common")
+    content 'wa-catalog:en_ulb:V21-05@zip'
+    content 'bibleineverylanguage:langnames@json'
 
+    implementation project(":common")
+    implementation "io.reactivex.rxjava2:rxkotlin:$rxkotlinVer"
     implementation "org.slf4j:slf4j-api:$slf4jApiVer"
     implementation "com.google.dagger:dagger:$daggerVer"
 }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/persistence/database/daos/LanguageDao.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/persistence/database/daos/LanguageDao.kt
@@ -123,6 +123,7 @@ class LanguageDao(
                         entity.gateway,
                         entity.region
                     )
+                    .onConflictDoNothing()
                     .execute()
             }
             // Implicit commit


### PR DESCRIPTION
Changes the location to retrieve langnames from translationDatabase to BibleInEveryLanguage.

As there was a bug in the content from BIEL resulting in a language code being duplicated, an onConflictIgnore option was added to insertAll to make the app language initialization safer.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/937)
<!-- Reviewable:end -->
