### PR TITLE
Remove padding to avoid overflowing buttons

### DIFF
--- a/jvm/controls/src/main/resources/css/scrolling-waveform.css
+++ b/jvm/controls/src/main/resources/css/scrolling-waveform.css
@@ -63,7 +63,6 @@
 }
 
 .scrolling-waveform-frame__image-container {
-    -fx-padding: 80 0;
     -fx-background-color: white;
 }
 


### PR DESCRIPTION
Reverts a CSS change in #1002 which caused the "move marker" buttons overflow beyond the visible layout.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/1031)
<!-- Reviewable:end -->
