### PR TITLE
Fix binding error logged in narration

### DIFF
--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/NarrationViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/NarrationViewModel.kt
@@ -161,9 +161,11 @@ class NarrationViewModel : ViewModel() {
 
         hasVersesProperty.bind(recordedVerses.booleanBinding { it.isNotEmpty() })
         lastRecordedVerseProperty.bind(recordedVerses.sizeProperty)
-        hasAllItemsRecordedProperty.bind(recordedVerses.booleanBinding {
-            narration.versesWithRecordings().all { true }
-        })
+        hasAllItemsRecordedProperty.bind(
+            booleanBinding(recordedVerses, narratableList) {
+                recordedVerses.isNotEmpty() && recordedVerses.size == narratableList.size
+            }
+        )
 
         subscribe<AppCloseRequestEvent> {
             logger.info("Received close event request")


### PR DESCRIPTION
`narration` DI field is not initialized when binding. Uses the other property to determine whether all items have been recorded

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/1030)
<!-- Reviewable:end -->
