### PR TITLE
Book chapter titles in Translation - Chapter Review

### DIFF
--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/audio/OratureAudioFile.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/audio/OratureAudioFile.kt
@@ -232,3 +232,9 @@ internal class OratureMarkers {
         }
     }
 }
+
+fun OratureAudioFile.getVerseAndTitleMarkers(): List<AudioMarker> {
+    return getMarker<BookMarker>()
+        .plus(getMarker<ChapterMarker>())
+        .plus(getMarker<VerseMarker>())
+}

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/audio/OratureAudioFile.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/audio/OratureAudioFile.kt
@@ -96,6 +96,12 @@ class OratureAudioFile : AudioFile {
         }
     }
 
+    fun getVerseAndTitleMarkers(): List<AudioMarker> {
+        return getMarker<BookMarker>()
+            .plus(getMarker<ChapterMarker>())
+            .plus(getMarker<VerseMarker>())
+    }
+
     inline fun <reified T: AudioMarker> getMarker(): List<T> {
         val type = T::class
         val enum = getMarkerTypeFromClass(type)
@@ -231,10 +237,4 @@ internal class OratureMarkers {
             addEntry(it)
         }
     }
-}
-
-fun OratureAudioFile.getVerseAndTitleMarkers(): List<AudioMarker> {
-    return getMarker<BookMarker>()
-        .plus(getMarker<ChapterMarker>())
-        .plus(getMarker<VerseMarker>())
 }

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/SplitAudioOnCues.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/SplitAudioOnCues.kt
@@ -23,7 +23,6 @@ import org.wycliffeassociates.otter.common.audio.AudioFile
 import org.wycliffeassociates.otter.common.audio.AudioFileFormat
 import org.wycliffeassociates.otter.common.data.audio.AudioMarker
 import org.wycliffeassociates.otter.common.domain.audio.OratureAudioFile
-import org.wycliffeassociates.otter.common.domain.audio.getVerseAndTitleMarkers
 import org.wycliffeassociates.otter.common.persistence.IDirectoryProvider
 import java.io.File
 import javax.inject.Inject

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/SplitAudioOnCues.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/SplitAudioOnCues.kt
@@ -22,10 +22,8 @@ import io.reactivex.Single
 import org.wycliffeassociates.otter.common.audio.AudioFile
 import org.wycliffeassociates.otter.common.audio.AudioFileFormat
 import org.wycliffeassociates.otter.common.data.audio.AudioMarker
-import org.wycliffeassociates.otter.common.data.audio.BookMarker
-import org.wycliffeassociates.otter.common.data.audio.ChapterMarker
-import org.wycliffeassociates.otter.common.data.audio.VerseMarker
 import org.wycliffeassociates.otter.common.domain.audio.OratureAudioFile
+import org.wycliffeassociates.otter.common.domain.audio.getVerseAndTitleMarkers
 import org.wycliffeassociates.otter.common.persistence.IDirectoryProvider
 import java.io.File
 import javax.inject.Inject
@@ -37,9 +35,7 @@ class SplitAudioOnCues @Inject constructor(private val directoryProvider: IDirec
     fun execute(file: File, initialMarker: AudioMarker): VerseSegments {
         val sourceAudio = OratureAudioFile(file)
         val cues = sourceAudio
-            .getMarker<BookMarker>()
-            .plus(sourceAudio.getMarker<ChapterMarker>())
-            .plus(sourceAudio.getMarker<VerseMarker>())
+            .getVerseAndTitleMarkers()
             .ifEmpty {
                 listOf(initialMarker)
             }

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/project/usfm/UsfmProjectReader.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/project/usfm/UsfmProjectReader.kt
@@ -22,6 +22,8 @@ import java.io.File
 import java.io.Reader
 import org.wycliffeassociates.otter.common.collections.OtterTree
 import org.wycliffeassociates.otter.common.collections.OtterTreeNode
+import org.wycliffeassociates.otter.common.data.primitives.BOOK_TITLE_SORT
+import org.wycliffeassociates.otter.common.data.primitives.CHAPTER_TITLE_SORT
 import org.wycliffeassociates.otter.common.data.primitives.Collection
 import org.wycliffeassociates.otter.common.data.primitives.CollectionOrContent
 import org.wycliffeassociates.otter.common.data.primitives.Content
@@ -166,7 +168,7 @@ private fun parseUSFMToChapterTrees(reader: Reader, projectSlug: String): List<O
             draftNumber = 1
         )
         val chapTitle = Content(
-            sort = -1,
+            sort = CHAPTER_TITLE_SORT,
             labelKey = ContentLabel.CHAPTER.value,
             start = startVerse,
             end = endVerse,
@@ -178,7 +180,7 @@ private fun parseUSFMToChapterTrees(reader: Reader, projectSlug: String): List<O
         )
         if (chapter.number == 1) {
             val bookContent = Content(
-                sort = -2,
+                sort = BOOK_TITLE_SORT,
                 labelKey = "book",
                 start = startVerse,
                 end = endVerse,

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ChapterReviewViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ChapterReviewViewModel.kt
@@ -44,7 +44,6 @@ import org.wycliffeassociates.otter.common.data.workbook.Take
 import org.wycliffeassociates.otter.common.data.workbook.TakeCheckingState
 import org.wycliffeassociates.otter.common.device.IAudioPlayer
 import org.wycliffeassociates.otter.common.domain.audio.OratureAudioFile
-import org.wycliffeassociates.otter.common.domain.audio.getVerseAndTitleMarkers
 import org.wycliffeassociates.otter.common.domain.content.ConcatenateAudio
 import org.wycliffeassociates.otter.common.domain.content.ChapterTranslationBuilder
 import org.wycliffeassociates.otter.common.domain.model.MarkerItem

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ChapterReviewViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ChapterReviewViewModel.kt
@@ -259,9 +259,10 @@ class ChapterReviewViewModel : ViewModel(), IMarkerViewModel {
     private fun loadVerseMarkers(audio: OratureAudioFile, sourceAudio: OratureAudioFile?) {
         markers.clear()
         val sourceMarkers = getSourceMarkers(sourceAudio)
-        val placedMarkers = audio.getMarker<VerseMarker>().map {
-            MarkerItem(it, true)
-        }
+        val placedMarkers = audio.getMarker<BookMarker>()
+                .plus(audio.getMarker<ChapterMarker>())
+                .plus(audio.getMarker<VerseMarker>())
+                .map { MarkerItem(it, true) }
 
         totalMarkersProperty.set(sourceMarkers.size)
         markerModel = MarkerPlacementModel(

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ChapterReviewViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ChapterReviewViewModel.kt
@@ -36,8 +36,6 @@ import javafx.scene.paint.Color
 import org.slf4j.LoggerFactory
 import org.wycliffeassociates.otter.common.audio.wav.IWaveFileCreator
 import org.wycliffeassociates.otter.common.data.audio.AudioMarker
-import org.wycliffeassociates.otter.common.data.audio.BookMarker
-import org.wycliffeassociates.otter.common.data.audio.ChapterMarker
 import org.wycliffeassociates.otter.common.data.audio.ChunkMarker
 import org.wycliffeassociates.otter.common.data.audio.VerseMarker
 import org.wycliffeassociates.otter.common.data.primitives.CheckingStatus
@@ -46,6 +44,7 @@ import org.wycliffeassociates.otter.common.data.workbook.Take
 import org.wycliffeassociates.otter.common.data.workbook.TakeCheckingState
 import org.wycliffeassociates.otter.common.device.IAudioPlayer
 import org.wycliffeassociates.otter.common.domain.audio.OratureAudioFile
+import org.wycliffeassociates.otter.common.domain.audio.getVerseAndTitleMarkers
 import org.wycliffeassociates.otter.common.domain.content.ConcatenateAudio
 import org.wycliffeassociates.otter.common.domain.content.ChapterTranslationBuilder
 import org.wycliffeassociates.otter.common.domain.model.MarkerItem
@@ -259,9 +258,7 @@ class ChapterReviewViewModel : ViewModel(), IMarkerViewModel {
     private fun loadVerseMarkers(audio: OratureAudioFile, sourceAudio: OratureAudioFile?) {
         markers.clear()
         val sourceMarkers = getSourceMarkers(sourceAudio)
-        val placedMarkers = audio.getMarker<BookMarker>()
-                .plus(audio.getMarker<ChapterMarker>())
-                .plus(audio.getMarker<VerseMarker>())
+        val placedMarkers = audio.getVerseAndTitleMarkers()
                 .map { MarkerItem(it, true) }
 
         totalMarkersProperty.set(sourceMarkers.size)
@@ -279,9 +276,7 @@ class ChapterReviewViewModel : ViewModel(), IMarkerViewModel {
     private fun getSourceMarkers(sourceAudio: OratureAudioFile?): List<AudioMarker> {
         return when {
             sourceAudio != null && hasUserDefinedChunks() -> {
-                sourceAudio.getMarker<BookMarker>()
-                    .plus(sourceAudio.getMarker<ChapterMarker>())
-                    .plus(sourceAudio.getMarker<VerseMarker>())
+                sourceAudio.getVerseAndTitleMarkers()
             }
 
             /* no user-defined chunks found, this means project was migrated from Ot1, only have verse markers */


### PR DESCRIPTION
The source audio must contain title markers to have this feature visible. Otherwise, the `ChapterReview` step will default to whatever is available in the source markers.

This PR also handles the edge case when source audio is available and the project came from Orature 1, which does not support titles.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/1026)
<!-- Reviewable:end -->
