### PR TITLE
Chapter draft update

### DIFF
--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/project/ProjectFilesAccessor.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/project/ProjectFilesAccessor.kt
@@ -703,16 +703,7 @@ class ProjectFilesAccessor(
 
         val bookElements: Observable<BookElement> = when {
             chaptersOnly -> chapters.cast()
-            else -> {
-                chapters.flatMap { chapter ->
-                    chapter.chunks
-                        .take(1)
-                        .flatMap {
-                            it.toObservable().cast<BookElement>()
-                        }
-                        .startWith(chapter)
-                }
-            }
+            else -> chapters.concatMap { chapter -> chapter.children.startWith(chapter) }
         }
 
         return bookElements


### PR DESCRIPTION
Updates getDraft() to get the latest list of chunks from a relay (empty list if the relay hasn't emitted)

This should be roughly equivalent to the past which would look at the relay cache.

Reverts the PFA change to use the draft again