### PR TITLE
Fix Back-up project missing selected takes

### DIFF
--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/project/ProjectFilesAccessor.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/project/ProjectFilesAccessor.kt
@@ -703,7 +703,16 @@ class ProjectFilesAccessor(
 
         val bookElements: Observable<BookElement> = when {
             chaptersOnly -> chapters.cast()
-            else -> chapters.concatMap { chapter -> chapter.children.startWith(chapter) }
+            else -> {
+                chapters.flatMap { chapter ->
+                    chapter.chunks
+                        .take(1)
+                        .flatMap {
+                            it.toObservable().cast<BookElement>()
+                        }
+                        .startWith(chapter)
+                }
+            }
         }
 
         return bookElements

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/BlindDraftViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/BlindDraftViewModel.kt
@@ -103,6 +103,9 @@ class BlindDraftViewModel : ViewModel() {
     }
 
     fun undockBlindDraft() {
+        workbookDataStore.workbook.let { wb ->
+            wb.projectFilesAccessor.updateSelectedTakesFile(wb).subscribe()
+        }
         audioDataStore.stopPlayers()
         audioDataStore.closePlayers()
         audioConnectionFactory.releasePlayer()


### PR DESCRIPTION
Bug: translation back-up files may not contain chunks' selected takes file name in `selected.txt` metadata file.

This PR changes the way of exporting selected takes by accessing the `chapter.chunks` relay directly instead of `chapter.children`.


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/1047)
<!-- Reviewable:end -->
