### PR TITLE
Fixes Missing Marker Line for Narration in higher JavaFX Versions

### DIFF
--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/markers/VerseMarkerControl.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/markers/VerseMarkerControl.kt
@@ -65,13 +65,13 @@ class VerseMarkerControl : BorderPane() {
 
             dragAreaProperty.set(this)
 
-            region {
+            stackpane {
                 line {
                     addClass("verse-marker__line")
 
-                    startXProperty().bind(this@region.layoutXProperty().plus(MARKER_AREA_WIDTH / 2))
-                    startYProperty().bind(this@region.layoutYProperty())
-                    endXProperty().bind(this@region.widthProperty().minus(MARKER_AREA_WIDTH / 2))
+                    startXProperty().bind(this@stackpane.layoutXProperty().plus(MARKER_AREA_WIDTH / 2))
+                    startYProperty().bind(this@stackpane.layoutYProperty())
+                    endXProperty().bind(this@stackpane.widthProperty().minus(MARKER_AREA_WIDTH / 2))
                     endYProperty().bind(this@VerseMarkerControl.prefHeightProperty())
                     strokeWidth = MARKER_WIDTH
                 }


### PR DESCRIPTION
On JavaFX 21 the line is not added to the region (it does not show up at all on the scene graph). As a result, it is swapped out with a stackpane.

This issue is confirmed at least to be on MacOS and Linux

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/973)
<!-- Reviewable:end -->
