### PR TITLE
Fix for disappearing markers OT-863

### DIFF
--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/NarrationViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/NarrationViewModel.kt
@@ -703,7 +703,9 @@ class NarrationViewModel : ViewModel() {
             }
 
             narrationStateProperty.value == NarrationStateType.RECORDING_PAUSED -> {
+                renderer.clearActiveRecordingData()
                 recordingVerseIndex.set(-1)
+                isPrependRecordingProperty.set(false)
             }
 
             else -> {}


### PR DESCRIPTION
Resolves issue where recording paused next caused markers to disappear when recording a non-sequential verse marker.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/1115)
<!-- Reviewable:end -->
