### PR TITLE
Replace JFXProgressBar with MFXProgressBar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -112,16 +112,16 @@ subprojects {
 
     java {
         toolchain {
-            languageVersion = JavaLanguageVersion.of(11)
+            languageVersion = JavaLanguageVersion.of(17)
         }
     }
 
     compileKotlin {
-        kotlinOptions.jvmTarget = "11"
+        kotlinOptions.jvmTarget = "17"
     }
 
     compileTestKotlin {
-        kotlinOptions.jvmTarget = "11"
+        kotlinOptions.jvmTarget = "17"
     }
 
     gradleLint.rules = ['deprecated-dependency-configuration']

--- a/build.gradle
+++ b/build.gradle
@@ -109,7 +109,12 @@ subprojects {
     }
 
     group 'org.wycliffeassociates'
-    sourceCompatibility = 11
+
+    java {
+        toolchain {
+            languageVersion = JavaLanguageVersion.of(11)
+        }
+    }
 
     compileKotlin {
         kotlinOptions.jvmTarget = "11"

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -54,4 +54,5 @@ ext {
     tarsosDspVer = '2.4.1'
     mp3TagVer = '0.9.3'
     tikaVer = '2.0.0'
+    materialFxVer = '11.17.0'
 }

--- a/jvm/controls/build.gradle
+++ b/jvm/controls/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     // JFoenix
     implementation "com.jfoenix:jfoenix:$jfoenixVer"
     implementation "com.github.bkenn:kfoenix:$kfoenixVer"
+    implementation "io.github.palexdev:materialfx:$materialFxVer"
 
     // ControlsFX
     implementation "org.controlsfx:controlsfx:$controlsfxVer"

--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/dialog/ConfirmDialog.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/dialog/ConfirmDialog.kt
@@ -18,7 +18,7 @@
  */
 package org.wycliffeassociates.otter.jvm.controls.dialog
 
-import com.jfoenix.controls.JFXProgressBar
+import io.github.palexdev.materialfx.controls.MFXProgressBar
 import javafx.beans.binding.Bindings
 import javafx.beans.binding.ObjectBinding
 import javafx.beans.property.ObjectProperty
@@ -106,7 +106,7 @@ class ConfirmDialog : OtterDialog() {
         vbox {
             addClass("confirm-dialog__progress")
             add(
-                JFXProgressBar().apply {
+                MFXProgressBar().apply {
                     prefWidthProperty().bind(this@vbox.widthProperty())
                 }
             )

--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/dialog/LoadingModal.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/dialog/LoadingModal.kt
@@ -18,7 +18,7 @@
  */
 package org.wycliffeassociates.otter.jvm.controls.dialog
 
-import com.jfoenix.controls.JFXProgressBar
+import io.github.palexdev.materialfx.controls.MFXProgressBar
 import javafx.beans.property.SimpleStringProperty
 import javafx.scene.layout.Priority
 import javafx.scene.layout.VBox
@@ -38,7 +38,7 @@ class LoadingModal : OtterDialog() {
                 addClass("confirm-dialog__message", "normal-text")
             }
             add(
-                JFXProgressBar().apply {
+                MFXProgressBar().apply {
                     prefWidthProperty().bind(this@vbox.widthProperty())
                 }
             )

--- a/jvm/controls/src/main/resources/css/confirm-dialog.css
+++ b/jvm/controls/src/main/resources/css/confirm-dialog.css
@@ -65,16 +65,21 @@
     -fx-pref-height: 8px;
 }
 
-.confirm-dialog__progress .progress-bar .bar {
+.confirm-dialog__progress .progress-bar .bar1,
+.confirm-dialog__progress .progress-bar .bar2 {
     -fx-background-radius: 6px;
-    -fx-background-color: -wa-primary;
+    -fx-arc-height: 6;
+    -fx-arc-width: 6;
+    -fx-fill: -wa-primary;
 }
 
 .confirm-dialog__progress .progress-bar .track {
-    -fx-background-color: -wa-slider-track-color;
+    -fx-fill: -wa-slider-track-color;
     -fx-background-radius: 6px;
     -fx-border-width: 1px;
     -fx-border-radius: 6px;
+    -fx-arc-height: 6;
+    -fx-arc-width: 6;
     -fx-border-color: -wa-slider-border-color;
 }
 

--- a/jvm/controls/src/main/resources/css/progress-dialog.css
+++ b/jvm/controls/src/main/resources/css/progress-dialog.css
@@ -27,13 +27,18 @@
 }
 
 .progress-dialog .progress-bar .track {
-    -fx-background-color: -wa-progress-track-background;
+    -fx-fill: -wa-progress-track-background;
     -fx-background-insets: 0;
     -fx-background-radius: 5px;
+    -fx-arc-height: 5;
+    -fx-arc-width: 5;
 }
 
-.progress-dialog .progress-bar .bar {
-    -fx-background-color: -wa-progress-foreground;
+.progress-dialog .progress-bar .bar1,
+ .progress-dialog .progress-bar .bar2 {
+    -fx-fill: -wa-progress-foreground;
     -fx-background-insets: 0;
     -fx-background-radius: 8px 0 0 8px;
+    -fx-arc-height: 5;
+    -fx-arc-width: 5;
 }

--- a/jvm/controls/src/main/resources/org/wycliffeassociates/otter/jvm/controls/skins/cards/ChapterCard.fxml
+++ b/jvm/controls/src/main/resources/org/wycliffeassociates/otter/jvm/controls/skins/cards/ChapterCard.fxml
@@ -26,6 +26,7 @@
 <?import org.kordamp.ikonli.javafx.*?>
 
 <?import javafx.scene.image.ImageView?>
+<?import io.github.palexdev.materialfx.controls.MFXProgressBar?>
 <HBox fx:id="root" spacing="10.0" xmlns="http://javafx.com/javafx/11.0.1" xmlns:fx="http://javafx.com/fxml/1">
     <children>
         <StackPane alignment="CENTER" HBox.hgrow="NEVER" prefWidth="70.0" styleClass="chapter-card__graphic">
@@ -54,7 +55,7 @@
                                         <FontIcon iconLiteral="mdi-rocket" iconSize="18" />
                                     </graphic>
                                 </Label>
-                                <JFXProgressBar fx:id="recordedProgress" styleClass="chapter-card__recorded-progress" maxWidth="1.7976931348623157E308" progress="0.0" HBox.hgrow="ALWAYS" />
+                                <MFXProgressBar fx:id="recordedProgress" styleClass="chapter-card__recorded-progress" maxWidth="1.7976931348623157E308" progress="0.0" HBox.hgrow="ALWAYS" />
                                 <Label fx:id="recordedChunks" text="0/0" HBox.hgrow="NEVER" />
                             </children>
                         </HBox>
@@ -65,7 +66,7 @@
                                         <FontIcon iconLiteral="mdi-check-circle-outline" />
                                     </graphic>
                                 </Label>
-                                <JFXProgressBar fx:id="selectedProgress" styleClass="chapter-card__selected-progress" maxWidth="1.7976931348623157E308" progress="0.0" HBox.hgrow="ALWAYS" />
+                                <MFXProgressBar fx:id="selectedProgress" styleClass="chapter-card__selected-progress" maxWidth="1.7976931348623157E308" progress="0.0" HBox.hgrow="ALWAYS" />
                                 <Label fx:id="selectedChunks" text="0/0" HBox.hgrow="NEVER" />
                             </children>
                         </HBox>

--- a/jvm/workbookapp/build.gradle
+++ b/jvm/workbookapp/build.gradle
@@ -50,7 +50,7 @@ sourceSets {
 }
 
 compileIntegrationTestKotlin {
-    kotlinOptions.jvmTarget = "11"
+    kotlinOptions.jvmTarget = "17"
 }
 
 configurations {

--- a/jvm/workbookapp/build.gradle
+++ b/jvm/workbookapp/build.gradle
@@ -120,6 +120,7 @@ dependencies {
     // JFoenix
     implementation "com.jfoenix:jfoenix:$jfoenixVer"
     implementation "com.github.bkenn:kfoenix:$kfoenixVer"
+    implementation "io.github.palexdev:materialfx:$materialFxVer"
 
     // ControlsFX
     implementation "org.wycliffeassociates:javafx-gridview:$javaGridviewVer"

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/drawer/SettingsView.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/drawer/SettingsView.kt
@@ -18,7 +18,7 @@
  */
 package org.wycliffeassociates.otter.jvm.workbookapp.ui.components.drawer
 
-import com.jfoenix.controls.JFXProgressBar
+import io.github.palexdev.materialfx.controls.MFXProgressBar
 import javafx.application.Platform
 import javafx.collections.ObservableList
 import javafx.scene.control.Button
@@ -264,7 +264,7 @@ class SettingsView : View() {
                             stackpane {
                                 addClass("app-drawer-progress-bar")
                                 hgrow = Priority.ALWAYS
-                                add(JFXProgressBar().apply {
+                                add(MFXProgressBar().apply {
                                     progressBar = this
                                     hgrow = Priority.ALWAYS
                                     addClass("app-drawer-progress")

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/updater/install4j/ui/view/UpdateDownloadingFragment.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/updater/install4j/ui/view/UpdateDownloadingFragment.kt
@@ -18,7 +18,7 @@
  */
 package org.wycliffeassociates.otter.jvm.workbookapp.updater.install4j.ui.view
 
-import com.jfoenix.controls.JFXProgressBar
+import io.github.palexdev.materialfx.controls.MFXProgressBar
 import org.wycliffeassociates.otter.jvm.workbookapp.updater.install4j.ui.viewmodel.AppUpdaterViewModel
 import tornadofx.*
 
@@ -48,7 +48,7 @@ class UpdateDownloadingFragment : Fragment() {
         }
 
         add(
-            JFXProgressBar().apply {
+            MFXProgressBar().apply {
                 prefWidth = 300.0
                 progressProperty().bind(vm.percentCompleteProperty.divide(100.0))
             }


### PR DESCRIPTION
Replaces the JFoenix Progress Bar with MaterialFx ProgressBar

The JFXProgressBar causes a ClassNotDefinedException on higher versions of JavaFX

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/974)
<!-- Reviewable:end -->
