### PR TITLE
Fix re-recording renderer

### DIFF
--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/AudioScene.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/AudioScene.kt
@@ -22,6 +22,7 @@ import io.reactivex.Observable
 import org.slf4j.LoggerFactory
 import org.wycliffeassociates.otter.common.audio.AudioFileReader
 import java.util.*
+import kotlin.math.max
 import kotlin.math.roundToInt
 
 class AudioScene(
@@ -54,6 +55,9 @@ class AudioScene(
         reRecordStart: Int,
         nextVerseLocation: Int
     ): Pair<FloatArray, List<IntRange>> {
+        // if the first item is being re-recorded, both it and the next verse locations will be 0
+        // which will break rendering of the subsequent verses. Thus, we max with 1.
+        val nextVerseLocation = max(1, nextVerseLocation)
         Arrays.fill(frameBuffer, 0f)
         val framesOnScreen = secondsOnScreen * recordingSampleRate
 

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/Narration.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/Narration.kt
@@ -330,7 +330,7 @@ class Narration @AssistedInject constructor(
 
     fun resumeRecordingAgain() {
         // Seeks to the end of the scratchAudio, since the re-record has not yet been finalized.
-        val lastRecordingPosition = chapterRepresentation.scratchAudio.totalFrames
+        val lastRecordingPosition = chapterRepresentation.scratchAudio.totalFrames - 1
         player.seek(chapterRepresentation.absoluteFrameToRelativeChapterFrame(lastRecordingPosition))
         writer?.start()
         isRecording.set(true)


### PR DESCRIPTION
Re-recording the first verse was not showing a waveform of the other verses.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/1087)
<!-- Reviewable:end -->
