### PR TITLE
Fix inconsistent checking state of translation (OT-810)

### DIFF
--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/persistence/repositories/WorkbookRepository.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/persistence/repositories/WorkbookRepository.kt
@@ -395,9 +395,13 @@ class WorkbookRepository(
         return take.checkingState
             .concatMapCompletable {
                 val takeToUpdate = modelTake.copy(checkingStatus = it.status, checksum = it.checksum)
-                content.selectedTake = takeToUpdate
-                db.updateTake(takeToUpdate)
-                    .andThen(db.updateContent(content))
+                if (content.selectedTake?.path == takeToUpdate.path) {
+                    content.selectedTake = takeToUpdate
+                    db.updateTake(takeToUpdate)
+                        .andThen(db.updateContent(content))  // update checking status of selected take
+                } else {
+                    db.updateTake(takeToUpdate)
+                }
             }
             .subscribeOn(Schedulers.io())
             .doOnError { e -> logger.error("Error in Take's Checking Status subscription: $take", e) }

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/persistence/repositories/WorkbookRepository.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/persistence/repositories/WorkbookRepository.kt
@@ -387,12 +387,17 @@ class WorkbookRepository(
             }
     }
 
-    private fun subscribeToCheckingStatus(take: WorkbookTake, modelTake: ModelTake): Disposable {
+    private fun subscribeToCheckingStatus(
+        take: WorkbookTake,
+        modelTake: ModelTake,
+        content: Content
+    ): Disposable {
         return take.checkingState
-            .flatMapCompletable {
-                db.updateTake(
-                    modelTake.copy(checkingStatus =  it.status, checksum = it.checksum)
-                )
+            .concatMapCompletable {
+                val takeToUpdate = modelTake.copy(checkingStatus = it.status, checksum = it.checksum)
+                content.selectedTake = takeToUpdate
+                db.updateTake(takeToUpdate)
+                    .andThen(db.updateContent(content))
             }
             .subscribeOn(Schedulers.io())
             .doOnError { e -> logger.error("Error in Take's Checking Status subscription: $take", e) }
@@ -535,7 +540,7 @@ class WorkbookRepository(
             .doOnNext { (wbTake, modelTake) ->
                 if (content.type == ContentType.TEXT) {
                     wbTake?.let {
-                        subscribeToCheckingStatus(it, modelTake) // subscribe to takes from db
+                        subscribeToCheckingStatus(it, modelTake, content) // subscribe to takes from db
                     }
                 }
                 takeMap[wbTake] = modelTake
@@ -575,7 +580,7 @@ class WorkbookRepository(
                         selectedTakeRelay.accept(TakeHolder(wbTake))
 
                         if (content.type == ContentType.TEXT) {
-                            subscribeToCheckingStatus(wbTake, modelTake) // subscribe to takes from UI
+                            subscribeToCheckingStatus(wbTake, modelTake, content) // subscribe to takes from UI
                         }
                     }
             }


### PR DESCRIPTION
Chunk (Content) stored in `activeConnection` cache needs to be updated when the Take's checking status changes

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/990)
<!-- Reviewable:end -->
