### PR TITLE
Fix export dialog all chapter selected

### DIFF
--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ExportProjectViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ExportProjectViewModel.kt
@@ -95,7 +95,7 @@ class ExportProjectViewModel : ViewModel() {
 
                                 else -> projectCompletionStatus.getChapterTranslationProgress(chapter)
                             }
-                            ChapterDescriptor(chapter.sort, progress)
+                            ChapterDescriptor(chapter.sort, progress, progress > 0)
                         }
                     }.blockingGet() // blocking get is required for the .cache() observable to emit
             }


### PR DESCRIPTION
Hot fix for a bug related to merging in #946. This causes all chapter to be selected when docking the export modal

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/963)
<!-- Reviewable:end -->
