### PR TITLE
Fix for incorrect state after non-sequential record pause (OT-864)

### DIFF
--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/teleprompter/TeleprompterStateTransition.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/teleprompter/TeleprompterStateTransition.kt
@@ -57,12 +57,10 @@ object PauseVerseRecordingAction {
         if (index !in contexts.indices) return
 
         if (0 != index) {
-            for (i in 0 until contexts.size) {
-
+            for (i in contexts.indices) {
                 if (contexts[i].state.type == TeleprompterItemState.RECORD_DISABLED) {
                     continue
                 }
-
                 contexts[i].restore()
                 if (contexts[i].state.type == TeleprompterItemState.RECORD_AGAIN_DISABLED) {
                     contexts[i].changeState(TeleprompterItemState.RECORD_AGAIN)

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/teleprompter/TeleprompterStateTransition.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/teleprompter/TeleprompterStateTransition.kt
@@ -57,7 +57,12 @@ object PauseVerseRecordingAction {
         if (index !in contexts.indices) return
 
         if (0 != index) {
-            for (i in 0 until index) {
+            for (i in 0 until contexts.size) {
+
+                if (contexts[i].state.type == TeleprompterItemState.RECORD_DISABLED) {
+                    continue
+                }
+
                 contexts[i].restore()
                 if (contexts[i].state.type == TeleprompterItemState.RECORD_AGAIN_DISABLED) {
                     contexts[i].changeState(TeleprompterItemState.RECORD_AGAIN)
@@ -108,10 +113,12 @@ object NextVerseAction {
 
         if (wasActive) {
             contexts[currentIndex].changeState(TeleprompterItemState.RECORD_AGAIN_DISABLED)
-            contexts.firstOrNull { it.state.type == TeleprompterItemState.RECORD_DISABLED }?.changeState(TeleprompterItemState.RECORD_ACTIVE)
+            contexts.firstOrNull { it.state.type == TeleprompterItemState.RECORD_DISABLED }
+                ?.changeState(TeleprompterItemState.RECORD_ACTIVE)
         } else {
             contexts[currentIndex].changeState(TeleprompterItemState.RECORD_AGAIN)
-            contexts.firstOrNull { it.state.type == TeleprompterItemState.RECORD_DISABLED }?.changeState(TeleprompterItemState.RECORD)
+            contexts.firstOrNull { it.state.type == TeleprompterItemState.RECORD_DISABLED }
+                ?.changeState(TeleprompterItemState.RECORD)
         }
     }
 }


### PR DESCRIPTION
Accounts for non-sequential record pauses by restoring all teleprompter item that are not in a RECORD_DISABLED state on recording pause

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/1116)
<!-- Reviewable:end -->
