### PR TITLE
Add additional events when to clear waveform

### DIFF
--- a/assets/src/main/kotlin/org/wycliffeassociates/otter/assets/initialization/InitializeMarker.kt
+++ b/assets/src/main/kotlin/org/wycliffeassociates/otter/assets/initialization/InitializeMarker.kt
@@ -41,7 +41,7 @@ class InitializeMarker @Inject constructor(
 ) : Installable {
 
     override val name = "MARKER"
-    override val version = 32
+    override val version = 33
     private val log = LoggerFactory.getLogger(InitializeMarker::class.java)
 
     override fun exec(progressEmitter: ObservableEmitter<ProgressStatus>): Completable {

--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/event/NavigationRequestEvent.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/event/NavigationRequestEvent.kt
@@ -24,6 +24,6 @@ import tornadofx.View
 class NavigationRequestEvent(val view: View) : FXEvent()
 class NavigationRequestBlockedEvent(val navigationRequest: NavigationRequestEvent) : FXEvent()
 class NavigateChapterEvent(val chapterNumber: Int) : FXEvent()
-class BeforeNavigationEvent : FXEvent()
+class TranslationNavigationEvent : FXEvent()
 
 object AppCloseRequestEvent : FXEvent()

--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/event/NavigationRequestEvent.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/event/NavigationRequestEvent.kt
@@ -24,5 +24,6 @@ import tornadofx.View
 class NavigationRequestEvent(val view: View) : FXEvent()
 class NavigationRequestBlockedEvent(val navigationRequest: NavigationRequestEvent) : FXEvent()
 class NavigateChapterEvent(val chapterNumber: Int) : FXEvent()
+class BeforeNavigationEvent : FXEvent()
 
 object AppCloseRequestEvent : FXEvent()

--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/waveform/MarkerPlacementWaveform.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/waveform/MarkerPlacementWaveform.kt
@@ -98,12 +98,17 @@ class MarkerPlacementWaveform : StackPane() {
 
     private val waveformFrame: WaveformFrame
 
-    fun freeImages() {
+    fun cleanup() {
         waveformFrame.freeImages()
+        top.resetState()
     }
 
     fun addWaveformImage(image: Image) {
         waveformFrame.addImage(image)
+    }
+
+    fun initializeMarkers() {
+        top.initialize()
     }
 
     private lateinit var top: MarkerTrackControl

--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/waveform/WaveformFrame.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/waveform/WaveformFrame.kt
@@ -27,7 +27,6 @@ import javafx.geometry.Pos
 import javafx.scene.Node
 import javafx.scene.effect.ColorAdjust
 import javafx.scene.image.Image
-import javafx.scene.image.ImageView
 import javafx.scene.input.KeyCode
 import javafx.scene.layout.HBox
 import javafx.scene.layout.Region

--- a/jvm/markerapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/markerapp/app/view/MarkerView.kt
+++ b/jvm/markerapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/markerapp/app/view/MarkerView.kt
@@ -53,13 +53,15 @@ class MarkerView : PluginEntrypoint() {
         slider?.let {
             viewModel.initializeAudioController(it)
         }
-        waveform.markers.bind(viewModel.markers, { it })
+        waveform.markers.bind(viewModel.markers) { it }
+        waveform.initializeMarkers()
+        viewModel.cleanupWaveform = waveform::cleanup
     }
 
     init {
-        tryImportStylesheet(resources.get("/css/verse-marker-app.css"))
-        tryImportStylesheet(resources.get("/css/scrolling-waveform.css"))
-        tryImportStylesheet(resources.get("/css/chunk-marker.css"))
+        tryImportStylesheet(resources["/css/verse-marker-app.css"])
+        tryImportStylesheet(resources["/css/scrolling-waveform.css"])
+        tryImportStylesheet(resources["/css/chunk-marker.css"])
 
         subscribe<PluginCloseRequestEvent> {
             unsubscribe()

--- a/jvm/markerapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/markerapp/app/viewmodel/VerseMarkerViewModel.kt
+++ b/jvm/markerapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/markerapp/app/viewmodel/VerseMarkerViewModel.kt
@@ -86,6 +86,8 @@ class VerseMarkerViewModel : ViewModel(), IMarkerViewModel {
 
     override var resumeAfterScroll = false
 
+    var cleanupWaveform: () -> Unit = {}
+
     private var timer: AnimationTimer? = object : AnimationTimer() {
         override fun handle(currentNanoTime: Long) {
             calculatePosition()
@@ -172,6 +174,7 @@ class VerseMarkerViewModel : ViewModel(), IMarkerViewModel {
         audioController!!.release()
         audioController = null
         asyncBuilder.cancel()
+        cleanupWaveform()
 
         writeMarkers()
             .doOnError { e ->

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/AppBar.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/AppBar.kt
@@ -25,7 +25,6 @@ import org.kordamp.ikonli.javafx.FontIcon
 import org.kordamp.ikonli.materialdesign.MaterialDesign
 import org.wycliffeassociates.otter.jvm.controls.button.AppBarButton
 import org.wycliffeassociates.otter.jvm.controls.event.NavigationRequestEvent
-import org.wycliffeassociates.otter.jvm.controls.event.BeforeNavigationEvent
 import org.wycliffeassociates.otter.jvm.controls.styles.tryImportStylesheet
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.components.drawer.AddFilesView
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.components.drawer.DrawerEvent
@@ -52,7 +51,6 @@ class AppBar : Fragment() {
         toggleGroup = buttonsToggleGroup
         selectedProperty().onChange { removePseudoClass("selected") }
         setOnMouseClicked {
-            fire(BeforeNavigationEvent())
             val homePage = find<HomePage2>()
             fire(NavigationRequestEvent(homePage))
         }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/AppBar.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/AppBar.kt
@@ -25,6 +25,7 @@ import org.kordamp.ikonli.javafx.FontIcon
 import org.kordamp.ikonli.materialdesign.MaterialDesign
 import org.wycliffeassociates.otter.jvm.controls.button.AppBarButton
 import org.wycliffeassociates.otter.jvm.controls.event.NavigationRequestEvent
+import org.wycliffeassociates.otter.jvm.controls.event.BeforeNavigationEvent
 import org.wycliffeassociates.otter.jvm.controls.styles.tryImportStylesheet
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.components.drawer.AddFilesView
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.components.drawer.DrawerEvent
@@ -51,6 +52,7 @@ class AppBar : Fragment() {
         toggleGroup = buttonsToggleGroup
         selectedProperty().onChange { removePseudoClass("selected") }
         setOnMouseClicked {
+            fire(BeforeNavigationEvent())
             val homePage = find<HomePage2>()
             fire(NavigationRequestEvent(homePage))
         }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/ChapterReview.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/ChapterReview.kt
@@ -177,7 +177,8 @@ class ChapterReview : View() {
         logger.info("Final Review docked.")
         timer = startAnimationTimer { viewModel.calculatePosition() }
         waveform.initializeMarkers()
-        viewModel.subscribeOnWaveformImages = ::subscribeOnWaveformImages
+        viewModel.subscribeOnWaveformImagesProperty.set(::subscribeOnWaveformImages)
+        viewModel.cleanupWaveformProperty.set(waveform::cleanup)
         viewModel.dock()
         subscribeEvents()
     }
@@ -209,11 +210,11 @@ class ChapterReview : View() {
         }.also { eventSubscriptions.add(it) }
 
         subscribe<TranslationNavigationEvent> {
-            waveform.cleanup()
+            viewModel.cleanupWaveform()
         }.also { eventSubscriptions.add(it) }
 
         subscribe<NavigationRequestEvent> { // navigate Home
-            waveform.cleanup()
+            viewModel.cleanupWaveform()
         }.also { eventSubscriptions.add(it) }
     }
 

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/ChapterReview.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/ChapterReview.kt
@@ -31,6 +31,7 @@ import org.kordamp.ikonli.materialdesign.MaterialDesign
 import org.slf4j.LoggerFactory
 import org.wycliffeassociates.otter.jvm.controls.Shortcut
 import org.wycliffeassociates.otter.jvm.controls.createAudioScrollBar
+import org.wycliffeassociates.otter.jvm.controls.event.BeforeNavigationEvent
 import org.wycliffeassociates.otter.jvm.controls.event.GoToNextChapterEvent
 import org.wycliffeassociates.otter.jvm.controls.event.MarkerDeletedEvent
 import org.wycliffeassociates.otter.jvm.controls.event.MarkerMovedEvent
@@ -96,8 +97,6 @@ class ChapterReview : View() {
                 setOnRewind(viewModel::rewind)
                 setOnFastForward(viewModel::fastForward)
                 setOnToggleMedia(viewModel::mediaToggle)
-
-                viewModel.subscribeOnWaveformImages = ::subscribeOnWaveformImages
 
                 markers.bind(viewModel.markers) { it }
             }
@@ -177,6 +176,7 @@ class ChapterReview : View() {
         logger.info("Final Review docked.")
         timer = startAnimationTimer { viewModel.calculatePosition() }
         waveform.initializeMarkers()
+        viewModel.subscribeOnWaveformImages = ::subscribeOnWaveformImages
         viewModel.dock()
         subscribeEvents()
     }
@@ -184,7 +184,6 @@ class ChapterReview : View() {
     override fun onUndock() {
         logger.info("Final Review undocked.")
         timer?.stop()
-        waveform.cleanup()
         viewModel.undock()
         unsubscribeEvents()
     }
@@ -206,6 +205,10 @@ class ChapterReview : View() {
 
         subscribe<RedoChunkingPageEvent> {
             viewModel.redoMarker()
+        }.also { eventSubscriptions.add(it) }
+
+        subscribe<BeforeNavigationEvent> {
+            waveform.cleanup()
         }.also { eventSubscriptions.add(it) }
     }
 

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/ChapterReview.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/ChapterReview.kt
@@ -31,10 +31,11 @@ import org.kordamp.ikonli.materialdesign.MaterialDesign
 import org.slf4j.LoggerFactory
 import org.wycliffeassociates.otter.jvm.controls.Shortcut
 import org.wycliffeassociates.otter.jvm.controls.createAudioScrollBar
-import org.wycliffeassociates.otter.jvm.controls.event.BeforeNavigationEvent
+import org.wycliffeassociates.otter.jvm.controls.event.TranslationNavigationEvent
 import org.wycliffeassociates.otter.jvm.controls.event.GoToNextChapterEvent
 import org.wycliffeassociates.otter.jvm.controls.event.MarkerDeletedEvent
 import org.wycliffeassociates.otter.jvm.controls.event.MarkerMovedEvent
+import org.wycliffeassociates.otter.jvm.controls.event.NavigationRequestEvent
 import org.wycliffeassociates.otter.jvm.controls.event.RedoChunkingPageEvent
 import org.wycliffeassociates.otter.jvm.controls.event.UndoChunkingPageEvent
 import org.wycliffeassociates.otter.jvm.controls.media.simpleaudioplayer
@@ -207,7 +208,11 @@ class ChapterReview : View() {
             viewModel.redoMarker()
         }.also { eventSubscriptions.add(it) }
 
-        subscribe<BeforeNavigationEvent> {
+        subscribe<TranslationNavigationEvent> {
+            waveform.cleanup()
+        }.also { eventSubscriptions.add(it) }
+
+        subscribe<NavigationRequestEvent> { // navigate Home
             waveform.cleanup()
         }.also { eventSubscriptions.add(it) }
     }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/Chunking.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/Chunking.kt
@@ -144,7 +144,8 @@ class Chunking : View() {
         subscribeEvents()
         timer = startAnimationTimer { viewModel.calculatePosition() }
         waveform.initializeMarkers()
-        viewModel.subscribeOnWaveformImages = ::subscribeOnWaveformImages
+        viewModel.subscribeOnWaveformImagesProperty.set(::subscribeOnWaveformImages)
+        viewModel.cleanupWaveformProperty.set(waveform::cleanup)
         viewModel.dock()
     }
 
@@ -176,11 +177,11 @@ class Chunking : View() {
         }.also { eventSubscriptions.add(it) }
 
         subscribe<TranslationNavigationEvent> {
-            waveform.cleanup()
+            viewModel.cleanupWaveform()
         }.also { eventSubscriptions.add(it) }
 
         subscribe<NavigationRequestEvent> { // navigate Home
-            waveform.cleanup()
+            viewModel.cleanupWaveform()
         }.also { eventSubscriptions.add(it) }
     }
 

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/Chunking.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/Chunking.kt
@@ -31,9 +31,10 @@ import org.kordamp.ikonli.materialdesign.MaterialDesign
 import org.slf4j.LoggerFactory
 import org.wycliffeassociates.otter.jvm.controls.Shortcut
 import org.wycliffeassociates.otter.jvm.controls.createAudioScrollBar
-import org.wycliffeassociates.otter.jvm.controls.event.BeforeNavigationEvent
+import org.wycliffeassociates.otter.jvm.controls.event.TranslationNavigationEvent
 import org.wycliffeassociates.otter.jvm.controls.event.MarkerDeletedEvent
 import org.wycliffeassociates.otter.jvm.controls.event.MarkerMovedEvent
+import org.wycliffeassociates.otter.jvm.controls.event.NavigationRequestEvent
 import org.wycliffeassociates.otter.jvm.controls.event.RedoChunkingPageEvent
 import org.wycliffeassociates.otter.jvm.controls.event.UndoChunkingPageEvent
 import org.wycliffeassociates.otter.jvm.controls.model.pixelsToFrames
@@ -174,7 +175,11 @@ class Chunking : View() {
             viewModel.redoMarker()
         }.also { eventSubscriptions.add(it) }
 
-        subscribe<BeforeNavigationEvent> {
+        subscribe<TranslationNavigationEvent> {
+            waveform.cleanup()
+        }.also { eventSubscriptions.add(it) }
+
+        subscribe<NavigationRequestEvent> { // navigate Home
             waveform.cleanup()
         }.also { eventSubscriptions.add(it) }
     }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/Chunking.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/Chunking.kt
@@ -31,6 +31,7 @@ import org.kordamp.ikonli.materialdesign.MaterialDesign
 import org.slf4j.LoggerFactory
 import org.wycliffeassociates.otter.jvm.controls.Shortcut
 import org.wycliffeassociates.otter.jvm.controls.createAudioScrollBar
+import org.wycliffeassociates.otter.jvm.controls.event.BeforeNavigationEvent
 import org.wycliffeassociates.otter.jvm.controls.event.MarkerDeletedEvent
 import org.wycliffeassociates.otter.jvm.controls.event.MarkerMovedEvent
 import org.wycliffeassociates.otter.jvm.controls.event.RedoChunkingPageEvent
@@ -150,7 +151,6 @@ class Chunking : View() {
         super.onUndock()
         logger.info("Chunking undocked")
         timer?.stop()
-        waveform.cleanup()
         unsubscribeEvents()
         viewModel.undock()
     }
@@ -172,6 +172,10 @@ class Chunking : View() {
 
         subscribe<RedoChunkingPageEvent> {
             viewModel.redoMarker()
+        }.also { eventSubscriptions.add(it) }
+
+        subscribe<BeforeNavigationEvent> {
+            waveform.cleanup()
         }.also { eventSubscriptions.add(it) }
     }
 

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/Consume.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/Consume.kt
@@ -30,7 +30,8 @@ import org.kordamp.ikonli.materialdesign.MaterialDesign
 import org.slf4j.LoggerFactory
 import org.wycliffeassociates.otter.jvm.controls.Shortcut
 import org.wycliffeassociates.otter.jvm.controls.createAudioScrollBar
-import org.wycliffeassociates.otter.jvm.controls.event.BeforeNavigationEvent
+import org.wycliffeassociates.otter.jvm.controls.event.NavigationRequestEvent
+import org.wycliffeassociates.otter.jvm.controls.event.TranslationNavigationEvent
 import org.wycliffeassociates.otter.jvm.controls.model.pixelsToFrames
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.viewmodel.ConsumeViewModel
 import org.wycliffeassociates.otter.jvm.controls.waveform.MarkerWaveform
@@ -157,7 +158,11 @@ class Consume : View() {
     private fun subscribeEvents() {
         addShortcut()
 
-        subscribe<BeforeNavigationEvent> {
+        subscribe<TranslationNavigationEvent> {
+            waveform.cleanup()
+        }.also { eventSubscriptions.add(it) }
+
+        subscribe<NavigationRequestEvent> { // navigate Home
             waveform.cleanup()
         }.also { eventSubscriptions.add(it) }
     }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/Consume.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/Consume.kt
@@ -60,7 +60,8 @@ class Consume : View() {
         super.onDock()
         logger.info("Consume docked")
         timer = startAnimationTimer { viewModel.calculatePosition() }
-        viewModel.subscribeOnWaveformImages = ::subscribeOnWaveformImages
+        viewModel.subscribeOnWaveformImagesProperty.set(::subscribeOnWaveformImages)
+        viewModel.cleanupWaveformProperty.set(waveform::cleanup)
         viewModel.onDockConsume()
         waveform.initializeMarkers()
         waveform.markers.bind(viewModel.markers) { it }
@@ -159,11 +160,11 @@ class Consume : View() {
         addShortcut()
 
         subscribe<TranslationNavigationEvent> {
-            waveform.cleanup()
+            viewModel.cleanupWaveform()
         }.also { eventSubscriptions.add(it) }
 
         subscribe<NavigationRequestEvent> { // navigate Home
-            waveform.cleanup()
+            viewModel.cleanupWaveform()
         }.also { eventSubscriptions.add(it) }
     }
 

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/PeerEdit.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/PeerEdit.kt
@@ -205,8 +205,8 @@ open class PeerEdit : View() {
         recorderViewModel.volumeCanvas = recordingView.volumeCanvas
         mainSectionProperty.set(playbackView)
         timer = startAnimationTimer { viewModel.calculatePosition() }
-        viewModel.subscribeOnWaveformImages = ::subscribeOnWaveformImages
-        viewModel.cleanUpWaveform = waveform::cleanup
+        viewModel.subscribeOnWaveformImagesProperty.set(::subscribeOnWaveformImages)
+        viewModel.cleanupWaveformProperty.set(waveform::cleanup)
         viewModel.dock()
         subscribeEvents()
     }
@@ -242,11 +242,11 @@ open class PeerEdit : View() {
         }.also { eventSubscriptions.add(it) }
 
         subscribe<TranslationNavigationEvent> {
-            waveform.cleanup()
+            viewModel.cleanupWaveform()
         }.also { eventSubscriptions.add(it) }
 
         subscribe<NavigationRequestEvent> { // navigate Home
-            waveform.cleanup()
+            viewModel.cleanupWaveform()
         }.also { eventSubscriptions.add(it) }
     }
 

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/PeerEdit.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/PeerEdit.kt
@@ -33,7 +33,8 @@ import org.kordamp.ikonli.materialdesign.MaterialDesign
 import org.slf4j.LoggerFactory
 import org.wycliffeassociates.otter.jvm.controls.Shortcut
 import org.wycliffeassociates.otter.jvm.controls.createAudioScrollBar
-import org.wycliffeassociates.otter.jvm.controls.event.BeforeNavigationEvent
+import org.wycliffeassociates.otter.jvm.controls.event.TranslationNavigationEvent
+import org.wycliffeassociates.otter.jvm.controls.event.NavigationRequestEvent
 import org.wycliffeassociates.otter.jvm.controls.event.RedoChunkingPageEvent
 import org.wycliffeassociates.otter.jvm.controls.event.UndoChunkingPageEvent
 import org.wycliffeassociates.otter.jvm.controls.media.simpleaudioplayer
@@ -240,7 +241,11 @@ open class PeerEdit : View() {
             viewModel.redo()
         }.also { eventSubscriptions.add(it) }
 
-        subscribe<BeforeNavigationEvent> {
+        subscribe<TranslationNavigationEvent> {
+            waveform.cleanup()
+        }.also { eventSubscriptions.add(it) }
+
+        subscribe<NavigationRequestEvent> { // navigate Home
             waveform.cleanup()
         }.also { eventSubscriptions.add(it) }
     }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ChapterReviewViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ChapterReviewViewModel.kt
@@ -100,7 +100,8 @@ class ChapterReviewViewModel : ViewModel(), IMarkerViewModel {
     private val height = Integer.min(Screen.getMainScreen().platformHeight, WAVEFORM_MAX_HEIGHT.toInt())
     private val builder = ObservableWaveformBuilder()
 
-    var subscribeOnWaveformImages: () -> Unit = {}
+    var subscribeOnWaveformImagesProperty = SimpleObjectProperty {}
+    val cleanupWaveformProperty = SimpleObjectProperty {}
 
     val chapterTitleProperty = workbookDataStore.activeChapterTitleBinding()
     val sourcePlayerProperty = SimpleObjectProperty<IAudioPlayer>()
@@ -198,6 +199,14 @@ class ChapterReviewViewModel : ViewModel(), IMarkerViewModel {
                 )
                 it.deletedTimestamp.accept(DateHolder.now())
             }
+    }
+
+    fun cleanupWaveform() {
+        cleanupWaveformProperty.value.invoke()
+    }
+
+    fun subscribeOnWaveformImages() {
+        subscribeOnWaveformImagesProperty.value.invoke()
     }
 
     private fun loadChapterTake() {

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ChunkingViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ChunkingViewModel.kt
@@ -100,7 +100,8 @@ class ChunkingViewModel : ViewModel(), IMarkerViewModel {
     private val height = Integer.min(Screen.getMainScreen().platformHeight, WAVEFORM_MAX_HEIGHT.toInt())
     private val builder = ObservableWaveformBuilder()
 
-    var subscribeOnWaveformImages: () -> Unit = {}
+    var subscribeOnWaveformImagesProperty = SimpleObjectProperty {}
+    val cleanupWaveformProperty = SimpleObjectProperty {}
 
     val isPlayingProperty = SimpleBooleanProperty(false)
     val compositeDisposable = CompositeDisposable()
@@ -251,6 +252,14 @@ class ChunkingViewModel : ViewModel(), IMarkerViewModel {
 
     fun pause() {
         audioController?.pause()
+    }
+
+    fun cleanupWaveform() {
+        cleanupWaveformProperty.value.invoke()
+    }
+
+    fun subscribeOnWaveformImages() {
+        subscribeOnWaveformImagesProperty.value.invoke()
     }
 
     private fun createWaveformImages(audio: OratureAudioFile) {

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ConsumeViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ConsumeViewModel.kt
@@ -60,7 +60,8 @@ class ConsumeViewModel : ViewModel(), IMarkerViewModel {
 
     lateinit var waveform: Observable<Image>
 
-    var subscribeOnWaveformImages: () -> Unit = {}
+    var subscribeOnWaveformImagesProperty = SimpleObjectProperty {}
+    val cleanupWaveformProperty = SimpleObjectProperty {}
 
     override var markerModel: VerseMarkerModel? = null
     override val markers = observableListOf<ChunkMarkerModel>()
@@ -150,6 +151,14 @@ class ConsumeViewModel : ViewModel(), IMarkerViewModel {
         builder.cancel()
         compositeDisposable.clear()
         markerModel = null
+    }
+
+    fun cleanupWaveform() {
+        cleanupWaveformProperty.value.invoke()
+    }
+
+    fun subscribeOnWaveformImages() {
+        subscribeOnWaveformImagesProperty.value.invoke()
     }
 
     private fun loadAudio(audioFile: File): OratureAudioFile {

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/PeerEditViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/PeerEditViewModel.kt
@@ -74,8 +74,8 @@ class PeerEditViewModel : ViewModel(), IWaveformViewModel {
     val disposable = CompositeDisposable()
 
     lateinit var waveform: Observable<Image>
-    var subscribeOnWaveformImages: () -> Unit = {}
-    var cleanUpWaveform: () -> Unit = {}
+    var subscribeOnWaveformImagesProperty = SimpleObjectProperty {}
+    val cleanupWaveformProperty = SimpleObjectProperty {}
     private var audioController: AudioPlayerController? = null
 
     override var sampleRate: Int = 0 // beware of divided by 0
@@ -218,6 +218,14 @@ class PeerEditViewModel : ViewModel(), IWaveformViewModel {
         }
     }
 
+    fun cleanupWaveform() {
+        cleanupWaveformProperty.value.invoke()
+    }
+
+    fun subscribeOnWaveformImages() {
+        subscribeOnWaveformImagesProperty.value.invoke()
+    }
+
     private fun subscribeToChunks() {
         workbookDataStore.chapter
             .chunks
@@ -259,7 +267,7 @@ class PeerEditViewModel : ViewModel(), IWaveformViewModel {
     }
 
     private fun createWaveformImages(audio: OratureAudioFile) {
-        cleanUpWaveform()
+        cleanupWaveform()
         imageWidthProperty.set(computeImageWidth(width))
 
         builder.cancel()

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/TranslationViewModel2.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/TranslationViewModel2.kt
@@ -34,7 +34,7 @@ import org.wycliffeassociates.otter.common.data.primitives.ProjectMode
 import org.wycliffeassociates.otter.common.data.workbook.Chapter
 import org.wycliffeassociates.otter.common.data.workbook.Chunk
 import org.wycliffeassociates.otter.common.domain.collections.CreateProject
-import org.wycliffeassociates.otter.jvm.controls.event.BeforeNavigationEvent
+import org.wycliffeassociates.otter.jvm.controls.event.TranslationNavigationEvent
 import org.wycliffeassociates.otter.jvm.controls.model.ChapterGridItemData
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.model.ChunkViewData
 import org.wycliffeassociates.otter.jvm.controls.model.ChunkingStep
@@ -104,7 +104,7 @@ class TranslationViewModel2 : ViewModel() {
     }
 
     fun navigateChapter(chapter: Int) {
-        FX.eventbus.fire(BeforeNavigationEvent())
+        FX.eventbus.fire(TranslationNavigationEvent())
 
         selectedStepProperty.set(null)
         noSourceAudioProperty.set(false)
@@ -123,7 +123,7 @@ class TranslationViewModel2 : ViewModel() {
     }
 
     fun navigateStep(target: ChunkingStep) {
-        FX.eventbus.fire(BeforeNavigationEvent())
+        FX.eventbus.fire(TranslationNavigationEvent())
 
         if (!loadingStepProperty.value) {
             loadingStepProperty.set(true)

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/TranslationViewModel2.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/TranslationViewModel2.kt
@@ -34,6 +34,7 @@ import org.wycliffeassociates.otter.common.data.primitives.ProjectMode
 import org.wycliffeassociates.otter.common.data.workbook.Chapter
 import org.wycliffeassociates.otter.common.data.workbook.Chunk
 import org.wycliffeassociates.otter.common.domain.collections.CreateProject
+import org.wycliffeassociates.otter.jvm.controls.event.BeforeNavigationEvent
 import org.wycliffeassociates.otter.jvm.controls.model.ChapterGridItemData
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.model.ChunkViewData
 import org.wycliffeassociates.otter.jvm.controls.model.ChunkingStep
@@ -103,6 +104,8 @@ class TranslationViewModel2 : ViewModel() {
     }
 
     fun navigateChapter(chapter: Int) {
+        FX.eventbus.fire(BeforeNavigationEvent())
+
         selectedStepProperty.set(null)
         noSourceAudioProperty.set(false)
         showAudioMissingViewProperty.set(false)
@@ -120,6 +123,8 @@ class TranslationViewModel2 : ViewModel() {
     }
 
     fun navigateStep(target: ChunkingStep) {
+        FX.eventbus.fire(BeforeNavigationEvent())
+
         if (!loadingStepProperty.value) {
             loadingStepProperty.set(true)
             runLater {


### PR DESCRIPTION
Added `BeforeNavigationEvent` to track when to clear waveform in Translation mode. Attempts to clean waveform will happen when going to Home page, other chapter and other step.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/1010)
<!-- Reviewable:end -->
