### PR TITLE
Avoid duplicating content when importing the same book as source

### DIFF
--- a/jvm/workbookapp/src/integration-test/kotlin/integrationtest/projects/TestRcImport.kt
+++ b/jvm/workbookapp/src/integration-test/kotlin/integrationtest/projects/TestRcImport.kt
@@ -246,4 +246,26 @@ class TestRcImport {
                 )
             }
     }
+
+    @Test
+    fun testImportDuplicateSourceRC() {
+        val ulbRowCount = RowCount(
+            collections = 1256,
+            contents = mapOf(
+                META to 1189,
+                TEXT to 31104
+            )
+        )
+
+        // importing the same source twice won't duplicate content
+        dbEnvProvider.get()
+            .import("en_ulb.zip")
+            .assertRowCounts(
+                ulbRowCount
+            )
+            .import("en_ulb.zip")
+            .assertRowCounts(
+                ulbRowCount
+            )
+    }
 }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/persistence/repositories/ResourceContainerRepository.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/persistence/repositories/ResourceContainerRepository.kt
@@ -232,10 +232,6 @@ class ResourceContainerRepository @Inject constructor(
                 ?.forEach(resourceRepository::calculateAndSetSubtreeHasResources)
         }
 
-        fun updateCollection(node: OtterTreeNode<CollectionOrContent>) {
-
-        }
-
         /** Finds a collection from the database that matches the given collection on slug, label, and containerId. */
         private fun fetchCollectionFromDb(collection: Collection, containerId: Int): Collection? {
             val entity = collectionDao.fetch(


### PR DESCRIPTION
Follows up #996 - importing source with the same version caused duplicate contents. We now skip the books that are already in the database and only import/merge the new ones.
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/1008)
<!-- Reviewable:end -->
