### PR TITLE
Fix loss of projects on Linux after updating app

### DIFF
--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/project/importer/RCImporter.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/project/importer/RCImporter.kt
@@ -68,7 +68,7 @@ abstract class RCImporter(
             }
             .doFinally {
                 stream.close()
-                outFile.parentFile.deleteRecursively()
+                outFile.delete()
             }
             .subscribeOn(Schedulers.io())
     }


### PR DESCRIPTION
Should not manually delete the entire `tempDir` directory after a file is imported. We delete the file itself instead

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/1059)
<!-- Reviewable:end -->
