### PR TITLE
Fix empty screen after migrating narration

### DIFF
--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/Narration.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/Narration.kt
@@ -401,6 +401,10 @@ class Narration @AssistedInject constructor(
     }
 
     private fun execute(action: NarrationAction) {
+        if (!audioLoaded) {
+            player.load(chapterReaderConnection)
+            audioLoaded = true
+        }
         // Ensures we are not locked to a verse and that the location is in the relative chapter space
         seek(getLocationInChapter(), true)
         history.execute(action, chapterRepresentation.totalVerses, chapterRepresentation.scratchAudio)


### PR DESCRIPTION
This resolves the empty screen when importing/migrating an OT1 narration project

![image](https://github.com/Bible-Translation-Tools/Orature/assets/34975907/b753fb8d-5e18-4ccb-9394-97da343cc197)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/1048)
<!-- Reviewable:end -->
