### PR TITLE
Fix crash when delete then create project (OT-797)

### DIFF
--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/collections/CreateProject.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/collections/CreateProject.kt
@@ -100,6 +100,7 @@ class CreateProject @Inject constructor(
             }
             .firstOrError()
             .flatMap { rootCollection ->
+                println("--> creating project")
                 collectionRepo
                     .deriveProjects(
                         rootCollection,

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/collections/CreateProject.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/collections/CreateProject.kt
@@ -100,7 +100,6 @@ class CreateProject @Inject constructor(
             }
             .firstOrError()
             .flatMap { rootCollection ->
-                println("--> creating project")
                 collectionRepo
                     .deriveProjects(
                         rootCollection,

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/collections/DeleteProject.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/collections/DeleteProject.kt
@@ -96,7 +96,6 @@ class DeleteProject @Inject constructor(
             .timer(timeoutMillis.toLong(), TimeUnit.MILLISECONDS)
             .andThen {
                 deleteQueue.put(books)
-                println("---------- added to delete queue: ${books.hashCode()}")
                 processDeleteQueue()
                 it.onComplete()
             }
@@ -110,7 +109,6 @@ class DeleteProject @Inject constructor(
     private fun processDeleteQueue() {
         while (deleteQueue.peek() != null) {
             val booksToDelete = deleteQueue.peek()
-            println(">>> processing delete... ${booksToDelete.hashCode()}")
             deleteProjects(booksToDelete).blockingAwait()
             deleteQueue.poll()
         }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/persistence/repositories/CollectionRepository.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/persistence/repositories/CollectionRepository.kt
@@ -124,7 +124,7 @@ class CollectionRepository @Inject constructor(
                             }
                         }
                     } catch (e: Exception) {
-                        log.info("Manifest doesn't exist, so no changes needed. Project : $project.")
+                        log.info("Delete project - Manifest doesn't exist, no changes committed for project: ${project.slug}")
                     }
                 }
             }
@@ -494,10 +494,6 @@ class CollectionRepository @Inject constructor(
             }
             .doOnError { e ->
                 log.error("Error in deriveProject for source collection: $sourceCollection, language: $language")
-                log.error("With:")
-                sourceMetadatas.forEach {
-                    log.error("Metadata: $it")
-                }
                 log.error("End Metadata", e)
             }
             .subscribeOn(Schedulers.io())

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/persistence/repositories/CollectionRepository.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/persistence/repositories/CollectionRepository.kt
@@ -124,7 +124,7 @@ class CollectionRepository @Inject constructor(
                             }
                         }
                     } catch (e: Exception) {
-                        log.info("Delete project - Manifest doesn't exist, no changes committed for project: ${project.slug}")
+                        log.info("Delete project - Manifest doesn't exist, no changes committed for ${project.slug}")
                     }
                 }
             }
@@ -494,6 +494,10 @@ class CollectionRepository @Inject constructor(
             }
             .doOnError { e ->
                 log.error("Error in deriveProject for source collection: $sourceCollection, language: $language")
+                log.error("With:")
+                sourceMetadatas.forEach {
+                    log.error("Metadata: $it")
+                }
                 log.error("End Metadata", e)
             }
             .subscribeOn(Schedulers.io())

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/HomePageViewModel2.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/HomePageViewModel2.kt
@@ -164,7 +164,7 @@ class HomePageViewModel2 : ViewModel() {
      */
     fun deleteProjectGroupWithTimer(cardModel: ProjectGroupCardModel): Disposable {
         val timeoutMillis = NOTIFICATION_DURATION_SEC * 1000
-        projectWizardViewModel.projectDeletingCount.incrementAndGet()
+        projectWizardViewModel.projectDeleteCounter.incrementAndGet()
 
         val completable: Completable = Completable.create { emitter ->
             val timerDisposable = deleteProjectUseCase
@@ -178,7 +178,7 @@ class HomePageViewModel2 : ViewModel() {
                     emitter.onComplete()
                 }
                 .doFinally {
-                    projectWizardViewModel.projectDeletingCount.decrementAndGet()
+                    projectWizardViewModel.projectDeleteCounter.decrementAndGet()
                 }
                 .subscribe()
 

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/HomePageViewModel2.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/HomePageViewModel2.kt
@@ -164,7 +164,7 @@ class HomePageViewModel2 : ViewModel() {
      */
     fun deleteProjectGroupWithTimer(cardModel: ProjectGroupCardModel): Disposable {
         val timeoutMillis = NOTIFICATION_DURATION_SEC * 1000
-        projectWizardViewModel.projectDeleteCounter.incrementAndGet()
+        projectWizardViewModel.increaseProjectDeleteCounter()
 
         val timerDisposable = deleteProjectUseCase
             .deleteProjectsWithTimer(cardModel.books, timeoutMillis.toInt())
@@ -179,7 +179,7 @@ class HomePageViewModel2 : ViewModel() {
                 logger.info("Undo deleting project group ${cardModel.sourceLanguage.name} -> ${cardModel.targetLanguage.name}.")
             }
             .doFinally {
-                projectWizardViewModel.projectDeleteCounter.decrementAndGet()
+                projectWizardViewModel.decreaseProjectDeleteCounter()
             }
             .subscribe()
 

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ProjectWizardViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ProjectWizardViewModel.kt
@@ -51,7 +51,7 @@ class ProjectWizardViewModel : ViewModel() {
 
     val sourceLanguageSearchQueryProperty = SimpleStringProperty("")
     val targetLanguageSearchQueryProperty = SimpleStringProperty("")
-    val projectDeletingCount = AtomicInteger(0)
+    val projectDeleteCounter = AtomicInteger(0)
 
     private val disposableListeners = mutableListOf<ListenerDisposer>()
 
@@ -166,8 +166,9 @@ class ProjectWizardViewModel : ViewModel() {
     }
 
     private fun waitForProjectDeletionFinishes(): Completable {
-        return Observable.interval(100, TimeUnit.MILLISECONDS)
-            .takeWhile { projectDeletingCount.get() > 0 }
+        val waitIntervalMillis = 100L
+        return Observable.interval(waitIntervalMillis, TimeUnit.MILLISECONDS)
+            .takeWhile { projectDeleteCounter.get() > 0 }
             .subscribeOn(Schedulers.io())
             .ignoreElements()
     }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ProjectWizardViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ProjectWizardViewModel.kt
@@ -120,7 +120,7 @@ class ProjectWizardViewModel : ViewModel() {
     fun onLanguageSelected(language: Language, onNavigateBack: () -> Unit) {
         val sourceLanguage = selectedSourceLanguageProperty.value
         if (sourceLanguage != null) {
-            logger.info("Creating project group: ${sourceLanguage.slug} - ${language.slug}")
+            logger.info("Creating project group: ${sourceLanguage.name} - ${language.name}")
             creationUseCase
                 .createAllBooks(
                     sourceLanguage,

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ProjectWizardViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ProjectWizardViewModel.kt
@@ -165,6 +165,9 @@ class ProjectWizardViewModel : ViewModel() {
         disposableListeners.clear()
     }
 
+    /**
+     * Blocks the execution of project creation until projects delete queue completes.
+     */
     private fun waitForProjectDeletionFinishes(): Completable {
         val waitIntervalMillis = 100L
         return Observable.interval(waitIntervalMillis, TimeUnit.MILLISECONDS)

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ProjectWizardViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ProjectWizardViewModel.kt
@@ -167,10 +167,7 @@ class ProjectWizardViewModel : ViewModel() {
 
     private fun waitForProjectDeletionFinishes(): Completable {
         return Observable.interval(100, TimeUnit.MILLISECONDS)
-            .takeWhile {
-                println("waiting for deletion...")
-                projectDeletingCount.get() > 0
-            }
+            .takeWhile { projectDeletingCount.get() > 0 }
             .subscribeOn(Schedulers.io())
             .ignoreElements()
     }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ProjectWizardViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ProjectWizardViewModel.kt
@@ -51,7 +51,7 @@ class ProjectWizardViewModel : ViewModel() {
 
     val sourceLanguageSearchQueryProperty = SimpleStringProperty("")
     val targetLanguageSearchQueryProperty = SimpleStringProperty("")
-    val projectDeleteCounter = AtomicInteger(0)
+    private val projectDeleteCounter = AtomicInteger(0)
 
     private val disposableListeners = mutableListOf<ListenerDisposer>()
 
@@ -164,6 +164,9 @@ class ProjectWizardViewModel : ViewModel() {
         disposableListeners.forEach { it.dispose() }
         disposableListeners.clear()
     }
+
+    fun increaseProjectDeleteCounter() { projectDeleteCounter.incrementAndGet() }
+    fun decreaseProjectDeleteCounter() { projectDeleteCounter.decrementAndGet() }
 
     /**
      * Blocks the execution of project creation until projects delete queue completes.


### PR DESCRIPTION
Executes deletion in sequential order using a Queue. Since we have a timeout until the actual deletion executes, project creation during this time will be delayed until the delete operations finish.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/947)
<!-- Reviewable:end -->
