### PR TITLE
Fixed incorrect potentiallyFinished and hasAllVersesRecorded property

### DIFF
--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/NarrationHeader.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/NarrationHeader.kt
@@ -94,7 +94,7 @@ class NarrationHeader : View() {
             narrationMenuButton(
                 viewModel.hasChapterTakeProperty,
                 viewModel.hasVersesProperty,
-                viewModel.hasAllChunksRecordedProperty
+                viewModel.hasEverythingRecordedProperty
             ) {
                 enableWhen(viewModel.chapterTakeBusyProperty.not().and(viewModel.isRecordingProperty.not()))
             }
@@ -149,7 +149,7 @@ class NarrationHeaderViewModel : ViewModel() {
     val hasNextChapter = SimpleBooleanProperty()
     val hasPreviousChapter = SimpleBooleanProperty()
     val hasVersesProperty = SimpleBooleanProperty()
-    val hasAllChunksRecordedProperty = SimpleBooleanProperty()
+    val hasEverythingRecordedProperty = SimpleBooleanProperty()
     val chapterTakeProperty = SimpleObjectProperty<Take>()
     val hasChapterTakeProperty = chapterTakeProperty.isNotNull
     val chapterTakeBusyProperty = SimpleBooleanProperty()
@@ -182,7 +182,7 @@ class NarrationHeaderViewModel : ViewModel() {
         hasUndoProperty.bind(narrationViewModel.hasUndoProperty)
         hasRedoProperty.bind(narrationViewModel.hasRedoProperty)
         hasVersesProperty.bind(narrationViewModel.hasVersesProperty)
-        hasAllChunksRecordedProperty.bind(narrationViewModel.hasAllChunksRecordedProperty)
+        hasEverythingRecordedProperty.bind(narrationViewModel.hasEverythingRecordedProperty)
     }
 
     private enum class StepDirection {

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/NarrationHeader.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/NarrationHeader.kt
@@ -94,7 +94,7 @@ class NarrationHeader : View() {
             narrationMenuButton(
                 viewModel.hasChapterTakeProperty,
                 viewModel.hasVersesProperty,
-                viewModel.hasAllVersesRecordedProperty
+                viewModel.hasAllChunksRecordedProperty
             ) {
                 enableWhen(viewModel.chapterTakeBusyProperty.not().and(viewModel.isRecordingProperty.not()))
             }
@@ -149,7 +149,7 @@ class NarrationHeaderViewModel : ViewModel() {
     val hasNextChapter = SimpleBooleanProperty()
     val hasPreviousChapter = SimpleBooleanProperty()
     val hasVersesProperty = SimpleBooleanProperty()
-    val hasAllVersesRecordedProperty = SimpleBooleanProperty()
+    val hasAllChunksRecordedProperty = SimpleBooleanProperty()
     val chapterTakeProperty = SimpleObjectProperty<Take>()
     val hasChapterTakeProperty = chapterTakeProperty.isNotNull
     val chapterTakeBusyProperty = SimpleBooleanProperty()
@@ -182,7 +182,7 @@ class NarrationHeaderViewModel : ViewModel() {
         hasUndoProperty.bind(narrationViewModel.hasUndoProperty)
         hasRedoProperty.bind(narrationViewModel.hasRedoProperty)
         hasVersesProperty.bind(narrationViewModel.hasVersesProperty)
-        hasAllVersesRecordedProperty.bind(narrationViewModel.hasAllVersesRecordedProperty)
+        hasAllChunksRecordedProperty.bind(narrationViewModel.hasAllChunksRecordedProperty)
     }
 
     private enum class StepDirection {

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/NarrationHeader.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/NarrationHeader.kt
@@ -94,7 +94,7 @@ class NarrationHeader : View() {
             narrationMenuButton(
                 viewModel.hasChapterTakeProperty,
                 viewModel.hasVersesProperty,
-                viewModel.hasEverythingRecordedProperty
+                viewModel.hasAllItemsRecordedProperty
             ) {
                 enableWhen(viewModel.chapterTakeBusyProperty.not().and(viewModel.isRecordingProperty.not()))
             }
@@ -149,7 +149,7 @@ class NarrationHeaderViewModel : ViewModel() {
     val hasNextChapter = SimpleBooleanProperty()
     val hasPreviousChapter = SimpleBooleanProperty()
     val hasVersesProperty = SimpleBooleanProperty()
-    val hasEverythingRecordedProperty = SimpleBooleanProperty()
+    val hasAllItemsRecordedProperty = SimpleBooleanProperty()
     val chapterTakeProperty = SimpleObjectProperty<Take>()
     val hasChapterTakeProperty = chapterTakeProperty.isNotNull
     val chapterTakeBusyProperty = SimpleBooleanProperty()
@@ -182,7 +182,7 @@ class NarrationHeaderViewModel : ViewModel() {
         hasUndoProperty.bind(narrationViewModel.hasUndoProperty)
         hasRedoProperty.bind(narrationViewModel.hasRedoProperty)
         hasVersesProperty.bind(narrationViewModel.hasVersesProperty)
-        hasEverythingRecordedProperty.bind(narrationViewModel.hasEverythingRecordedProperty)
+        hasAllItemsRecordedProperty.bind(narrationViewModel.hasAllItemsRecordedProperty)
     }
 
     private enum class StepDirection {

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/NarrationViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/NarrationViewModel.kt
@@ -142,7 +142,6 @@ class NarrationViewModel : ViewModel() {
     val totalAudioSizeProperty = SimpleIntegerProperty()
     private var onTaskRunnerIdle: () -> Unit = { }
 
-    //FIXME: Refactor this if and when Chunk entries are officially added for Titles in the Workbook
     val hasEverythingRecordedProperty = SimpleBooleanProperty()
     val potentiallyFinishedProperty = hasEverythingRecordedProperty
         .and(isRecordingProperty.not())

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/NarrationViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/NarrationViewModel.kt
@@ -163,7 +163,7 @@ class NarrationViewModel : ViewModel() {
         hasVersesProperty.bind(recordedVerses.booleanBinding { it.isNotEmpty() })
         lastRecordedVerseProperty.bind(recordedVerses.sizeProperty)
         hasEverythingRecordedProperty.bind(recordedVerses.booleanBinding {
-            !narration.versesWithRecordings().contains(false)
+            narration.versesWithRecordings().all { true }
         })
 
         subscribe<AppCloseRequestEvent> {

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/NarrationViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/NarrationViewModel.kt
@@ -142,8 +142,8 @@ class NarrationViewModel : ViewModel() {
     val totalAudioSizeProperty = SimpleIntegerProperty()
     private var onTaskRunnerIdle: () -> Unit = { }
 
-    val hasEverythingRecordedProperty = SimpleBooleanProperty()
-    val potentiallyFinishedProperty = hasEverythingRecordedProperty
+    val hasAllItemsRecordedProperty = SimpleBooleanProperty()
+    val potentiallyFinishedProperty = hasAllItemsRecordedProperty
         .and(isRecordingProperty.not())
         .and(isRecordingAgainProperty.not())
         .and(chapterTakeProperty.isNull)
@@ -162,7 +162,7 @@ class NarrationViewModel : ViewModel() {
 
         hasVersesProperty.bind(recordedVerses.booleanBinding { it.isNotEmpty() })
         lastRecordedVerseProperty.bind(recordedVerses.sizeProperty)
-        hasEverythingRecordedProperty.bind(recordedVerses.booleanBinding {
+        hasAllItemsRecordedProperty.bind(recordedVerses.booleanBinding {
             narration.versesWithRecordings().all { true }
         })
 

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/NarrationViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/NarrationViewModel.kt
@@ -143,8 +143,8 @@ class NarrationViewModel : ViewModel() {
     private var onTaskRunnerIdle: () -> Unit = { }
 
     //FIXME: Refactor this if and when Chunk entries are officially added for Titles in the Workbook
-    val hasAllChunksRecordedProperty = SimpleBooleanProperty()
-    val potentiallyFinishedProperty = hasAllChunksRecordedProperty
+    val hasEverythingRecordedProperty = SimpleBooleanProperty()
+    val potentiallyFinishedProperty = hasEverythingRecordedProperty
         .and(isRecordingProperty.not())
         .and(isRecordingAgainProperty.not())
         .and(chapterTakeProperty.isNull)
@@ -163,7 +163,7 @@ class NarrationViewModel : ViewModel() {
 
         hasVersesProperty.bind(recordedVerses.booleanBinding { it.isNotEmpty() })
         lastRecordedVerseProperty.bind(recordedVerses.sizeProperty)
-        hasAllChunksRecordedProperty.bind(recordedVerses.booleanBinding {
+        hasEverythingRecordedProperty.bind(recordedVerses.booleanBinding {
             !narration.versesWithRecordings().contains(false)
         })
 

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/NarrationViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/NarrationViewModel.kt
@@ -88,6 +88,7 @@ class NarrationViewModel : ViewModel() {
 
     @Inject
     lateinit var narrationFactory: NarrationFactory
+
     @Inject
     lateinit var appPreferencesRepo: IAppPreferencesRepository
 
@@ -142,10 +143,8 @@ class NarrationViewModel : ViewModel() {
     private var onTaskRunnerIdle: () -> Unit = { }
 
     //FIXME: Refactor this if and when Chunk entries are officially added for Titles in the Workbook
-    val numberOfTitlesProperty = SimpleIntegerProperty(0)
-    val hasAllVersesRecordedProperty = chunkTotalProperty
-        .eq(recordedVerses.sizeProperty.minus(numberOfTitlesProperty))
-    val potentiallyFinishedProperty = hasAllVersesRecordedProperty
+    val hasAllChunksRecordedProperty = SimpleBooleanProperty()
+    val potentiallyFinishedProperty = hasAllChunksRecordedProperty
         .and(isRecordingProperty.not())
         .and(isRecordingAgainProperty.not())
         .and(chapterTakeProperty.isNull)
@@ -164,6 +163,9 @@ class NarrationViewModel : ViewModel() {
 
         hasVersesProperty.bind(recordedVerses.booleanBinding { it.isNotEmpty() })
         lastRecordedVerseProperty.bind(recordedVerses.sizeProperty)
+        hasAllChunksRecordedProperty.bind(recordedVerses.booleanBinding {
+            !narration.versesWithRecordings().contains(false)
+        })
 
         subscribe<AppCloseRequestEvent> {
             logger.info("Received close event request")

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/menu/NarrationMenu.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/menu/NarrationMenu.kt
@@ -34,7 +34,7 @@ class NarrationMenu : ContextMenu() {
 
     val hasChapterTakeProperty = SimpleBooleanProperty()
     val hasVersesProperty = SimpleBooleanProperty()
-    val hasEverythingRecordedProperty = SimpleBooleanProperty()
+    val hasAllItemsRecordedProperty = SimpleBooleanProperty()
 
     init {
         addClass("wa-context-menu")
@@ -58,7 +58,7 @@ class NarrationMenu : ContextMenu() {
             action {
                 FX.eventbus.fire(NarrationOpenInPluginEvent(PluginType.MARKER))
             }
-            enableWhen(hasChapterTakeProperty.and(hasEverythingRecordedProperty))
+            enableWhen(hasChapterTakeProperty.and(hasAllItemsRecordedProperty))
         }
         val restartChapterOpt = MenuItem().apply {
             graphic = label(messages["restartChapter"]) {
@@ -78,7 +78,7 @@ class NarrationMenu : ContextMenu() {
 fun EventTarget.narrationMenuButton(
     hasChapterTakeBinding: ObservableBooleanValue,
     hasVersesBinding: ObservableBooleanValue,
-    hasEverythingRecordedProperty: ObservableBooleanValue,
+    hasAllItemsRecordedBinding: ObservableBooleanValue,
     op: Button.() -> Unit = {}
 ): Button {
     return Button().attachTo(this).apply {
@@ -89,7 +89,7 @@ fun EventTarget.narrationMenuButton(
         val menu = NarrationMenu().apply {
             this.hasChapterTakeProperty.bind(hasChapterTakeBinding)
             this.hasVersesProperty.bind(hasVersesBinding)
-            this.hasEverythingRecordedProperty.bind(hasEverythingRecordedProperty)
+            this.hasAllItemsRecordedProperty.bind(hasAllItemsRecordedBinding)
         }
 
         menu.setOnShowing { addPseudoClass("active") }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/menu/NarrationMenu.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/menu/NarrationMenu.kt
@@ -34,7 +34,7 @@ class NarrationMenu : ContextMenu() {
 
     val hasChapterTakeProperty = SimpleBooleanProperty()
     val hasVersesProperty = SimpleBooleanProperty()
-    val hasAllChunksRecordedProperty = SimpleBooleanProperty()
+    val hasEverythingRecordedProperty = SimpleBooleanProperty()
 
     init {
         addClass("wa-context-menu")
@@ -58,7 +58,7 @@ class NarrationMenu : ContextMenu() {
             action {
                 FX.eventbus.fire(NarrationOpenInPluginEvent(PluginType.MARKER))
             }
-            enableWhen(hasChapterTakeProperty.and(hasAllChunksRecordedProperty))
+            enableWhen(hasChapterTakeProperty.and(hasEverythingRecordedProperty))
         }
         val restartChapterOpt = MenuItem().apply {
             graphic = label(messages["restartChapter"]) {
@@ -78,7 +78,7 @@ class NarrationMenu : ContextMenu() {
 fun EventTarget.narrationMenuButton(
     hasChapterTakeBinding: ObservableBooleanValue,
     hasVersesBinding: ObservableBooleanValue,
-    hasAllChunksRecordedProperty: ObservableBooleanValue,
+    hasEverythingRecordedProperty: ObservableBooleanValue,
     op: Button.() -> Unit = {}
 ): Button {
     return Button().attachTo(this).apply {
@@ -89,7 +89,7 @@ fun EventTarget.narrationMenuButton(
         val menu = NarrationMenu().apply {
             this.hasChapterTakeProperty.bind(hasChapterTakeBinding)
             this.hasVersesProperty.bind(hasVersesBinding)
-            this.hasAllChunksRecordedProperty.bind(hasAllChunksRecordedProperty)
+            this.hasEverythingRecordedProperty.bind(hasEverythingRecordedProperty)
         }
 
         menu.setOnShowing { addPseudoClass("active") }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/menu/NarrationMenu.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/menu/NarrationMenu.kt
@@ -34,7 +34,7 @@ class NarrationMenu : ContextMenu() {
 
     val hasChapterTakeProperty = SimpleBooleanProperty()
     val hasVersesProperty = SimpleBooleanProperty()
-    val hasAllVersesRecordedProperty = SimpleBooleanProperty()
+    val hasAllChunksRecordedProperty = SimpleBooleanProperty()
 
     init {
         addClass("wa-context-menu")
@@ -58,7 +58,7 @@ class NarrationMenu : ContextMenu() {
             action {
                 FX.eventbus.fire(NarrationOpenInPluginEvent(PluginType.MARKER))
             }
-            enableWhen(hasChapterTakeProperty.and(hasAllVersesRecordedProperty))
+            enableWhen(hasChapterTakeProperty.and(hasAllChunksRecordedProperty))
         }
         val restartChapterOpt = MenuItem().apply {
             graphic = label(messages["restartChapter"]) {
@@ -78,7 +78,7 @@ class NarrationMenu : ContextMenu() {
 fun EventTarget.narrationMenuButton(
     hasChapterTakeBinding: ObservableBooleanValue,
     hasVersesBinding: ObservableBooleanValue,
-    hasAllVersesRecordedProperty: ObservableBooleanValue,
+    hasAllChunksRecordedProperty: ObservableBooleanValue,
     op: Button.() -> Unit = {}
 ): Button {
     return Button().attachTo(this).apply {
@@ -89,7 +89,7 @@ fun EventTarget.narrationMenuButton(
         val menu = NarrationMenu().apply {
             this.hasChapterTakeProperty.bind(hasChapterTakeBinding)
             this.hasVersesProperty.bind(hasVersesBinding)
-            this.hasAllVersesRecordedProperty.bind(hasAllVersesRecordedProperty)
+            this.hasAllChunksRecordedProperty.bind(hasAllChunksRecordedProperty)
         }
 
         menu.setOnShowing { addPseudoClass("active") }


### PR DESCRIPTION
Updated hasAllVersesRecordedProperty to store the correct value and removed unnecessary numberOfTitlesProperty.

Without the fix, a chapter take was not created when save was clicked after all verses had been recorded.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/1021)
<!-- Reviewable:end -->
