### PR TITLE
Derive content as verse-by-verse when importing files from Ot1

### DIFF
--- a/assets/src/main/kotlin/org/wycliffeassociates/otter/assets/initialization/Util.kt
+++ b/assets/src/main/kotlin/org/wycliffeassociates/otter/assets/initialization/Util.kt
@@ -41,7 +41,7 @@ internal fun setupImportCallback(
         }
 
         override fun onRequestUserInput(parameter: ImportCallbackParameter): Single<ImportOptions> {
-            throw NotImplementedError("no op")
+            return Single.just(ImportOptions(chapters = parameter.options))
         }
 
         override fun onNotifySuccess(language: String?, project: String?, workbookDescriptor: WorkbookDescriptor?) {

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/project/ProjectAppVersion.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/project/ProjectAppVersion.kt
@@ -1,0 +1,9 @@
+package org.wycliffeassociates.otter.common.domain.project
+
+/**
+ * The app version from which the project file is generated.
+ */
+enum class ProjectAppVersion {
+    ONE,
+    THREE
+}

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/project/importer/OngoingProjectImporter.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/project/importer/OngoingProjectImporter.kt
@@ -402,9 +402,9 @@ class OngoingProjectImporter @Inject constructor(
         project: Collection,
         projectAccessor: ProjectFilesAccessor
     ) {
-        val filteredChapters = takesInChapterFilter?.values?.distinct() ?: listOf()
+        val filteredChapters = takesInChapterFilter?.values?.distinct()
         collectionRepository.getChildren(project).blockingGet()
-            .filter { if (filteredChapters.isEmpty()) true else it.sort in filteredChapters }
+            .filter { filteredChapters == null || it.sort in filteredChapters }
             .forEach { chapter ->
                 val contents = projectAccessor.getChapterContent(project.slug, chapter.sort)
                     .mapIndexed { index, content ->

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/project/importer/OngoingProjectImporter.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/project/importer/OngoingProjectImporter.kt
@@ -391,7 +391,6 @@ class OngoingProjectImporter @Inject constructor(
         chapters.forEach { chapter ->
             if (chunks.containsKey(chapter.sort)) {
                 val contents = chunks[chapter.sort] ?: listOf()
-                println("deleting content for chapter ${chapter.slug}")
                 contentRepository.deleteForCollection(chapter).blockingAwait()
                 contentRepository.insertForCollection(contents, chapter).blockingGet()
             }

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/project/importer/OngoingProjectImporter.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/project/importer/OngoingProjectImporter.kt
@@ -356,7 +356,7 @@ class OngoingProjectImporter @Inject constructor(
                 return serialized.mode
             }
         }
-        // backward compatibility - project mode does not exist until Orature 3
+        // project mode does not exist until Orature 3
         projectAppVersion = ProjectAppVersion.ONE
         return if (targetLanguage.slug == sourceLanguage.slug) {
             ProjectMode.NARRATION
@@ -401,7 +401,7 @@ class OngoingProjectImporter @Inject constructor(
 
     /**
      * Populates all contents under the filtered chapters as verse-by-verse.
-     * This method is used for backward-compatible with projects from Orature 1
+     * This method is used when importing projects from Orature 1
      */
     private fun deriveChapterContentFromVerses(
         project: Collection,

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/project/importer/OngoingProjectImporter.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/project/importer/OngoingProjectImporter.kt
@@ -740,7 +740,7 @@ class OngoingProjectImporter @Inject constructor(
     }
 
     private fun getContent(sig: ContentSignature, project: Collection, metadata: ResourceMetadata): Content? {
-        return contentCache.computeIfAbsent(sig) { (chapter, verse, sort, type) ->
+        return sig.let { (chapter, verse, sort, type) ->
             val collection: Observable<Collection> = collectionRepository
                 .getChildren(project)
                 .flattenAsObservable { it }

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/persistence/repositories/ITakeRepository.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/persistence/repositories/ITakeRepository.kt
@@ -28,6 +28,7 @@ import org.wycliffeassociates.otter.common.data.primitives.Take
 interface ITakeRepository : IRepository<Take> {
     fun insertForContent(take: Take, content: Content): Single<Int>
     fun getByContent(content: Content, includeDeleted: Boolean = false): Single<List<Take>>
+    fun deleteForContent(content: Content): Completable
     fun removeNonExistentTakes(): Completable
     fun markDeleted(take: Take): Completable
     fun getSoftDeletedTakes(project: Collection): Single<List<Take>>

--- a/jvm/workbookapp/src/integration-test/kotlin/integrationtest/projects/export/TestBackupProjectExporter.kt
+++ b/jvm/workbookapp/src/integration-test/kotlin/integrationtest/projects/export/TestBackupProjectExporter.kt
@@ -86,7 +86,6 @@ class TestBackupProjectExporter {
     @Before
     fun setUp() {
         importer.get().import(seedProject).blockingGet()
-        importer.get().import(narrationBackup).blockingGet()
         workbook = workbookRepository.getProjects().blockingGet()
             .find { it.target.slug == ResourceContainerBuilder.defaultProjectSlug }!!
         outputDir = createTempDirectory("orature-export-test").toFile()
@@ -187,6 +186,8 @@ class TestBackupProjectExporter {
 
     @Test
     fun exportNarrationBackup() {
+        importer.get().import(narrationBackup).blockingGet()
+
         val result = exportBackupUseCase.get()
             .export(
                 outputDir,

--- a/jvm/workbookapp/src/integration-test/kotlin/integrationtest/projects/importer/TestOngoingProjectImporter.kt
+++ b/jvm/workbookapp/src/integration-test/kotlin/integrationtest/projects/importer/TestOngoingProjectImporter.kt
@@ -84,7 +84,7 @@ class TestOngoingProjectImporter {
             originalTakes.size
         )
 
-        /* Import the same project with chapter selection provided from callback */
+        /* re-import project with custom chapter filter */
         importOngoingProject(callback = this.callback)
 
         val currentTakes = db.db.takeDao.fetchAll()
@@ -97,9 +97,8 @@ class TestOngoingProjectImporter {
             .distinct()
 
         Assert.assertEquals(
-            "There should be $takesInProject + $takesAdded takes " +
-                    "after importing chapter: $chaptersSelected",
-            takesInProject + takesAdded,
+            "There should be $takesInProject takes after import-override.",
+            takesInProject,
             currentTakes.size
         )
         Assert.assertEquals(takesAdded, addedTakes.size)

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/persistence/repositories/CollectionRepository.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/persistence/repositories/CollectionRepository.kt
@@ -473,17 +473,16 @@ class CollectionRepository @Inject constructor(
                         projectEntity.id,
                         workbookTypeDao.fetchId(mode)
                     )
-
                     if (workbookDescriptor == null) {
-                        // copy the content under chapter-level
-                        if (verseByVerse) {
-                            copyContent(dsl, sourceCollectionEntity.id, mainDerivedMetadata.id)
-                            linkDerivativeContent(dsl, sourceCollectionEntity.id, projectEntity.id)
-                        } else {
-                            copyMetaContent(dsl, sourceCollectionEntity.id, mainDerivedMetadata.id)
-                        }
-
                         insertWorkbookDescriptor(sourceCollection.id, projectEntity.id, mode)
+                    }
+
+                    // copy the content under chapter-level
+                    if (verseByVerse) {
+                        copyContent(dsl, sourceCollectionEntity.id, mainDerivedMetadata.id)
+                        linkDerivativeContent(dsl, sourceCollectionEntity.id, projectEntity.id)
+                    } else {
+                        copyMetaContent(dsl, sourceCollectionEntity.id, mainDerivedMetadata.id)
                     }
 
                     return@transactionResult collectionMapper.mapFromEntity(

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/persistence/repositories/CollectionRepository.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/persistence/repositories/CollectionRepository.kt
@@ -474,16 +474,16 @@ class CollectionRepository @Inject constructor(
                         workbookTypeDao.fetchId(mode)
                     )
                     if (workbookDescriptor == null) {
+                        // copy the content under chapter-level
+                        if (verseByVerse) {
+                            copyContent(dsl, sourceCollectionEntity.id, mainDerivedMetadata.id)
+                            linkDerivativeContent(dsl, sourceCollectionEntity.id, projectEntity.id)
+                        } else {
+                            copyMetaContent(dsl, sourceCollectionEntity.id, mainDerivedMetadata.id)
+                        }
                         insertWorkbookDescriptor(sourceCollection.id, projectEntity.id, mode)
                     }
 
-                    // copy the content under chapter-level
-                    if (verseByVerse) {
-                        copyContent(dsl, sourceCollectionEntity.id, mainDerivedMetadata.id)
-                        linkDerivativeContent(dsl, sourceCollectionEntity.id, projectEntity.id)
-                    } else {
-                        copyMetaContent(dsl, sourceCollectionEntity.id, mainDerivedMetadata.id)
-                    }
 
                     return@transactionResult collectionMapper.mapFromEntity(
                         projectEntity,

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/persistence/repositories/TakeRepository.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/persistence/repositories/TakeRepository.kt
@@ -63,6 +63,21 @@ class TakeRepository @Inject constructor(
             .subscribeOn(Schedulers.io())
     }
 
+    override fun deleteForContent(content: Content): Completable {
+        return Completable
+            .fromAction {
+                takeDao
+                    .fetchByContentId(content.id, true)
+                    .forEach {
+                        takeDao.delete(it)
+                    }
+            }
+            .doOnError { e ->
+                logger.error("Error in deleteForContent: $content\n", e)
+            }
+            .subscribeOn(Schedulers.io())
+    }
+
     /** Set the deleted timestamp to now. */
     override fun markDeleted(take: Take): Completable {
         return Completable


### PR DESCRIPTION
Allows copying Content as verse-by-verse for projects coming from Orature 1
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/966)
<!-- Reviewable:end -->
