### PR TITLE
Disable actions while record again paused (OT 838 )

### DIFF
--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/narration/NarrationTextItem.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/narration/NarrationTextItem.kt
@@ -58,6 +58,7 @@ class NarrationTextItem : VBox() {
 
     val isRecordingAgainProperty = SimpleBooleanProperty()
     val isRecordingAgain by isRecordingAgainProperty
+    val isRecordAgainPausedProperty = SimpleBooleanProperty()
     val isSelectedProperty = SimpleBooleanProperty(false)
     val isLastVerseProperty = SimpleBooleanProperty()
 
@@ -68,7 +69,7 @@ class NarrationTextItem : VBox() {
     val onPauseRecordingAction = SimpleObjectProperty<EventHandler<ActionEvent>>()
     val onPauseRecordAgainAction = SimpleObjectProperty<EventHandler<ActionEvent>>()
     val onResumeRecordingAction = SimpleObjectProperty<EventHandler<ActionEvent>>()
-    val onResumeRecordingAgainAction= SimpleObjectProperty<EventHandler<ActionEvent>>()
+    val onResumeRecordingAgainAction = SimpleObjectProperty<EventHandler<ActionEvent>>()
     val onRecordActionProperty = SimpleObjectProperty<EventHandler<ActionEvent>>()
     val onRecordAgainActionProperty = SimpleObjectProperty<EventHandler<ActionEvent>>()
     val onSaveRecordingActionProperty = SimpleObjectProperty<EventHandler<ActionEvent>>()
@@ -88,8 +89,9 @@ class NarrationTextItem : VBox() {
                         addClass("btn", "btn--secondary")
                         graphic = FontIcon(MaterialDesign.MDI_PLAY)
                         tooltip(messages["play"])
+
                         disableWhen {
-                            hasRecordingProperty.not()
+                            hasRecordingProperty.not().or(isRecordAgainPausedProperty)
                         }
                         disabledProperty().onChangeAndDoNow {
                             togglePseudoClass("inactive", it!!)

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/NarrationTextCell.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/NarrationTextCell.kt
@@ -48,6 +48,7 @@ class NarrationTextCell(
     private val recordButtonTextProperty: ObservableValue<String>,
     private val isRecordingProperty: ObservableValue<Boolean>,
     private val isRecordingAgainProperty: ObservableValue<Boolean>,
+    private val isRecordAgainPausedProperty: ObservableValue<Boolean>,
     private val isPlayingProperty: ObservableValue<Boolean>,
     private val recordingIndexProperty: IntegerProperty,
     private val playingVerseProperty: IntegerProperty,
@@ -91,6 +92,7 @@ class NarrationTextCell(
             recordButtonTextProperty.bind(this@NarrationTextCell.recordButtonTextProperty)
             isRecordingProperty.bind(this@NarrationTextCell.isRecordingProperty)
             isRecordingAgainProperty.bind(this@NarrationTextCell.isRecordingAgainProperty)
+            isRecordAgainPausedProperty.bind(this@NarrationTextCell.isRecordAgainPausedProperty)
             isPlayingProperty.bind(this@NarrationTextCell.isPlayingProperty)
             playingVerseIndexProperty.bind(this@NarrationTextCell.playingVerseProperty)
             isHighlightedProperty.bind(shouldHighlight)

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/AudioWorkspaceView.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/AudioWorkspaceView.kt
@@ -101,7 +101,9 @@ class AudioWorkspaceView : View() {
         }
 
         disableWhen {
-            viewModel.isRecordingProperty.or(viewModel.isPlayingProperty)
+            viewModel.isRecordingProperty
+                .or(viewModel.isPlayingProperty)
+                .or(viewModel.isRecordAgainPausedProperty)
         }
 
         unitIncrement = SCROLL_INCREMENT_UNIT

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/AudioWorkspaceView.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/AudioWorkspaceView.kt
@@ -185,6 +185,7 @@ class AudioWorkspaceView : View() {
                 verseIndexProperty.set(viewModel.recordedVerses.indexOf(marker))
                 labelProperty.set(markerLabel)
                 isRecordingProperty.bind(viewModel.isRecordingProperty)
+                isRecordAgainPausedProperty.bind(viewModel.isRecordAgainPausedProperty)
             }
         }
 
@@ -204,6 +205,7 @@ class AudioWorkspaceViewModel : ViewModel() {
     private val narrationViewModel: NarrationViewModel by inject()
 
     val isRecordingProperty = SimpleBooleanProperty()
+    val isRecordAgainPausedProperty = SimpleBooleanProperty()
     val isPlayingProperty = SimpleBooleanProperty()
     var recordedVerses = observableListOf<AudioMarker>()
 
@@ -222,6 +224,7 @@ class AudioWorkspaceViewModel : ViewModel() {
 
     fun onDock() {
         isRecordingProperty.bind(narrationViewModel.isRecordingProperty)
+        isRecordAgainPausedProperty.bind(narrationViewModel.isRecordAgainPausedProperty)
         isPlayingProperty.bind(narrationViewModel.isPlayingProperty)
         totalAudioSizeProperty.bind(narrationViewModel.totalAudioSizeProperty)
         audioPositionProperty.bind(narrationViewModel.audioPositionProperty)

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/NarrationToolBar.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/NarrationToolBar.kt
@@ -87,8 +87,12 @@ class NarrationToolBar : View() {
             setOnAction {
                 viewModel.seekToPrevious()
             }
+
             disableWhen {
-                viewModel.isPlayingProperty.or(viewModel.isRecordingProperty).or(viewModel.hasVersesProperty.not())
+                viewModel.isPlayingProperty
+                    .or(viewModel.isRecordingProperty)
+                    .or(viewModel.hasVersesProperty.not())
+                    .or(viewModel.isRecordAgainPausedProperty)
             }
         }
         button {
@@ -99,7 +103,10 @@ class NarrationToolBar : View() {
                 viewModel.seekToNext()
             }
             disableWhen {
-                viewModel.isPlayingProperty.or(viewModel.isRecordingProperty).or(viewModel.hasVersesProperty.not())
+                viewModel.isPlayingProperty
+                    .or(viewModel.isRecordingProperty)
+                    .or(viewModel.hasVersesProperty.not())
+                    .or(viewModel.isRecordAgainPausedProperty)
             }
         }
     }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/NarrationToolBar.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/NarrationToolBar.kt
@@ -51,7 +51,9 @@ class NarrationToolBar : View() {
 
 
             disableWhen {
-                viewModel.isRecordingProperty.or(viewModel.hasVersesProperty.not())
+                viewModel.isRecordingProperty
+                    .or(viewModel.hasVersesProperty.not())
+                    .or(viewModel.isRecordAgainPausedProperty)
             }
 
             viewModel.isPlayingProperty.onChangeAndDoNow {

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/NarrationViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/NarrationViewModel.kt
@@ -167,7 +167,6 @@ class NarrationViewModel : ViewModel() {
                 recordedVerses.isNotEmpty() && recordedVerses.size == narratableList.size
             }
         )
-        isRecordAgainPausedProperty.bind(recordAgainVerseIndexProperty.isNotNull)
 
         subscribe<AppCloseRequestEvent> {
             logger.info("Received close event request")
@@ -578,6 +577,7 @@ class NarrationViewModel : ViewModel() {
 
         recordAgainVerseIndex = verseIndex
         recordingVerseIndex.set(verseIndex)
+        isRecordAgainPausedProperty.set(true)
         isRecording = true
         isRecordingAgain = true
         recordPause = false
@@ -593,6 +593,7 @@ class NarrationViewModel : ViewModel() {
         narration.onSaveRecording(verseIndex)
 
         recordAgainVerseIndex = null
+        isRecordAgainPausedProperty.set(false)
         recordingVerseIndex.set(verseIndex)
         isRecording = false
         isRecordingAgain = false
@@ -688,6 +689,7 @@ class NarrationViewModel : ViewModel() {
 
         isRecording = false
         recordPause = true
+        isRecordAgainPausedProperty.set(true)
 
         narration.pauseRecording()
         narration.finalizeVerse(index)

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/NarrationViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/NarrationViewModel.kt
@@ -34,6 +34,7 @@ import javafx.beans.property.SimpleStringProperty
 import javafx.collections.ObservableList
 import javafx.scene.canvas.Canvas
 import javafx.scene.canvas.GraphicsContext
+import net.bytebuddy.build.Plugin.Factory.Simple
 import org.slf4j.LoggerFactory
 import org.wycliffeassociates.otter.common.audio.AudioFileReader
 import org.wycliffeassociates.otter.common.audio.DEFAULT_SAMPLE_RATE
@@ -109,6 +110,7 @@ class NarrationViewModel : ViewModel() {
     var isRecordingAgain by isRecordingAgainProperty
     val recordAgainVerseIndexProperty = SimpleObjectProperty<Int?>()
     var recordAgainVerseIndex by recordAgainVerseIndexProperty
+    val isRecordAgainPausedProperty = SimpleBooleanProperty(false)
     val isPlayingProperty = SimpleBooleanProperty(false)
     val recordingVerseIndex = SimpleIntegerProperty()
 
@@ -166,6 +168,7 @@ class NarrationViewModel : ViewModel() {
                 recordedVerses.isNotEmpty() && recordedVerses.size == narratableList.size
             }
         )
+        isRecordAgainPausedProperty.bind(recordAgainVerseIndexProperty.isNotNull)
 
         subscribe<AppCloseRequestEvent> {
             logger.info("Received close event request")

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/NarrationViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/NarrationViewModel.kt
@@ -34,7 +34,6 @@ import javafx.beans.property.SimpleStringProperty
 import javafx.collections.ObservableList
 import javafx.scene.canvas.Canvas
 import javafx.scene.canvas.GraphicsContext
-import net.bytebuddy.build.Plugin.Factory.Simple
 import org.slf4j.LoggerFactory
 import org.wycliffeassociates.otter.common.audio.AudioFileReader
 import org.wycliffeassociates.otter.common.audio.DEFAULT_SAMPLE_RATE

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/NarrationViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/NarrationViewModel.kt
@@ -577,7 +577,7 @@ class NarrationViewModel : ViewModel() {
 
         recordAgainVerseIndex = verseIndex
         recordingVerseIndex.set(verseIndex)
-        isRecordAgainPausedProperty.set(true)
+        isRecordAgainPausedProperty.set(false)
         isRecording = true
         isRecordingAgain = true
         recordPause = false

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/NarrationViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/NarrationViewModel.kt
@@ -689,7 +689,6 @@ class NarrationViewModel : ViewModel() {
 
         isRecording = false
         recordPause = true
-        isRecordAgainPausedProperty.set(true)
 
         narration.pauseRecording()
         narration.finalizeVerse(index)
@@ -704,6 +703,7 @@ class NarrationViewModel : ViewModel() {
 
         isRecording = false
         recordPause = true
+        isRecordAgainPausedProperty.set(true)
 
         narration.pauseRecording()
         narration.finalizeVerse(index)

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/TeleprompterView.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/TeleprompterView.kt
@@ -68,6 +68,8 @@ class TeleprompterViewModel : ViewModel() {
     val isRecordingAgainProperty = SimpleBooleanProperty()
     private var isRecordingAgain by isRecordingAgainProperty
 
+    val isRecordAgainPausedProperty = SimpleBooleanProperty()
+
 
     val lastRecordedVerseProperty = SimpleIntegerProperty(0)
 
@@ -82,6 +84,7 @@ class TeleprompterViewModel : ViewModel() {
         isPlayingProperty.bind(narrationViewModel.isPlayingProperty)
         recordPauseProperty.bindBidirectional(narrationViewModel.recordPauseProperty)
         isRecordingAgainProperty.bindBidirectional(narrationViewModel.isRecordingAgainProperty)
+        isRecordAgainPausedProperty.bind(narrationViewModel.isRecordAgainPausedProperty)
         lastRecordedVerseProperty.bindBidirectional(narrationViewModel.lastRecordedVerseProperty)
         recordingVerseProperty.bind(narrationViewModel.recordingVerseIndex)
         playingVerseProperty.bind(narrationViewModel.playingVerseIndex)
@@ -136,9 +139,9 @@ class TeleprompterViewModel : ViewModel() {
             TeleprompterItemState.RECORD_AGAIN_PAUSED
         )
         val verse = narrationViewModel.narratableList
-                .firstOrNull {
-                    it.state in activeStates || !it.hasRecording
-                }
+            .firstOrNull {
+                it.state in activeStates || !it.hasRecording
+            }
 
         stickyVerseProperty.set(verse)
     }
@@ -240,6 +243,7 @@ class TeleprompterView : View() {
                     viewModel.recordButtonTextBinding(),
                     viewModel.isRecordingProperty,
                     viewModel.isRecordingAgainProperty,
+                    viewModel.isRecordAgainPausedProperty,
                     viewModel.isPlayingProperty,
                     viewModel.recordingVerseProperty,
                     viewModel.playingVerseProperty,

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/markers/VerseMarkerControl.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/markers/VerseMarkerControl.kt
@@ -29,6 +29,7 @@ import javafx.scene.Node
 import javafx.scene.control.Button
 import javafx.scene.layout.BorderPane
 import javafx.scene.layout.Region
+import net.bytebuddy.build.Plugin.Factory.Simple
 import org.kordamp.ikonli.javafx.FontIcon
 import org.kordamp.ikonli.materialdesign.MaterialDesign
 import org.wycliffeassociates.otter.common.data.audio.AudioMarker
@@ -48,6 +49,7 @@ class VerseMarkerControl : BorderPane() {
     val canBeMovedProperty: BooleanBinding = verseIndexProperty.greaterThan(0)
     val userIsDraggingProperty = SimpleBooleanProperty(false)
     val isRecordingProperty = SimpleBooleanProperty()
+    val isRecordAgainPausedProperty = SimpleBooleanProperty()
 
     val dragAreaProperty = SimpleObjectProperty<Node>()
 
@@ -102,10 +104,10 @@ class VerseMarkerControl : BorderPane() {
         }
 
         center = label(labelProperty) {
-                minWidth = Region.USE_PREF_SIZE
-                addClass("verse-marker__title")
-                setAlignment(this, Pos.BOTTOM_LEFT)
-            }
+            minWidth = Region.USE_PREF_SIZE
+            addClass("verse-marker__title")
+            setAlignment(this, Pos.BOTTOM_LEFT)
+        }
 
         right = Button().apply {
             addClass("btn", "btn--icon", "verse-marker__menu")
@@ -115,6 +117,7 @@ class VerseMarkerControl : BorderPane() {
 
             val menu = VerseMenu().apply {
                 isRecordingProperty.bind(this@VerseMarkerControl.isRecordingProperty)
+                isRecordAgainPausedProperty.bind(this@VerseMarkerControl.isRecordAgainPausedProperty)
                 verseProperty.bind(this@VerseMarkerControl.verseProperty)
                 verseIndexProperty.bind(this@VerseMarkerControl.verseIndexProperty)
             }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/menu/VerseMenu.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/menu/VerseMenu.kt
@@ -64,7 +64,7 @@ class VerseMenu : ContextMenu() {
                 FX.eventbus.fire(RecordAgainEvent(verseIndexProperty.value))
             }
             disableWhen {
-                isRecordingProperty
+                isRecordingProperty.or(isRecordAgainPausedProperty)
             }
         }
 //        item(importVerseTextProperty.value) {
@@ -85,7 +85,7 @@ class VerseMenu : ContextMenu() {
                 FX.eventbus.fire(OpenInAudioPluginEvent(verseIndexProperty.value))
             }
             disableWhen {
-                isRecordingProperty
+                isRecordingProperty.or(isRecordAgainPausedProperty)
             }
         }
 

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/menu/VerseMenu.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/menu/VerseMenu.kt
@@ -18,22 +18,14 @@
  */
 package org.wycliffeassociates.otter.jvm.workbookapp.ui.narration.menu
 
-import javafx.beans.property.BooleanProperty
-import javafx.beans.property.IntegerProperty
-import javafx.beans.property.ObjectProperty
 import javafx.beans.property.SimpleBooleanProperty
 import javafx.beans.property.SimpleIntegerProperty
 import javafx.beans.property.SimpleObjectProperty
-import javafx.beans.property.SimpleStringProperty
-import javafx.event.EventTarget
-import javafx.scene.control.Button
 import javafx.scene.control.ContextMenu
-import javafx.scene.control.MenuButton
 import javafx.scene.control.MenuItem
 import org.kordamp.ikonli.javafx.FontIcon
 import org.kordamp.ikonli.materialdesign.MaterialDesign
 import org.wycliffeassociates.otter.common.data.audio.AudioMarker
-import org.wycliffeassociates.otter.common.data.audio.VerseMarker
 import org.wycliffeassociates.otter.jvm.controls.event.OpenInAudioPluginEvent
 import org.wycliffeassociates.otter.jvm.controls.event.PlayVerseEvent
 import org.wycliffeassociates.otter.jvm.controls.event.RecordAgainEvent
@@ -45,6 +37,7 @@ class VerseMenu : ContextMenu() {
     val verseProperty = SimpleObjectProperty<AudioMarker>()
     val verseIndexProperty = SimpleIntegerProperty()
     val isRecordingProperty = SimpleBooleanProperty()
+    val isRecordAgainPausedProperty = SimpleBooleanProperty()
 
     init {
         addClass("wa-context-menu")
@@ -57,8 +50,9 @@ class VerseMenu : ContextMenu() {
             action {
                 FX.eventbus.fire(PlayVerseEvent(verseProperty.value))
             }
+
             disableWhen {
-                isRecordingProperty
+                isRecordingProperty.or(isRecordAgainPausedProperty)
             }
         }
         val recordAgainOpt = MenuItem().apply {


### PR DESCRIPTION
Disables the following when in a record again pause state

- Audio playback
- Seek next/previous verse
- Record again
- Edit verse
- Scrolling with scroll bar

NOTE: I have not disabled scrolling with drag and drop, because that is a separate bug. Currently, the user can always drag/drop scroll even if the scroll bar is disabled.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/1046)
<!-- Reviewable:end -->
