### PR TITLE
Fix `Workbook is null` error

### DIFF
--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/button/DebouncedButton.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/button/DebouncedButton.kt
@@ -22,6 +22,7 @@ import javafx.animation.Animation
 import javafx.animation.PauseTransition
 import javafx.event.EventTarget
 import javafx.scene.control.Button
+import javafx.scene.control.ButtonBase
 import javafx.util.Duration
 import tornadofx.*
 
@@ -86,7 +87,7 @@ fun EventTarget.debouncedButton(
  * debounce(700.0) // called after setOnAction()
  * ```
  */
-fun Button.debounce(coolDownMillis: Double = DEFAULT_COOL_DOWN_MILLIS) {
+fun ButtonBase.debounce(coolDownMillis: Double = DEFAULT_COOL_DOWN_MILLIS) {
     val actionHandler = this.onActionProperty().value ?: return
     val coolDownTransition = PauseTransition(Duration.millis(coolDownMillis))
 

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/AppBar.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/AppBar.kt
@@ -24,6 +24,7 @@ import javafx.scene.layout.VBox
 import org.kordamp.ikonli.javafx.FontIcon
 import org.kordamp.ikonli.materialdesign.MaterialDesign
 import org.wycliffeassociates.otter.jvm.controls.button.AppBarButton
+import org.wycliffeassociates.otter.jvm.controls.button.debounce
 import org.wycliffeassociates.otter.jvm.controls.event.NavigationRequestEvent
 import org.wycliffeassociates.otter.jvm.controls.styles.tryImportStylesheet
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.components.drawer.AddFilesView
@@ -50,10 +51,11 @@ class AppBar : Fragment() {
 
         toggleGroup = buttonsToggleGroup
         selectedProperty().onChange { removePseudoClass("selected") }
-        setOnMouseClicked {
+        setOnAction {
             val homePage = find<HomePage2>()
             fire(NavigationRequestEvent(homePage))
         }
+        debounce()
     }
 
     private val addButton = AppBarButton().apply {


### PR DESCRIPTION
Going home while loading chapter take may result in `Workbook is null` error because `activeWorkbookProperty` in the datastore may be assigned to null before the code using it executes -`getMarkersFromText()`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/1049)
<!-- Reviewable:end -->
