### PR TITLE
Render markers based on audio position (Java 17)

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -14,8 +14,8 @@ ext {
 
     // Libraries
     kotlinVer = '1.8.0'
-    javafxVer = '19'
-    javaVer = '11'
+    javafxVer = '21'
+    javaVer = '17'
     javaGridviewVer = '1.0.0'
     tornadofxVer = '2.1.1-WA-fork'
     rxkotlinVer = '2.4.0'

--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/marker/MarkerTrackControl.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/marker/MarkerTrackControl.kt
@@ -26,7 +26,6 @@ import javafx.beans.binding.Bindings
 import javafx.beans.property.SimpleBooleanProperty
 import javafx.beans.property.SimpleIntegerProperty
 import javafx.geometry.Point2D
-import javafx.scene.layout.Region
 import javafx.scene.shape.Rectangle
 import org.wycliffeassociates.otter.jvm.utils.onChangeAndDoNow
 import tornadofx.*
@@ -34,6 +33,7 @@ import java.util.concurrent.Callable
 import javafx.beans.property.SimpleObjectProperty
 import javafx.scene.input.KeyCode
 import javafx.scene.input.KeyEvent
+import javafx.scene.layout.Pane
 import org.wycliffeassociates.otter.common.audio.DEFAULT_SAMPLE_RATE
 import org.wycliffeassociates.otter.common.data.audio.ChapterMarker
 import org.wycliffeassociates.otter.common.data.audio.VerseMarker
@@ -49,7 +49,7 @@ import org.wycliffeassociates.otter.jvm.utils.onChangeWithDisposer
 const val MOVE_MARKER_INTERVAL = 0.001
 const val MARKER_COUNT = 500
 
-open class MarkerTrackControl : Region() {
+open class MarkerTrackControl : Pane() {
 
     val markers = observableListOf<MarkerItem>()
     val canMoveMarkerProperty = SimpleBooleanProperty(true)
@@ -337,8 +337,8 @@ open class MarkerTrackControl : Region() {
             audioPositionProperty.value + framesOnScreen
         )
         children.clear()
-        children.addAll(highlights)
         markers.forEachIndexed { index, markerItem ->
+            children.add(highlights[index])
             if (markerItem.frame in bufferRange) {
                 children.add(_markers[index])
             }

--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/marker/MarkerTrackControl.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/marker/MarkerTrackControl.kt
@@ -337,9 +337,9 @@ open class MarkerTrackControl : Region() {
             audioPositionProperty.value + framesOnScreen
         )
         children.clear()
+        children.addAll(highlights)
         markers.forEachIndexed { index, markerItem ->
             if (markerItem.frame in bufferRange) {
-                children.add(highlights[index])
                 children.add(_markers[index])
             }
         }

--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/marker/MarkerTrackControl.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/marker/MarkerTrackControl.kt
@@ -24,6 +24,7 @@ import com.sun.javafx.scene.traversal.TraversalMethod
 import com.sun.javafx.util.Utils
 import javafx.beans.binding.Bindings
 import javafx.beans.property.SimpleBooleanProperty
+import javafx.beans.property.SimpleIntegerProperty
 import javafx.geometry.Point2D
 import javafx.scene.layout.Region
 import javafx.scene.shape.Rectangle
@@ -33,14 +34,17 @@ import java.util.concurrent.Callable
 import javafx.beans.property.SimpleObjectProperty
 import javafx.scene.input.KeyCode
 import javafx.scene.input.KeyEvent
+import org.wycliffeassociates.otter.common.audio.DEFAULT_SAMPLE_RATE
 import org.wycliffeassociates.otter.common.data.audio.ChapterMarker
 import org.wycliffeassociates.otter.common.data.audio.VerseMarker
 import org.wycliffeassociates.otter.jvm.controls.event.MarkerMovedEvent
 import org.wycliffeassociates.otter.common.domain.model.MarkerItem
+import org.wycliffeassociates.otter.jvm.controls.model.SECONDS_ON_SCREEN
 import org.wycliffeassociates.otter.jvm.controls.model.framesToPixels
 import org.wycliffeassociates.otter.jvm.controls.model.pixelsToFrames
 import org.wycliffeassociates.otter.jvm.utils.ListenerDisposer
 import org.wycliffeassociates.otter.jvm.utils.onChangeAndDoNowWithDisposer
+import org.wycliffeassociates.otter.jvm.utils.onChangeWithDisposer
 
 const val MOVE_MARKER_INTERVAL = 0.001
 const val MARKER_COUNT = 500
@@ -55,6 +59,7 @@ open class MarkerTrackControl : Region() {
     val onSeekNextProperty = SimpleObjectProperty<() -> Unit>()
     val onSeekProperty = SimpleObjectProperty<(Int) -> Unit>()
     val onLocationRequestProperty = SimpleObjectProperty<() -> Int>()
+    val audioPositionProperty = SimpleIntegerProperty()
 
     fun setOnPositionChanged(op: (Int, Double) -> Unit) {
         onPositionChangedProperty.set(op)
@@ -77,15 +82,14 @@ open class MarkerTrackControl : Region() {
         resetState()
         preallocateMarkers()
 
-        highlights.forEach { add(it) }
-        _markers.forEach { add(it) }
         refreshMarkers()
         refreshHighlights()
+        renderMarkers()
 
-        markers.onChangeAndDoNowWithDisposer {
-            it.sortedBy { it.frame }
+        markers.onChangeWithDisposer {
             refreshMarkers()
             refreshHighlights()
+            renderMarkers()
         }.also(listeners::add)
     }
 
@@ -282,6 +286,10 @@ open class MarkerTrackControl : Region() {
     init {
         initialize()
 
+        audioPositionProperty.onChange {
+            renderMarkers()
+        }
+
         // Makes the region mouse transparent but not children
         pickOnBoundsProperty().set(false)
 
@@ -308,6 +316,31 @@ open class MarkerTrackControl : Region() {
             when (it.code) {
                 KeyCode.ENTER, KeyCode.SPACE -> it.consume()
                 else -> {}
+            }
+        }
+    }
+
+    /**
+     * Uses a sliding-window to render only the marker nodes that are within
+     * a specified viewport. This reduces the number of unnecessary nodes attached
+     * to the scene and improves performance as a result.
+     */
+    private fun renderMarkers() {
+        val framesOnScreen = SECONDS_ON_SCREEN * DEFAULT_SAMPLE_RATE
+        val start = (audioPositionProperty.value - framesOnScreen).coerceAtLeast(0)
+        val end = (audioPositionProperty.value + framesOnScreen)
+        if (start == end) {
+            return
+        }
+        val bufferRange = IntRange(
+            audioPositionProperty.value - framesOnScreen,
+            audioPositionProperty.value + framesOnScreen
+        )
+        children.clear()
+        markers.forEachIndexed { index, markerItem ->
+            if (markerItem.frame in bufferRange) {
+                children.add(highlights[index])
+                children.add(_markers[index])
             }
         }
     }

--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/skins/MarkerNodeSkin.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/skins/MarkerNodeSkin.kt
@@ -20,6 +20,7 @@ package org.wycliffeassociates.otter.jvm.controls.skins
 
 import javafx.scene.control.SkinBase
 import javafx.scene.layout.Priority
+import javafx.scene.layout.Region.USE_PREF_SIZE
 import javafx.scene.layout.VBox
 import org.kordamp.ikonli.javafx.FontIcon
 import org.kordamp.ikonli.material.Material
@@ -48,6 +49,7 @@ class MarkerNodeSkin(val control: MarkerNode) : SkinBase<MarkerNode>(control) {
                 label(control.markerNumberProperty) {
                     addClass("normal-text")
                     graphic = FontIcon(Material.BOOKMARK_OUTLINE).addClass("wa-icon")
+                    minWidth = USE_PREF_SIZE
                 }
                 button {
                     addClass("btn", "btn--icon", "btn--borderless", "normal-text")

--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/waveform/MarkerPlacementWaveform.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/waveform/MarkerPlacementWaveform.kt
@@ -20,6 +20,7 @@ package org.wycliffeassociates.otter.jvm.controls.waveform
 
 import javafx.beans.property.SimpleBooleanProperty
 import javafx.beans.property.SimpleDoubleProperty
+import javafx.beans.property.SimpleIntegerProperty
 import javafx.beans.property.SimpleObjectProperty
 import javafx.event.ActionEvent
 import javafx.event.EventHandler
@@ -39,6 +40,7 @@ class MarkerPlacementWaveform : StackPane() {
     val markers = observableListOf<MarkerItem>()
     val imageWidthProperty = SimpleDoubleProperty()
     val positionProperty = SimpleDoubleProperty(0.0)
+    val audioPositionProperty = SimpleIntegerProperty(0)
     val canMoveMarkerProperty = SimpleBooleanProperty(true)
 
     private val onPositionChanged = SimpleObjectProperty<(Int, Double) -> Unit> { _, _ -> }
@@ -128,6 +130,7 @@ class MarkerPlacementWaveform : StackPane() {
         val topTrack = MarkerTrackControl().apply {
             top = this
             markers.bind(this@MarkerPlacementWaveform.markers, { it })
+            audioPositionProperty.bind(this@MarkerPlacementWaveform.audioPositionProperty)
             canMoveMarkerProperty.bind(this@MarkerPlacementWaveform.canMoveMarkerProperty)
             onPositionChangedProperty.bind(onPositionChanged)
             onLocationRequestProperty.bind(onLocationRequest)

--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/waveform/MarkerWaveform.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/waveform/MarkerWaveform.kt
@@ -20,6 +20,7 @@ package org.wycliffeassociates.otter.jvm.controls.waveform
 
 import javafx.beans.property.SimpleBooleanProperty
 import javafx.beans.property.SimpleDoubleProperty
+import javafx.beans.property.SimpleIntegerProperty
 import javafx.beans.property.SimpleObjectProperty
 import javafx.event.ActionEvent
 import javafx.event.EventHandler
@@ -40,6 +41,7 @@ class MarkerWaveform : StackPane() {
 
     val markers = observableListOf<MarkerItem>()
     val positionProperty = SimpleDoubleProperty(0.0)
+    val audioPositionProperty = SimpleIntegerProperty()
     val canMoveMarkerProperty = SimpleBooleanProperty(true)
     val canDeleteMarkerProperty = SimpleBooleanProperty(true)
 
@@ -137,6 +139,7 @@ class MarkerWaveform : StackPane() {
             canDeleteMarkerProperty.bind(this@MarkerWaveform.canDeleteMarkerProperty)
             onPositionChangedProperty.bind(onPositionChanged)
             onLocationRequestProperty.bind(onLocationRequest)
+            audioPositionProperty.bind(this@MarkerWaveform.audioPositionProperty)
         }
         waveformFrame = WaveformFrame(topTrack).apply {
             themeProperty.bind(this@MarkerWaveform.themeProperty)

--- a/jvm/markerapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/markerapp/app/view/MarkerView.kt
+++ b/jvm/markerapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/markerapp/app/view/MarkerView.kt
@@ -97,6 +97,7 @@ class MarkerView : PluginEntrypoint() {
                 addClass("vm-marker-waveform")
                 themeProperty.bind(viewModel.themeColorProperty)
                 positionProperty.bind(viewModel.positionProperty)
+                audioPositionProperty.bind(viewModel.audioPositionProperty)
 
                 setOnSeekNext { viewModel.seekNext() }
                 setOnSeekPrevious { viewModel.seekPrevious() }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/ChapterReview.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/ChapterReview.kt
@@ -96,6 +96,7 @@ class ChapterReview : View() {
                 vgrow = Priority.ALWAYS
                 themeProperty.bind(settingsViewModel.appColorMode)
                 positionProperty.bind(viewModel.positionProperty)
+                audioPositionProperty.bind(viewModel.audioPositionProperty)
                 clip = Rectangle().apply {
                     widthProperty().bind(container.widthProperty())
                     heightProperty().bind(container.heightProperty())

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/Chunking.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/Chunking.kt
@@ -76,6 +76,7 @@ class Chunking : View() {
                     }
                     themeProperty.bind(settingsViewModel.appColorMode)
                     positionProperty.bind(viewModel.positionProperty)
+                    audioPositionProperty.bind(viewModel.audioPositionProperty)
                     canMoveMarkerProperty.set(true)
                     canDeleteMarkerProperty.set(true)
 

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/Consume.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/Consume.kt
@@ -99,6 +99,7 @@ class Consume : View() {
                     }
                     themeProperty.bind(settingsViewModel.appColorMode)
                     positionProperty.bind(viewModel.positionProperty)
+                    audioPositionProperty.bind(viewModel.audioPositionProperty)
                     canMoveMarkerProperty.set(false)
                     canDeleteMarkerProperty.set(false)
 


### PR DESCRIPTION
### For Translation Projects
The performance issue appeared to derive from the number of marker controls (500x) that were added to the pane. 
This PR uses the sliding window approach to render only the necessary markers based on the current position of the audio.

The list of 500 markers is still initialized but we only include in the scene a certain amount at any given time.

```
        children.clear()
        ...
            if (markerItem.frame in bufferRange) {
                children.add(_markers[index])
            }
        ...
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/1069)
<!-- Reviewable:end -->
