### PR TITLE
Fix migration (cont)

### DIFF
--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/project/importer/OngoingProjectImporter.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/project/importer/OngoingProjectImporter.kt
@@ -99,10 +99,10 @@ class OngoingProjectImporter @Inject constructor(
     private var projectAppVersion = ProjectAppVersion.THREE
     private var projectMode: ProjectMode = ProjectMode.TRANSLATION
     private var takesInChapterFilter: Map<String, Int>? = null
-    private var completedChapterTranslation: List<Int>? = null
+    private var completedChapterTranslation: List<Int>? = null // used for determining checking status
     private var takesCheckingMap: TakeCheckingStatusMap = mapOf()
-    private var completedChapterNarration = listOf<Int>()
-    private var takesToCompile = mutableMapOf<Int, List<File>>() // for migration from Ot1 - narration projects
+    private var completedChapterNarration = listOf<Int>() // store verses of incomplete chapter in Ot1 to compile
+    private var takesToCompile = mutableMapOf<Int, List<File>>() // for compiling verses of incomplete chapter in Ot1
     private var migratedSelectedTakes = listOf<String>() // list of selected take paths extracted from Ot1 database
 
     override fun import(
@@ -538,7 +538,7 @@ class OngoingProjectImporter @Inject constructor(
         val isNarrationMigration = projectAppVersion == ProjectAppVersion.ONE && projectMode == ProjectMode.NARRATION
         if (isNarrationMigration) {
             takesToCompile.forEach { (chapter, takeFiles) ->
-                compileIncompleteChapter(chapter, takeFiles, project, metadata)
+                compileIncompleteChapterNarration(chapter, takeFiles, project, metadata)
             }
         }
     }
@@ -804,7 +804,7 @@ class OngoingProjectImporter @Inject constructor(
      * can restore the file as one chapter take. Only call this method if the chapter
      * has not completed/compiled before migrating to Orature 3.x.
      */
-    private fun compileIncompleteChapter(
+    private fun compileIncompleteChapterNarration(
         chapterNumber: Int,
         takeFiles: List<File>,
         project: Collection,

--- a/common/src/test/kotlin/org/wycliffeassociates/otter/common/ResourceContainerBuilder.kt
+++ b/common/src/test/kotlin/org/wycliffeassociates/otter/common/ResourceContainerBuilder.kt
@@ -24,15 +24,12 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import org.wycliffeassociates.otter.common.audio.AudioFileFormat
 import org.wycliffeassociates.otter.common.data.Chunkification
-import org.wycliffeassociates.otter.common.data.audio.OratureCueType
-import org.wycliffeassociates.otter.common.data.audio.VerseMarker
 import org.wycliffeassociates.otter.common.data.primitives.Content
 import org.wycliffeassociates.otter.common.data.primitives.ContentType
 import org.wycliffeassociates.otter.common.data.primitives.Language
 import org.wycliffeassociates.otter.common.data.primitives.ProjectMode
 import org.wycliffeassociates.otter.common.data.primitives.SerializableProjectMode
 import org.wycliffeassociates.otter.common.data.workbook.TakeCheckingState
-import org.wycliffeassociates.otter.common.domain.audio.OratureAudioFile
 import org.wycliffeassociates.otter.common.domain.content.FileNamer
 import org.wycliffeassociates.otter.common.domain.resourcecontainer.RcConstants
 import org.wycliffeassociates.resourcecontainer.ResourceContainer
@@ -195,12 +192,6 @@ class ResourceContainerBuilder(baseRC: File? = null) {
                 tempTakeFile.copyTo(this, overwrite = true)
                 deleteOnExit()
             }
-        if (start != null && end != null) {
-            OratureAudioFile(takeToAdd).apply {
-                addMarker(VerseMarker(start, end, 0))
-                update()
-            }
-        }
 
         val chapterDirTokens = "c${chapter.toString().padStart(2, '0')}"
         val relativePath = "$chapterDirTokens/$fileName"

--- a/common/src/test/kotlin/org/wycliffeassociates/otter/common/ResourceContainerBuilder.kt
+++ b/common/src/test/kotlin/org/wycliffeassociates/otter/common/ResourceContainerBuilder.kt
@@ -24,12 +24,15 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import org.wycliffeassociates.otter.common.audio.AudioFileFormat
 import org.wycliffeassociates.otter.common.data.Chunkification
+import org.wycliffeassociates.otter.common.data.audio.OratureCueType
+import org.wycliffeassociates.otter.common.data.audio.VerseMarker
 import org.wycliffeassociates.otter.common.data.primitives.Content
 import org.wycliffeassociates.otter.common.data.primitives.ContentType
 import org.wycliffeassociates.otter.common.data.primitives.Language
 import org.wycliffeassociates.otter.common.data.primitives.ProjectMode
 import org.wycliffeassociates.otter.common.data.primitives.SerializableProjectMode
 import org.wycliffeassociates.otter.common.data.workbook.TakeCheckingState
+import org.wycliffeassociates.otter.common.domain.audio.OratureAudioFile
 import org.wycliffeassociates.otter.common.domain.content.FileNamer
 import org.wycliffeassociates.otter.common.domain.resourcecontainer.RcConstants
 import org.wycliffeassociates.resourcecontainer.ResourceContainer
@@ -192,6 +195,12 @@ class ResourceContainerBuilder(baseRC: File? = null) {
                 tempTakeFile.copyTo(this, overwrite = true)
                 deleteOnExit()
             }
+        if (start != null && end != null) {
+            OratureAudioFile(takeToAdd).apply {
+                addMarker(VerseMarker(start, end, 0))
+                update()
+            }
+        }
 
         val chapterDirTokens = "c${chapter.toString().padStart(2, '0')}"
         val relativePath = "$chapterDirTokens/$fileName"


### PR DESCRIPTION
To appropriately handle both migration and importing projects from Ot1, especially for narration, we need to determine the completed chapter based on two factors:
- the selected takes inside the import file (based on selected.txt)
- the migrated selected takes extracted from Ot1 database

`union()` these two sets will give us the correct list of selected takes and allow filtering the completed chapter based on the file name (signature).

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/1094)
<!-- Reviewable:end -->
