### PR TITLE
Load chapters after showing export dialog

### DIFF
--- a/jvm/controls/src/main/resources/css/import-export-dialogs.css
+++ b/jvm/controls/src/main/resources/css/import-export-dialogs.css
@@ -11,11 +11,13 @@
 }
 
 .export-project-dialog .export-project-dialog__body {
-    -fx-padding: 12 0;
+    -fx-padding: 0;
 }
 
 .export-project-dialog__body .left-pane {
     -fx-pref-width: 240;
+    -fx-border-width: 0 1 0 0;
+    -fx-border-color: -wa-border-light;
 }
 
 .export-project-dialog__body .radio-button-card__labels {
@@ -38,4 +40,8 @@
 .export-project-dialog__body .radio-button-card__control:focused:selected {
     -fx-background-color: -wa-primary-light;
     -fx-border-color: -wa-primary;
+}
+
+.export-project-dialog__body .column-header-background {
+    -fx-background-radius: 0;
 }

--- a/jvm/controls/src/main/resources/css/theme/light-theme.css
+++ b/jvm/controls/src/main/resources/css/theme/light-theme.css
@@ -159,7 +159,7 @@
 
     /* dialog */
     -wa-dialog-overlay: -wa-black-60;
-    -wa-dialog-background: -wa-background;
+    -wa-dialog-background: -wa-foreground;
 
     /* status */
     -wa-success-color: #82A93F;

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/HomePage2.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/HomePage2.kt
@@ -295,11 +295,14 @@ class HomePage2 : View() {
                 themeProperty.set(settingsViewModel.appColorMode.value)
                 workbookDescriptorProperty.set(workbookDescriptor)
 
+                open()
+
                 exportProjectViewModel.loadChapters(workbookDescriptor)
                     .observeOnFx()
                     .subscribe { chapters ->
                         this.chapters.setAll(chapters)
-                        open()
+                        this.selectedChapters.clear()
+                        this.selectedChapters.addAll(chapters.filter { it.selectable })
                     }
 
                 setOnCloseAction { this.close() }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/dialogs/ExportProjectDialog.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/dialogs/ExportProjectDialog.kt
@@ -24,10 +24,10 @@ import java.text.MessageFormat
 class ExportProjectDialog : OtterDialog() {
 
     val chapters = observableListOf<ChapterDescriptor>()
-    val workbookDescriptorProperty = SimpleObjectProperty<WorkbookDescriptor>()
+    val selectedChapters = observableSetOf<ChapterDescriptor>()
 
+    val workbookDescriptorProperty = SimpleObjectProperty<WorkbookDescriptor>()
     private val exportTypeProperty = SimpleObjectProperty<ExportType>(ExportType.BACKUP)
-    private val selectedChapters = observableSetOf<ChapterDescriptor>()
     private val onCloseActionProperty = SimpleObjectProperty<EventHandler<ActionEvent>>()
     private lateinit var tableView: ExportProjectTableView
 
@@ -125,9 +125,11 @@ class ExportProjectDialog : OtterDialog() {
                 })
             }
             region { hgrow = Priority.ALWAYS }
-            button(messages["export"]) {
+            button(messages["exportProject"]) {
                 addClass("btn", "btn--primary")
                 disableWhen { booleanBinding(selectedChapters) { selectedChapters.isEmpty() } }
+                tooltip(text)
+                graphic = FontIcon(MaterialDesign.MDI_PUBLISH)
 
                 action {
                     val directory = chooseDirectory(FX.messages["exportProject"], owner = currentWindow)

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ExportProjectViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ExportProjectViewModel.kt
@@ -73,7 +73,7 @@ class ExportProjectViewModel : ViewModel() {
                             else -> 0.0
                         }
 
-                        ChapterDescriptor(chapter.sort, progress)
+                        ChapterDescriptor(chapter.sort, progress, progress > 0)
                     }
             }
             .toList()


### PR DESCRIPTION
When opening Export Book dialog, we should first show the dialog and then load the chapters asynchronously to avoid blocking the UI for books with numerous chapters (e.g. Psalms)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/950)
<!-- Reviewable:end -->
