### PR TITLE
Handle migrated translation project

### DIFF
--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/ChunkingTranslationPage.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/ChunkingTranslationPage.kt
@@ -96,7 +96,9 @@ class ChunkingTranslationPage : View() {
                 visibleWhen {
                     viewModel.selectedStepProperty.booleanBinding { step ->
                         step?.let {
-                            it.ordinal >= ChunkingStep.PEER_EDIT.ordinal
+                            val showSourceText = viewModel.noSourceAudioProperty.value ||
+                                    it.ordinal >= ChunkingStep.PEER_EDIT.ordinal
+                            showSourceText
                         } ?: false
                     }
                 }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/ChunkingTranslationPage.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/ChunkingTranslationPage.kt
@@ -47,7 +47,13 @@ class ChunkingTranslationPage : View() {
 
     private val mainFragmentProperty = viewModel.selectedStepProperty.objectBinding { step ->
         val fragment = when(step) {
-            ChunkingStep.CONSUME_AND_VERBALIZE -> find<Consume>()
+            ChunkingStep.CONSUME_AND_VERBALIZE -> {
+                if (viewModel.noSourceAudioProperty.value) {
+                    find<SourceAudioMissing>()
+                } else {
+                    find<Consume>()
+                }
+            }
             ChunkingStep.CHUNKING -> find<Chunking>()
             ChunkingStep.BLIND_DRAFT -> find<BlindDraft>()
             ChunkingStep.PEER_EDIT,
@@ -80,7 +86,8 @@ class ChunkingTranslationPage : View() {
 
             left = ChunkingStepsDrawer(viewModel.selectedStepProperty).apply {
                 chunksProperty.bind(viewModel.chunkListProperty)
-                this.reachableStepProperty.bind(viewModel.reachableStepProperty)
+                reachableStepProperty.bind(viewModel.reachableStepProperty)
+                noSourceAudioProperty.bind(viewModel.noSourceAudioProperty)
             }
 
             centerProperty().bind(mainFragmentProperty)

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/BlindDraft.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/BlindDraft.kt
@@ -66,6 +66,7 @@ class BlindDraft : View() {
                 label(viewModel.chunkTitleProperty).addClass("h4", "h4--80")
                 simpleaudioplayer {
                     playerProperty.bind(viewModel.sourcePlayerProperty)
+                    disableProperty().bind(playerProperty.isNull)
                     enablePlaybackRateProperty.set(true)
                     sideTextProperty.set(messages["sourceAudio"])
                     menuSideProperty.set(Side.BOTTOM)

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/ChapterReview.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/ChapterReview.kt
@@ -68,6 +68,7 @@ class ChapterReview : View() {
             label(viewModel.chapterTitleProperty).addClass("h4", "h4--80")
             simpleaudioplayer {
                 playerProperty.bind(viewModel.sourcePlayerProperty)
+                disableProperty().bind(playerProperty.isNull)
                 enablePlaybackRateProperty.set(true)
                 sideTextProperty.set(messages["sourceAudio"])
                 menuSideProperty.set(Side.BOTTOM)

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/ChunkingStepsDrawer.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/ChunkingStepsDrawer.kt
@@ -37,6 +37,7 @@ class ChunkingStepsDrawer(
 ) : VBox() {
     val chunksProperty = SimpleListProperty<ChunkViewData>()
     val reachableStepProperty = SimpleObjectProperty<ChunkingStep>(ChunkingStep.BLIND_DRAFT)
+    val noSourceAudioProperty = SimpleBooleanProperty(false)
 
     private val isCollapsedProperty = SimpleBooleanProperty(false)
 
@@ -77,7 +78,10 @@ class ChunkingStepsDrawer(
             isFitToWidth = true
             vbox {
                 chunkingStep(ChunkingStep.CONSUME_AND_VERBALIZE,selectedStepProperty,reachableStepProperty, isCollapsedProperty)
-                chunkingStep(ChunkingStep.CHUNKING, selectedStepProperty, reachableStepProperty, isCollapsedProperty)
+                chunkingStep(ChunkingStep.CHUNKING, selectedStepProperty, reachableStepProperty, isCollapsedProperty) {
+                    visibleWhen(noSourceAudioProperty.not())
+                    managedWhen(visibleProperty())
+                }
                 chunkingStep(ChunkingStep.BLIND_DRAFT, selectedStepProperty, reachableStepProperty, isCollapsedProperty) {
                     chunkListProperty.bind(chunksProperty)
                 }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/PeerEdit.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/PeerEdit.kt
@@ -75,6 +75,7 @@ open class PeerEdit : View() {
             label(viewModel.chunkTitleProperty).addClass("h4", "h4--80")
             simpleaudioplayer {
                 playerProperty.bind(viewModel.sourcePlayerProperty)
+                disableProperty().bind(playerProperty.isNull)
                 enablePlaybackRateProperty.set(true)
                 sideTextProperty.set(messages["sourceAudio"])
                 menuSideProperty.set(Side.BOTTOM)

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/SourceAudioMissing.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/SourceAudioMissing.kt
@@ -220,6 +220,11 @@ class SourceAudioMissing : View() {
         }
     }
 
+    override fun onDock() {
+        super.onDock()
+        viewModel.loadingStepProperty.set(false)
+    }
+
     private fun onDragOverHandler(): EventHandler<DragEvent> {
         return EventHandler {
             if (it.gestureSource != this && it.dragboard.hasFiles()) {

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ChapterReviewViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ChapterReviewViewModel.kt
@@ -211,11 +211,13 @@ class ChapterReviewViewModel : ViewModel(), IMarkerViewModel {
             }
             .subscribeOn(Schedulers.io())
             .observeOnFx()
+            .doFinally {
+                translationViewModel.loadingStepProperty.set(false)
+            }
             .subscribe { audio ->
                 loadVerseMarkers(audio)
                 createWaveformImages(audio)
                 subscribeOnWaveformImages()
-                translationViewModel.loadingStepProperty.set(false)
             }
     }
 

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ChunkingViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ChunkingViewModel.kt
@@ -113,13 +113,15 @@ class ChunkingViewModel : ViewModel(), IMarkerViewModel {
         initializeSourceAudio(workbookDataStore.chapter.sort)
             .subscribeOn(Schedulers.io())
             .observeOnFx()
+            .doFinally {
+                translationViewModel.loadingStepProperty.set(false)
+            }
             .subscribe { sa ->
                 audioDataStore.sourceAudioProperty.set(sa)
                 audio = loadAudio(sa.file)
                 createWaveformImages(audio)
                 loadChunkMarkers(audio)
                 subscribeOnWaveformImages()
-                translationViewModel.loadingStepProperty.set(false)
             }
     }
 

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ConsumeViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ConsumeViewModel.kt
@@ -98,13 +98,15 @@ class ConsumeViewModel : ViewModel(), IMarkerViewModel {
             }
             .subscribeOn(Schedulers.io())
             .observeOnFx()
+            .doFinally {
+                translationViewModel.loadingStepProperty.set(false)
+            }
             .subscribe { sa ->
                 audioDataStore.sourceAudioProperty.set(sa)
                 audio = loadAudio(sa.file)
                 createWaveformImages(audio)
                 subscribeOnWaveformImages()
                 loadSourceMarkers(audio)
-                translationViewModel.loadingStepProperty.set(false)
             }
 
         translationViewModel.currentMarkerProperty.bind(currentMarkerNumberProperty)

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/TranslationViewModel2.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/TranslationViewModel2.kt
@@ -256,18 +256,28 @@ class TranslationViewModel2 : ViewModel() {
                 }
             }
             .doOnComplete { // source audio not found
-                showAudioMissingViewProperty.set(true)
-                if (chapter.chunks.take(1).blockingFirst().isNotEmpty()) {
-                    noSourceAudioProperty.set(true)
-                    updateStep {
-                        selectedStepProperty.set(reachableStepProperty.value)
-                    }
-                } else {
-                    reachableStepProperty.set(null)
-                    compositeDisposable.clear()
-                }
+                handleSourceAudioUnavailable(chapter)
             }
             .subscribe()
+    }
+
+    private fun handleSourceAudioUnavailable(chapter: Chapter) {
+        showAudioMissingViewProperty.set(true)
+        val chapterHasChunks = chapter
+            .chunks
+            .take(1)
+            .blockingFirst()
+            .isNotEmpty()
+
+        if (chapterHasChunks) {
+            noSourceAudioProperty.set(true)
+            updateStep {
+                selectedStepProperty.set(reachableStepProperty.value)
+            }
+        } else {
+            reachableStepProperty.set(null)
+            compositeDisposable.clear()
+        }
     }
 
     private fun resetUndoRedo() {

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/TranslationViewModel2.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/TranslationViewModel2.kt
@@ -58,6 +58,7 @@ class TranslationViewModel2 : ViewModel() {
     val canRedoProperty = SimpleBooleanProperty(false)
     val isFirstChapterProperty = SimpleBooleanProperty(false)
     val isLastChapterProperty = SimpleBooleanProperty(false)
+    val noSourceAudioProperty = SimpleBooleanProperty(false)
     val showAudioMissingViewProperty = SimpleBooleanProperty(false)
     val selectedStepProperty = SimpleObjectProperty<ChunkingStep>(null)
     val reachableStepProperty = SimpleObjectProperty<ChunkingStep>(ChunkingStep.CHUNKING)
@@ -103,6 +104,7 @@ class TranslationViewModel2 : ViewModel() {
 
     fun navigateChapter(chapter: Int) {
         selectedStepProperty.set(null)
+        noSourceAudioProperty.set(false)
         showAudioMissingViewProperty.set(false)
 
         workbookDataStore.workbook.target
@@ -244,6 +246,7 @@ class TranslationViewModel2 : ViewModel() {
             .subscribeOn(Schedulers.io())
             .observeOnFx()
             .doOnSuccess {
+                noSourceAudioProperty.set(false)
                 updateStep {
                     if (reachableStepProperty.value == ChunkingStep.CHUNKING) {
                         selectedStepProperty.set(ChunkingStep.CONSUME_AND_VERBALIZE)
@@ -252,10 +255,17 @@ class TranslationViewModel2 : ViewModel() {
                     }
                 }
             }
-            .doOnComplete {
+            .doOnComplete { // source audio not found
                 showAudioMissingViewProperty.set(true)
-                reachableStepProperty.set(null)
-                compositeDisposable.clear()
+                if (chapter.chunks.take(1).blockingFirst().isNotEmpty()) {
+                    noSourceAudioProperty.set(true)
+                    updateStep {
+                        selectedStepProperty.set(reachableStepProperty.value)
+                    }
+                } else {
+                    reachableStepProperty.set(null)
+                    compositeDisposable.clear()
+                }
             }
             .subscribe()
     }


### PR DESCRIPTION
Allows working with translation projects from Orature 1 after migration/import, UI-wise

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/965)
<!-- Reviewable:end -->
