### PR TITLE
Clear compressor after 0 padding

### DIFF
--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/AudioReaderDrawable.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/AudioReaderDrawable.kt
@@ -64,6 +64,8 @@ class AudioReaderDrawable(
         var totalFramesToRead = secondsOnScreen * recordingSampleRate
 
         val paddedFrames = padStart(pcmCompressor, audioReader.frameSizeBytes, location, totalFramesToRead)
+
+        pcmCompressor.clear() // clear the compressor after potentially padding 0s
         totalFramesToRead -= paddedFrames
 
         val clampedFrameLoc = location.coerceIn(0..audioReader.totalFrames)


### PR DESCRIPTION
If the compressor isn't cleared, some 0's will spill over causing a waveform wiggle for the first ~5 seconds of playback

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/1107)
<!-- Reviewable:end -->
