### PR TITLE
Don't seek to 0 on pause (Narration)

### DIFF
--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/ChapterRepresentation.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/ChapterRepresentation.kt
@@ -164,7 +164,7 @@ internal class ChapterRepresentation(
 
         history?.finalizeVerse(endIndex, totalVerses)
         onVersesUpdated()
-        return endIndex
+        return endIndex - 1 // subtract 1 due to the sector being finalized with `until`
     }
 
     fun onVersesUpdated() {


### PR DESCRIPTION
As finalizing a verse creates a sector using "until," the endIndex here is the exclusive end. Subtract 1 to make it inclusive.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/1086)
<!-- Reviewable:end -->
