### PR TITLE
Allow ocenaudio always

### DIFF
--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/menu/NarrationMenu.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/menu/NarrationMenu.kt
@@ -47,10 +47,6 @@ class NarrationMenu : ContextMenu() {
             action {
                 FX.eventbus.fire(NarrationOpenInPluginEvent(PluginType.EDITOR))
             }
-            enableWhen(
-                narrationStateProperty.isEqualTo(NarrationStateType.FINISHED)
-                    .or(narrationStateProperty.isEqualTo(NarrationStateType.HAS_RECORDINGS))
-            )
         }
         val verseMarkerOpt = MenuItem().apply {
             graphic = label(messages["editVerseMarkers"]) {
@@ -60,7 +56,7 @@ class NarrationMenu : ContextMenu() {
             action {
                 FX.eventbus.fire(NarrationOpenInPluginEvent(PluginType.MARKER))
             }
-            enableWhen(narrationStateProperty.isEqualTo(NarrationStateType.FINISHED))
+            enableWhen(narrationStateProperty.isEqualTo(NarrationStateType.HAS_RECORDINGS))
         }
         val restartChapterOpt = MenuItem().apply {
             graphic = label(messages["restartChapter"]) {


### PR DESCRIPTION
Allows opening ocenaudio with an empty chapter, and the verse marker app can be opened as long as there is audio recorded (allowing markers to be placed if a chapter is imported into the first item)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/1114)
<!-- Reviewable:end -->
