### PR TITLE
Temporary fix for incorrect data after opening edit verse (OT-803)

### DIFF
--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/NarrationHeader.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/NarrationHeader.kt
@@ -93,7 +93,8 @@ class NarrationHeader : View() {
             }
             narrationMenuButton(
                 viewModel.hasChapterTakeProperty,
-                viewModel.hasVersesProperty
+                viewModel.hasVersesProperty,
+                viewModel.hasAllVersesRecordedProperty
             ) {
                 enableWhen(viewModel.chapterTakeBusyProperty.not())
             }
@@ -150,7 +151,7 @@ class NarrationHeaderViewModel : ViewModel() {
     val hasNextChapter = SimpleBooleanProperty()
     val hasPreviousChapter = SimpleBooleanProperty()
     val hasVersesProperty = SimpleBooleanProperty()
-
+    val hasAllVersesRecordedProperty = SimpleBooleanProperty()
     val chapterTakeProperty = SimpleObjectProperty<Take>()
     val hasChapterTakeProperty = chapterTakeProperty.isNotNull
     val chapterTakeBusyProperty = SimpleBooleanProperty()
@@ -182,6 +183,7 @@ class NarrationHeaderViewModel : ViewModel() {
         hasUndoProperty.bind(narrationViewModel.hasUndoProperty)
         hasRedoProperty.bind(narrationViewModel.hasRedoProperty)
         hasVersesProperty.bind(narrationViewModel.hasVersesProperty)
+        hasAllVersesRecordedProperty.bind(narrationViewModel.hasAllVersesRecordedProperty)
     }
 
     private enum class StepDirection {

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/NarrationViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/NarrationViewModel.kt
@@ -134,9 +134,10 @@ class NarrationViewModel : ViewModel() {
     val totalAudioSizeProperty = SimpleIntegerProperty()
 
     //FIXME: Refactor this if and when Chunk entries are officially added for Titles in the Workbook
-    var numberOfTitlesProperty = SimpleIntegerProperty(0)
-    val potentiallyFinishedProperty = chunkTotalProperty
+    val numberOfTitlesProperty = SimpleIntegerProperty(0)
+    val hasAllVersesRecordedProperty = chunkTotalProperty
         .eq(recordedVerses.sizeProperty.minus(numberOfTitlesProperty))
+    val potentiallyFinishedProperty = hasAllVersesRecordedProperty
         .and(isRecordingProperty.not())
         .and(isRecordingAgainProperty.not())
     val potentiallyFinished by potentiallyFinishedProperty

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/menu/NarrationMenu.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/menu/NarrationMenu.kt
@@ -34,6 +34,7 @@ class NarrationMenu : ContextMenu() {
 
     val hasChapterTakeProperty = SimpleBooleanProperty()
     val hasVersesProperty = SimpleBooleanProperty()
+    val hasAllVersesRecordedProperty = SimpleBooleanProperty()
 
     init {
         addClass("wa-context-menu")
@@ -57,7 +58,7 @@ class NarrationMenu : ContextMenu() {
             action {
                 FX.eventbus.fire(NarrationOpenInPluginEvent(PluginType.MARKER))
             }
-            enableWhen(hasChapterTakeProperty)
+            enableWhen(hasChapterTakeProperty.and(hasAllVersesRecordedProperty))
         }
         val restartChapterOpt = MenuItem().apply {
             graphic = label(messages["restartChapter"]) {
@@ -77,6 +78,7 @@ class NarrationMenu : ContextMenu() {
 fun EventTarget.narrationMenuButton(
     hasChapterTakeBinding: ObservableBooleanValue,
     hasVersesBinding: ObservableBooleanValue,
+    hasAllVersesRecordedProperty: ObservableBooleanValue,
     op: Button.() -> Unit = {}
 ): Button {
     return Button().attachTo(this).apply {
@@ -87,6 +89,7 @@ fun EventTarget.narrationMenuButton(
         val menu = NarrationMenu().apply {
             this.hasChapterTakeProperty.bind(hasChapterTakeBinding)
             this.hasVersesProperty.bind(hasVersesBinding)
+            this.hasAllVersesRecordedProperty.bind(hasAllVersesRecordedProperty)
         }
 
         menu.setOnShowing { addPseudoClass("active") }


### PR DESCRIPTION
Not a long term fix, but keeps the user from entering an incorrect state in narration after opening the verse marker app directly after a restart chapter action

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/989)
<!-- Reviewable:end -->
