### PR TITLE
Fix import translation project with different chapters (OT-804)

### DIFF
--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/project/exporter/resourcecontainer/BackupProjectExporter.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/project/exporter/resourcecontainer/BackupProjectExporter.kt
@@ -102,7 +102,7 @@ class BackupProjectExporter @Inject constructor(
                     ) { takeName ->
                         takesFilter(takeName, takeFilenamePattern, options)
                     }
-                    projectAccessor.writeChunksFile(fileWriter)
+                    projectAccessor.writeChunksFile(fileWriter, options?.chapters)
                     projectAccessor.copyProjectModeFile(fileWriter)
                     projectAccessor.writeTakeCheckingStatus(fileWriter, workbook) { path ->
                         takesFilter(path, takeFilenamePattern, options)

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/project/importer/OngoingProjectImporter.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/project/importer/OngoingProjectImporter.kt
@@ -21,7 +21,6 @@ package org.wycliffeassociates.otter.common.domain.project.importer
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.core.JsonFactory
 import com.fasterxml.jackson.core.JsonGenerator
-import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.exc.MismatchedInputException
 import com.fasterxml.jackson.module.kotlin.readValue
@@ -364,19 +363,18 @@ class OngoingProjectImporter @Inject constructor(
         mapper.registerKotlinModule()
         mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL)
 
-        val chunks = mutableMapOf<Int, List<Content>>()
-
-        val file: File = accessor.getChunkFile()
-        try {
-            if (file.exists() && file.length() > 0) {
-                val typeRef: TypeReference<HashMap<Int, List<Content>>> =
-                    object : TypeReference<HashMap<Int, List<Content>>>() {}
-                val map: Map<Int, List<Content>> = mapper.readValue(file, typeRef)
-                chunks.putAll(map)
+        val chunkFileExists = fileReader.exists(RcConstants.CHUNKS_FILE)
+        val chunks: Chunkification = if (chunkFileExists) {
+            try {
+                fileReader.stream(RcConstants.CHUNKS_FILE).let { input ->
+                    mapper.readValue(input)
+                }
+            } catch (e: MismatchedInputException) {
+                // empty file
+                Chunkification()
             }
-        } catch (e: MismatchedInputException) {
-            // clear file if it can't be read
-            file.writer().use { }
+        } else {
+            Chunkification()
         }
 
         val chapters = collectionRepository.getChildren(project).blockingGet()


### PR DESCRIPTION
Avoid deleting other chapters when importing one. For export, only filtered chapters will be written to chunk file

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/969)
<!-- Reviewable:end -->
