### PR TITLE
Fixes resume recording after playing audio

### DIFF
--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/Narration.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/Narration.kt
@@ -308,7 +308,13 @@ class Narration @AssistedInject constructor(
     }
 
     fun resumeRecording() {
-        player.seek(player.getDurationInFrames())
+
+        // Ensures that the entire chapter is loaded into the player
+        lockToVerse(null)
+        audioLoaded = false
+        loadChapterIntoPlayer()
+
+        seek(player.getDurationInFrames())
         writer?.start()
         isRecording.set(true)
     }


### PR DESCRIPTION
Allows the user to continue recording a new verse after pausing recording, playing back some audio, then resuming recording. 

Does not fix resume re-recording after playing back audio, since we will be preventing audio playback while in a re-recording paused state.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/1045)
<!-- Reviewable:end -->
