### PR TITLE
Handle `ChapterReview` markers without source audio

### DIFF
--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ChapterReviewViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ChapterReviewViewModel.kt
@@ -252,8 +252,20 @@ class ChapterReviewViewModel : ViewModel(), IMarkerViewModel {
 
     private fun loadVerseMarkers(audio: OratureAudioFile) {
         markers.clear()
-        val sourceAudio = OratureAudioFile(sourceAudio.file)
-        val sourceMarkers = sourceAudio.getMarker<VerseMarker>()
+        val sourceMarkers = if (audioDataStore.sourceAudioProperty.value != null) {
+            val sourceAudio = OratureAudioFile(sourceAudio.file)
+            sourceAudio.getMarker<VerseMarker>()
+        } else {
+            // source audio doesn't exist, create verse markers from text
+            workbookDataStore.workbook.projectFilesAccessor
+                .getChapterContent(
+                    workbookDataStore.workbook.target.slug,
+                    workbookDataStore.chapter.sort
+                ).map { content ->
+                    VerseMarker(content.start, content.end, 0)
+                }
+        }
+
         val markerList = audio.getMarker<VerseMarker>().map {
             MarkerItem(it, true)
         }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ChapterReviewViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ChapterReviewViewModel.kt
@@ -260,9 +260,9 @@ class ChapterReviewViewModel : ViewModel(), IMarkerViewModel {
 
         totalMarkersProperty.set(sourceMarkers.size)
         markerModel = MarkerPlacementModel(
-            MarkerPlacementType.CHUNK,
+            MarkerPlacementType.VERSE,
             audio,
-            sourceMarkers.map { ChunkMarker(it.start, it.location) }
+            sourceMarkers.map { VerseMarker(it.start, it.end, 0) }
         ).also {
             it.loadMarkers(markerList)
         }


### PR DESCRIPTION
For migrated translation projects
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/1020)
<!-- Reviewable:end -->
