### PR TITLE
Blocking-write chunk markers when undocking Chunking

### DIFF
--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ChunkingViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ChunkingViewModel.kt
@@ -246,7 +246,7 @@ class ChunkingViewModel : ViewModel(), IMarkerViewModel {
 
                 completable.onComplete()
             }
-            .subscribe()
+            .blockingAwait() // ensures chunks are written before going to next step
     }
 
     fun pause() {


### PR DESCRIPTION
Prevents incorrect state when reading chunked audio **before** chunks are saved to file. This happens when moving from Chunking step to Blind Draft step

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/991)
<!-- Reviewable:end -->
