### PR TITLE
Fix function overload issue for JDK 13+ and update README with JDK max version allowed

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ More information can be found [here.](https://bibletranslationtools.org/tool/ora
 </p>
 
 # Usage
-Orature runs on OpenJDK 11+. Installers for Windows, Debian-based Linux, and Mac are available in the Releases section of the repository on GitHub.
+Orature runs on OpenJDK >= 11 and <= 20. Installers for Windows, Debian-based Linux, and Mac are available in the Releases section of the repository on GitHub.
 Orature uses the [Door43 Resource Container](https://resource-container.readthedocs.io/en/latest/index.html) format (in zip) for providing source content to narrate, draft, or translate. Currently, Bible content is supported in USFM format, Bible Stories and translation helps are supported in Markdown. Source Audio is supported if contained in the resource container and referrenced in the [media manifest](https://resource-container.readthedocs.io/en/latest/media.html). Note that paths should be local with respect to the container root, not a URL. Supported audio formats include 44.1khz mono 16 bit WAV, and MP3.
 
 # Quickstart
-*Requires Java version 11 or higher. JavaFX is included as a gradle dependency*
+*Requires Java version >= 11 and <= 20. JavaFX is included as a gradle dependency*
 To quickly get started with Orature, follow these steps:
 
 1. **Clone the repository:**

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/domain/resourcecontainer/project/ZipEntryTreeBuilder.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/domain/resourcecontainer/project/ZipEntryTreeBuilder.kt
@@ -35,7 +35,7 @@ class ZipEntryTreeBuilder @Inject constructor() : IZipEntryTreeBuilder {
 
     private fun createZipFileSystem(zipFilename: String): FileSystem {
         val path = Paths.get(zipFilename)
-        return FileSystems.newFileSystem(path, null)
+        return FileSystems.newFileSystem(path, null as java.lang.ClassLoader?)
     }
 
     override fun buildOtterFileTree(


### PR DESCRIPTION
Fixes overload issue described in #967 using suggested fix from the [JDK 13 release notes](https://www.oracle.com/java/technologies/javase/13-relnote-issues.html) by casting null value with `null as java.lang.ClassLoader?` to resolve the ambiguity.

Since build fails on JDK 21.0.1, updates README to indicate max version of JDK is v20 because of [this issue](https://youtrack.jetbrains.com/issue/KT-60507/Kapt-IllegalAccessError-superclass-access-check-failed-using-java-21-toolchain). Probably worth putting in, but if installers package the right JRE it might be irrelevant unless building from source. 

> As a note, the macOS distributable from the installer list is for x86_64 and doesn't work with Apple silicon (arm64).
> Click-to-run after the install caused a crash, and running from the command line gives various versions of:
> ```
> Loading library ... from resource failed: ... 
>     (mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64'))
> ```

Built and tested with JDK 17.0.2 (all tests passing) and JDK 20.0.2 (all tests passing) on macOS Sonoma 14.2.1 (23C71) with M3 (aarch64).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/968)
<!-- Reviewable:end -->
