### PR TITLE
Close workbook when importing

### DIFF
--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/project/importer/OngoingProjectImporter.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/project/importer/OngoingProjectImporter.kt
@@ -159,7 +159,10 @@ class OngoingProjectImporter @Inject constructor(
                     sourceLanguageSlug == existingProject.source.language.slug &&
                         languageSlug == existingProject.target.language.slug &&
                         projectSlug == existingProject.target.slug
-                }?.projectFilesAccessor?.isInitialized() ?: false
+                }?.let {
+                    workbookRepository.closeWorkbook(it)
+                    it.projectFilesAccessor.isInitialized()
+                } ?: false
             }
         }
     }


### PR DESCRIPTION
To prevent outdated database connections, it's best to close the workbook when we import an Ongoing project

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/1066)
<!-- Reviewable:end -->
