### PR TITLE
Revert PFA change, update Chapter.getDraft()

### DIFF
--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/project/ProjectFilesAccessor.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/project/ProjectFilesAccessor.kt
@@ -702,16 +702,7 @@ class ProjectFilesAccessor(
 
         val bookElements: Observable<BookElement> = when {
             chaptersOnly -> chapters.cast()
-            else -> {
-                chapters.flatMap { chapter ->
-                    chapter.chunks
-                        .take(1)
-                        .flatMap {
-                            it.toObservable().cast<BookElement>()
-                        }
-                        .startWith(chapter)
-                }
-            }
+            else -> chapters.concatMap { chapter -> chapter.children.startWith(chapter) }
         }
 
         return bookElements


### PR DESCRIPTION
Updates getDraft() to get the latest list of chunks from a relay (empty list if the relay hasn't emitted)

This should be roughly equivalent to the past which would look at the relay cache.

Reverts the PFA change to use the draft again

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/1055)
<!-- Reviewable:end -->
