### PR TITLE
Fix crash deleting projects [OT-859]

### DIFF
--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/HomePageViewModel2.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/HomePageViewModel2.kt
@@ -199,13 +199,13 @@ class HomePageViewModel2 : ViewModel() {
         projectWizardViewModel.increaseProjectDeleteCounter()
 
         val timerDisposable =
-            Completable
-                .timer(timeoutMillis.toLong(), TimeUnit.MILLISECONDS)
-                .andThen {
-                    projectsWithDeleteTimer.remove(cardModel) // remove from undoable list; delete task is starting
-                    it.onComplete()
+            deleteProjectUseCase
+                .deleteProjectsWithTimer(
+                    cardModel.booksModel,
+                    timeoutMillis.toInt()
+                ) {
+                    projectsWithDeleteTimer.remove(cardModel) // remove from undo list just right before deleting
                 }
-                .concatWith(deleteProjectUseCase.deleteProjects(cardModel.booksModel))
                 .observeOnFx()
                 .doOnComplete {
                     logger.info("Deleted project group: ${cardModel.sourceLanguage.name} -> ${cardModel.targetLanguage.name}.")


### PR DESCRIPTION
Context: when a project group is scheduled to be deleted, we add it to a map<project, disposable> (like a queue). When the user opens a book right after they deleted a project, we want to "fast-forward" the deletion by disposing all the projects stored in the map and start deleting them immediately.

#### This PR makes sure once a project's delete() enters its "critical section", it must be FIRST removed from the queue before executing the delete task. Otherwise, the code would accidentally dispose() the deletion during its critical section and throw an exception.

> projectsWithDeleteTimer.remove(cardModel) // must call before executing actual delete()

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/1101)
<!-- Reviewable:end -->
