### PR TITLE
Partial fix for verse markers bunching together (OT-768)

### DIFF
--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/AudioWorkspaceView.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/AudioWorkspaceView.kt
@@ -157,7 +157,8 @@ class AudioWorkspaceView : View() {
         viewModel.onDock()
         markerNodes.bind(viewModel.recordedVerses) { marker ->
             VerseMarkerControl().apply {
-                val markerLabel = when(marker) {
+                visibleProperty().set(false)
+                val markerLabel = when (marker) {
                     is ChapterMarker -> "c${marker.label}"
                     else -> marker.label
                 }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/NarrationViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/NarrationViewModel.kt
@@ -842,10 +842,10 @@ class NarrationViewModel : ViewModel() {
                         viewport.last - viewport.first
                     ).toDouble() - (MARKER_AREA_WIDTH / 2) + viewportOffset
                     runLater {
-                        marker.visibleProperty().set(true)
                         if (marker.layoutX != newPos) {
                             marker.layoutX = newPos
                         }
+                        marker.visibleProperty().set(true)
                     }
                     found = true
                 }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/NarrationViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/NarrationViewModel.kt
@@ -845,15 +845,12 @@ class NarrationViewModel : ViewModel() {
                         if (marker.layoutX != newPos) {
                             marker.layoutX = newPos
                         }
-                        marker.visibleProperty().set(true)
                     }
                     found = true
                 }
             }
-            if (!found) {
-                runLater {
-                    marker.visibleProperty().set(false)
-                }
+            runLater {
+                marker.visibleProperty().set(found)
             }
         }
     }


### PR DESCRIPTION
Still does not prevent "flicker".

What originally was happening is that it was showing all verse markers, then adjusting their visibility, then adjusting their position.

Showing all of them by default, then adjusting their visibility was causing them to "bunch together" temporarily. 

To fix this, I have it hiding all markers by default, then adjusting their visibility. I am still not crazy about this fix because it still results in a pretty noticeable flicker when clicking next verse or adjusting markers.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/955)
<!-- Reviewable:end -->
