### PR TITLE
Allow verse marker app when finished

### DIFF
--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/teleprompter/NarrationState.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/teleprompter/NarrationState.kt
@@ -7,7 +7,7 @@ enum class NarrationStateType {
     RECORDING_AGAIN_PAUSED,
     PLAYING,
     NOT_STARTED,
-    HAS_RECORDINGS,
+    IN_PROGRESS,
     FINISHED,
     MODIFYING_AUDIO_FILE,
     MOVING_MARKER,
@@ -54,7 +54,7 @@ object RecordingPausedState : NarrationState {
     override val validStateTransitions: Set<NarrationStateType> =
         setOf(
             NarrationStateType.RECORDING, // Resume
-            NarrationStateType.HAS_RECORDINGS, // Next
+            NarrationStateType.IN_PROGRESS, // Next
             NarrationStateType.MODIFYING_AUDIO_FILE, // Save (last verse)
             NarrationStateType.PLAYING, // Playing paused verse
             NarrationStateType.RECORDING_AGAIN, // Record again
@@ -67,7 +67,7 @@ object RecordingPausedState : NarrationState {
 
         return when (request) {
             NarrationStateType.RECORDING -> RecordingState
-            NarrationStateType.HAS_RECORDINGS -> HasRecordingState
+            NarrationStateType.IN_PROGRESS -> InProgressState
             NarrationStateType.MODIFYING_AUDIO_FILE -> ModifyingAudioState
             NarrationStateType.PLAYING -> PlayingAudioState
             NarrationStateType.RECORDING_AGAIN -> RecordingAgainState
@@ -86,7 +86,7 @@ object RecordingAgainState : NarrationState {
         setOf(
             NarrationStateType.MODIFYING_AUDIO_FILE, // Save with all verses recorded
             NarrationStateType.RECORDING_AGAIN_PAUSED, // Pause
-            NarrationStateType.HAS_RECORDINGS, // Save without all verses recorded
+            NarrationStateType.IN_PROGRESS, // Save without all verses recorded
         )
 
     override fun changeState(request: NarrationStateType): NarrationState {
@@ -97,7 +97,7 @@ object RecordingAgainState : NarrationState {
         return when (request) {
             NarrationStateType.MODIFYING_AUDIO_FILE -> ModifyingAudioState
             NarrationStateType.RECORDING_AGAIN_PAUSED -> RecordingAgainPausedState
-            NarrationStateType.HAS_RECORDINGS -> HasRecordingState
+            NarrationStateType.IN_PROGRESS -> InProgressState
             else -> {
                 throw IllegalStateException("State: $type tried to transition to state: $request")
             }
@@ -113,7 +113,7 @@ object RecordingAgainPausedState : NarrationState {
         setOf(
             NarrationStateType.MODIFYING_AUDIO_FILE, // Save (with all verses recorded)
             NarrationStateType.RECORDING_AGAIN, // Resume
-            NarrationStateType.HAS_RECORDINGS, // Save (without all verses recorded)
+            NarrationStateType.IN_PROGRESS, // Save (without all verses recorded)
         )
 
     override fun changeState(request: NarrationStateType): NarrationState {
@@ -124,7 +124,7 @@ object RecordingAgainPausedState : NarrationState {
         return when (request) {
             NarrationStateType.MODIFYING_AUDIO_FILE -> ModifyingAudioState
             NarrationStateType.RECORDING_AGAIN -> RecordingAgainState
-            NarrationStateType.HAS_RECORDINGS -> HasRecordingState
+            NarrationStateType.IN_PROGRESS -> InProgressState
             else -> {
                 throw IllegalStateException("State: $type tried to transition to state: $request")
             }
@@ -139,7 +139,7 @@ object PlayingAudioState : NarrationState {
     override val validStateTransitions: Set<NarrationStateType> =
         setOf(
             NarrationStateType.RECORDING_PAUSED, // After playing a verse that was in a recording paused state
-            NarrationStateType.HAS_RECORDINGS, // Playing audio completes without all verses recorded
+            NarrationStateType.IN_PROGRESS, // Playing audio completes without all verses recorded
             NarrationStateType.FINISHED, // Playing audio completes  with all verses recorded,
             NarrationStateType.MODIFYING_AUDIO_FILE, // Started playing audio while bouncing, and bouncing has not finished
         )
@@ -151,7 +151,7 @@ object PlayingAudioState : NarrationState {
 
         return when (request) {
             NarrationStateType.RECORDING_PAUSED -> RecordingPausedState
-            NarrationStateType.HAS_RECORDINGS -> HasRecordingState
+            NarrationStateType.IN_PROGRESS -> InProgressState
             NarrationStateType.FINISHED -> FinishedState
             NarrationStateType.MODIFYING_AUDIO_FILE -> ModifyingAudioState
             else -> {
@@ -169,7 +169,7 @@ object NotStartedState : NarrationState {
         setOf(
             NarrationStateType.RECORDING, // Record
             NarrationStateType.FINISHED, // Undoing a restart chapter
-            NarrationStateType.HAS_RECORDINGS, // Redo a recording
+            NarrationStateType.IN_PROGRESS, // Redo a recording
         )
 
     override fun changeState(request: NarrationStateType): NarrationState {
@@ -180,7 +180,7 @@ object NotStartedState : NarrationState {
         return when (request) {
             NarrationStateType.RECORDING -> RecordingState
             NarrationStateType.FINISHED -> FinishedState
-            NarrationStateType.HAS_RECORDINGS -> HasRecordingState
+            NarrationStateType.IN_PROGRESS -> InProgressState
             else -> {
                 throw IllegalStateException("State: $type tried to transition to state: $request")
             }
@@ -189,8 +189,8 @@ object NotStartedState : NarrationState {
 }
 
 
-object HasRecordingState : NarrationState {
-    override val type: NarrationStateType = NarrationStateType.HAS_RECORDINGS
+object InProgressState : NarrationState {
+    override val type: NarrationStateType = NarrationStateType.IN_PROGRESS
 
     override val validStateTransitions: Set<NarrationStateType> =
         setOf(
@@ -230,7 +230,7 @@ object FinishedState : NarrationState {
             NarrationStateType.RECORDING_AGAIN, // Record again
             NarrationStateType.MODIFYING_AUDIO_FILE, // Undo/redo, save (after record again), return/open from plugin
             NarrationStateType.NOT_STARTED, // Restart chapter
-            NarrationStateType.HAS_RECORDINGS, // Undo record
+            NarrationStateType.IN_PROGRESS, // Undo record
             NarrationStateType.PLAYING, // Play verse/chapter
             NarrationStateType.MOVING_MARKER, // Moving verse marker
         )
@@ -244,7 +244,7 @@ object FinishedState : NarrationState {
             NarrationStateType.RECORDING_AGAIN -> RecordingAgainState
             NarrationStateType.MODIFYING_AUDIO_FILE -> ModifyingAudioState
             NarrationStateType.NOT_STARTED -> NotStartedState
-            NarrationStateType.HAS_RECORDINGS -> HasRecordingState
+            NarrationStateType.IN_PROGRESS -> InProgressState
             NarrationStateType.PLAYING -> PlayingAudioState
             NarrationStateType.MOVING_MARKER -> MovingMarkerState
             else -> {
@@ -260,7 +260,7 @@ object ModifyingAudioState : NarrationState {
 
     override val validStateTransitions: Set<NarrationStateType> =
         setOf(
-            NarrationStateType.HAS_RECORDINGS, // After bouncing audio for opening plugin without all verses recorded
+            NarrationStateType.IN_PROGRESS, // After bouncing audio for opening plugin without all verses recorded
             NarrationStateType.FINISHED, // After record again/undo/redo
             NarrationStateType.RECORDING_AGAIN, // Starts recording again while bouncing audio
             NarrationStateType.PLAYING, // Plays verse/chapter while bouncing audio
@@ -273,7 +273,7 @@ object ModifyingAudioState : NarrationState {
         }
 
         return when (request) {
-            NarrationStateType.HAS_RECORDINGS -> HasRecordingState
+            NarrationStateType.IN_PROGRESS -> InProgressState
             NarrationStateType.FINISHED -> FinishedState
             NarrationStateType.RECORDING_AGAIN -> RecordingAgainState
             NarrationStateType.PLAYING -> PlayingAudioState
@@ -292,7 +292,7 @@ object MovingMarkerState : NarrationState {
 
     override val validStateTransitions: Set<NarrationStateType> =
         setOf(
-            NarrationStateType.HAS_RECORDINGS, // Moving marker finished without all verses placed
+            NarrationStateType.IN_PROGRESS, // Moving marker finished without all verses placed
             NarrationStateType.FINISHED, // Moving marker finished with all verses placed
             NarrationStateType.MODIFYING_AUDIO_FILE, // Moving marker finished while bouncing audio
         )
@@ -303,7 +303,7 @@ object MovingMarkerState : NarrationState {
         }
 
         return when (request) {
-            NarrationStateType.HAS_RECORDINGS -> HasRecordingState
+            NarrationStateType.IN_PROGRESS -> InProgressState
             NarrationStateType.FINISHED -> FinishedState
             NarrationStateType.MODIFYING_AUDIO_FILE -> ModifyingAudioState
             else -> {

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/teleprompter/NarrationStateTransition.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/teleprompter/NarrationStateTransition.kt
@@ -76,7 +76,7 @@ object NextAction {
         return if (isRecording) {
             globalContext.changeState(NarrationStateType.RECORDING)
         } else {
-            globalContext.changeState(NarrationStateType.HAS_RECORDINGS)
+            globalContext.changeState(NarrationStateType.IN_PROGRESS)
         }
 
     }
@@ -143,7 +143,7 @@ object StartSaveAction {
         return if (allVersesRecorded) {
             globalContext.changeState(NarrationStateType.MODIFYING_AUDIO_FILE)
         } else {
-            globalContext.changeState(NarrationStateType.HAS_RECORDINGS)
+            globalContext.changeState(NarrationStateType.IN_PROGRESS)
         }
 
     }
@@ -228,7 +228,7 @@ object PausePlaybackAction {
         } else if (allVersesRecorded) {
             NarrationStateType.FINISHED
         } else {
-            NarrationStateType.HAS_RECORDINGS
+            NarrationStateType.IN_PROGRESS
         }
 
 
@@ -303,7 +303,7 @@ object PlaceMarkerAction {
         return if (allVersesRecorded) {
             globalContext.changeState(NarrationStateType.FINISHED)
         } else {
-            globalContext.changeState(NarrationStateType.HAS_RECORDINGS)
+            globalContext.changeState(NarrationStateType.IN_PROGRESS)
         }
     }
 }

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/teleprompter/TeleprompterStateMachine.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/teleprompter/TeleprompterStateMachine.kt
@@ -79,7 +79,7 @@ class TeleprompterStateMachine(
         } else if (hasNoItemsRecorded) {
             NotStartedState
         } else {
-            HasRecordingState
+            InProgressState
         }
 
         updateNarrationContext(newGlobalContext)

--- a/common/src/test/kotlin/org/wycliffeassociates/otter/common/domain/narration/statemachine/NarrationStateTest.kt
+++ b/common/src/test/kotlin/org/wycliffeassociates/otter/common/domain/narration/statemachine/NarrationStateTest.kt
@@ -16,7 +16,7 @@ class NarrationStateTest {
             Pair(NarrationStateType.RECORDING_AGAIN_PAUSED, true),
             Pair(NarrationStateType.PLAYING, true),
             Pair(NarrationStateType.NOT_STARTED, true),
-            Pair(NarrationStateType.HAS_RECORDINGS, true),
+            Pair(NarrationStateType.IN_PROGRESS, true),
             Pair(NarrationStateType.FINISHED, true),
             Pair(NarrationStateType.MODIFYING_AUDIO_FILE, false),
             Pair(NarrationStateType.MOVING_MARKER, true),
@@ -69,7 +69,7 @@ class NarrationStateTest {
             Pair(NarrationStateType.RECORDING_AGAIN_PAUSED, true),
             Pair(NarrationStateType.PLAYING, false),
             Pair(NarrationStateType.NOT_STARTED, true),
-            Pair(NarrationStateType.HAS_RECORDINGS, false),
+            Pair(NarrationStateType.IN_PROGRESS, false),
             Pair(NarrationStateType.FINISHED, true),
             Pair(NarrationStateType.MODIFYING_AUDIO_FILE, false),
             Pair(NarrationStateType.MOVING_MARKER, true),
@@ -100,9 +100,9 @@ class NarrationStateTest {
 
 
     @Test
-    fun `RecordingPausedState changeState to IdleInProgressState`() {
-        val newState = RecordingPausedState.changeState(NarrationStateType.HAS_RECORDINGS)
-        Assert.assertEquals(newState.type, NarrationStateType.HAS_RECORDINGS)
+    fun `RecordingPausedState changeState to InProgressState`() {
+        val newState = RecordingPausedState.changeState(NarrationStateType.IN_PROGRESS)
+        Assert.assertEquals(newState.type, NarrationStateType.IN_PROGRESS)
     }
 
 
@@ -136,7 +136,7 @@ class NarrationStateTest {
             Pair(NarrationStateType.RECORDING_AGAIN_PAUSED, false),
             Pair(NarrationStateType.PLAYING, true),
             Pair(NarrationStateType.NOT_STARTED, true),
-            Pair(NarrationStateType.HAS_RECORDINGS, false),
+            Pair(NarrationStateType.IN_PROGRESS, false),
             Pair(NarrationStateType.FINISHED, true),
             Pair(NarrationStateType.MODIFYING_AUDIO_FILE, false),
             Pair(NarrationStateType.MOVING_MARKER, true),
@@ -174,9 +174,9 @@ class NarrationStateTest {
 
 
     @Test
-    fun `RecordingAgainState changeState to IdleInProgressState`() {
-        val newState = RecordingAgainState.changeState(NarrationStateType.HAS_RECORDINGS)
-        Assert.assertEquals(newState.type, NarrationStateType.HAS_RECORDINGS)
+    fun `RecordingAgainState changeState to InProgressState`() {
+        val newState = RecordingAgainState.changeState(NarrationStateType.IN_PROGRESS)
+        Assert.assertEquals(newState.type, NarrationStateType.IN_PROGRESS)
     }
 
 
@@ -190,7 +190,7 @@ class NarrationStateTest {
             Pair(NarrationStateType.RECORDING_AGAIN_PAUSED, true),
             Pair(NarrationStateType.PLAYING, true),
             Pair(NarrationStateType.NOT_STARTED, true),
-            Pair(NarrationStateType.HAS_RECORDINGS, false),
+            Pair(NarrationStateType.IN_PROGRESS, false),
             Pair(NarrationStateType.FINISHED, true),
             Pair(NarrationStateType.MODIFYING_AUDIO_FILE, false),
             Pair(NarrationStateType.MOVING_MARKER, true),
@@ -228,9 +228,9 @@ class NarrationStateTest {
 
 
     @Test
-    fun `RecordingAgainPausedState changeState to IdleInProgressState`() {
-        val newState = RecordingAgainPausedState.changeState(NarrationStateType.HAS_RECORDINGS)
-        Assert.assertEquals(newState.type, NarrationStateType.HAS_RECORDINGS)
+    fun `RecordingAgainPausedState changeState to InProgressState`() {
+        val newState = RecordingAgainPausedState.changeState(NarrationStateType.IN_PROGRESS)
+        Assert.assertEquals(newState.type, NarrationStateType.IN_PROGRESS)
     }
 
 
@@ -244,7 +244,7 @@ class NarrationStateTest {
             Pair(NarrationStateType.RECORDING_AGAIN_PAUSED, true),
             Pair(NarrationStateType.PLAYING, true),
             Pair(NarrationStateType.NOT_STARTED, true),
-            Pair(NarrationStateType.HAS_RECORDINGS, false),
+            Pair(NarrationStateType.IN_PROGRESS, false),
             Pair(NarrationStateType.FINISHED, false),
             Pair(NarrationStateType.MODIFYING_AUDIO_FILE, false),
             Pair(NarrationStateType.MOVING_MARKER, true),
@@ -275,14 +275,14 @@ class NarrationStateTest {
 
 
     @Test
-    fun `PlayingAudioState changeState to IdleInProgressState`() {
-        val newState = PlayingAudioState.changeState(NarrationStateType.HAS_RECORDINGS)
-        Assert.assertEquals(newState.type, NarrationStateType.HAS_RECORDINGS)
+    fun `PlayingAudioState changeState to InProgressState`() {
+        val newState = PlayingAudioState.changeState(NarrationStateType.IN_PROGRESS)
+        Assert.assertEquals(newState.type, NarrationStateType.IN_PROGRESS)
     }
 
 
     @Test
-    fun `PlayingAudioState changeState to IdleFinishedState`() {
+    fun `PlayingAudioState changeState to FinishedState`() {
         val newState = PlayingAudioState.changeState(NarrationStateType.FINISHED)
         Assert.assertEquals(newState.type, NarrationStateType.FINISHED)
     }
@@ -296,7 +296,7 @@ class NarrationStateTest {
 
 
     @Test
-    fun `IdleEmptyState changeState and all possible state transitions`() {
+    fun `NotStartedState changeState and all possible state transitions`() {
         // Pair.first = NarrationStateType, Pair.second = throws exception
         val stateTransitions = mutableListOf(
             Pair(NarrationStateType.RECORDING, false),
@@ -305,7 +305,7 @@ class NarrationStateTest {
             Pair(NarrationStateType.RECORDING_AGAIN_PAUSED, true),
             Pair(NarrationStateType.PLAYING, true),
             Pair(NarrationStateType.NOT_STARTED, true),
-            Pair(NarrationStateType.HAS_RECORDINGS, false),
+            Pair(NarrationStateType.IN_PROGRESS, false),
             Pair(NarrationStateType.FINISHED, false),
             Pair(NarrationStateType.MODIFYING_AUDIO_FILE, true),
             Pair(NarrationStateType.MOVING_MARKER, true),
@@ -329,28 +329,28 @@ class NarrationStateTest {
 
 
     @Test
-    fun `IdleEmptyState changeState to RecordingState`() {
+    fun `NotStartedState changeState to RecordingState`() {
         val newState = NotStartedState.changeState(NarrationStateType.RECORDING)
         Assert.assertEquals(newState.type, NarrationStateType.RECORDING)
     }
 
 
     @Test
-    fun `IdleEmptyState changeState to IdleFinishedState`() {
+    fun `NotStartedState changeState to FinishedState`() {
         val newState = NotStartedState.changeState(NarrationStateType.FINISHED)
         Assert.assertEquals(newState.type, NarrationStateType.FINISHED)
     }
 
 
     @Test
-    fun `IdleEmptyState changeState to IdleInProgressState`() {
-        val newState = NotStartedState.changeState(NarrationStateType.HAS_RECORDINGS)
-        Assert.assertEquals(newState.type, NarrationStateType.HAS_RECORDINGS)
+    fun `NotStartedState changeState to InProgressState`() {
+        val newState = NotStartedState.changeState(NarrationStateType.IN_PROGRESS)
+        Assert.assertEquals(newState.type, NarrationStateType.IN_PROGRESS)
     }
 
 
     @Test
-    fun `IdleInProgressState changeState and all possible state transitions`() {
+    fun `InProgressState changeState and all possible state transitions`() {
         // Pair.first = NarrationStateType, Pair.second = throws exception
         val stateTransitions = mutableListOf(
             Pair(NarrationStateType.RECORDING, false),
@@ -359,7 +359,7 @@ class NarrationStateTest {
             Pair(NarrationStateType.RECORDING_AGAIN_PAUSED, true),
             Pair(NarrationStateType.PLAYING, false),
             Pair(NarrationStateType.NOT_STARTED, false),
-            Pair(NarrationStateType.HAS_RECORDINGS, true),
+            Pair(NarrationStateType.IN_PROGRESS, true),
             Pair(NarrationStateType.FINISHED, true),
             Pair(NarrationStateType.MODIFYING_AUDIO_FILE, false),
             Pair(NarrationStateType.MOVING_MARKER, false),
@@ -369,7 +369,7 @@ class NarrationStateTest {
         // Verifies that exceptions are thrown when invalid states are requested
         for (transition in stateTransitions) {
             try {
-                HasRecordingState.changeState(transition.first)
+                InProgressState.changeState(transition.first)
                 if (transition.second) {
                     Assert.fail("Error: expected an exception for state transition: ${transition.first}")
                 }
@@ -382,47 +382,47 @@ class NarrationStateTest {
     }
 
     @Test
-    fun `IdleInProgressState changeState to RecordingState`() {
-        val newState = HasRecordingState.changeState(NarrationStateType.RECORDING)
+    fun `InProgressState changeState to RecordingState`() {
+        val newState = InProgressState.changeState(NarrationStateType.RECORDING)
         Assert.assertEquals(newState.type, NarrationStateType.RECORDING)
     }
 
     @Test
-    fun `IdleInProgressState changeState to ModifyingAudioState`() {
-        val newState = HasRecordingState.changeState(NarrationStateType.MODIFYING_AUDIO_FILE)
+    fun `InProgressState changeState to ModifyingAudioState`() {
+        val newState = InProgressState.changeState(NarrationStateType.MODIFYING_AUDIO_FILE)
         Assert.assertEquals(newState.type, NarrationStateType.MODIFYING_AUDIO_FILE)
     }
 
     @Test
-    fun `IdleInProgressState changeState to IdleEmptyState`() {
-        val newState = HasRecordingState.changeState(NarrationStateType.NOT_STARTED)
+    fun `InProgressState changeState to NotStartedState`() {
+        val newState = InProgressState.changeState(NarrationStateType.NOT_STARTED)
         Assert.assertEquals(newState.type, NarrationStateType.NOT_STARTED)
     }
 
 
     @Test
-    fun `IdleInProgressState changeState to RecordingAgainState`() {
-        val newState = HasRecordingState.changeState(NarrationStateType.RECORDING_AGAIN)
+    fun `InProgressState changeState to RecordingAgainState`() {
+        val newState = InProgressState.changeState(NarrationStateType.RECORDING_AGAIN)
         Assert.assertEquals(newState.type, NarrationStateType.RECORDING_AGAIN)
     }
 
 
     @Test
-    fun `IdleInProgressState changeState to PlayingAudioState`() {
-        val newState = HasRecordingState.changeState(NarrationStateType.PLAYING)
+    fun `InProgressState changeState to PlayingAudioState`() {
+        val newState = InProgressState.changeState(NarrationStateType.PLAYING)
         Assert.assertEquals(newState.type, NarrationStateType.PLAYING)
     }
 
 
     @Test
-    fun `IdleInProgressState changeState to MovingMarkerState`() {
-        val newState = HasRecordingState.changeState(NarrationStateType.MOVING_MARKER)
+    fun `InProgressState changeState to MovingMarkerState`() {
+        val newState = InProgressState.changeState(NarrationStateType.MOVING_MARKER)
         Assert.assertEquals(newState.type, NarrationStateType.MOVING_MARKER)
     }
 
 
     @Test
-    fun `IdleFinishedState changeState and all possible state transitions`() {
+    fun `FinishedState changeState and all possible state transitions`() {
         // Pair.first = NarrationStateType, Pair.second = throws exception
         val stateTransitions = mutableListOf(
             Pair(NarrationStateType.RECORDING, true),
@@ -431,7 +431,7 @@ class NarrationStateTest {
             Pair(NarrationStateType.RECORDING_AGAIN_PAUSED, true),
             Pair(NarrationStateType.PLAYING, false),
             Pair(NarrationStateType.NOT_STARTED, false),
-            Pair(NarrationStateType.HAS_RECORDINGS, false),
+            Pair(NarrationStateType.IN_PROGRESS, false),
             Pair(NarrationStateType.FINISHED, true),
             Pair(NarrationStateType.MODIFYING_AUDIO_FILE, false),
             Pair(NarrationStateType.MOVING_MARKER, false),
@@ -455,40 +455,40 @@ class NarrationStateTest {
 
 
     @Test
-    fun `IdleFinishedState changeState to RecordingAgainState`() {
+    fun `FinishedState changeState to RecordingAgainState`() {
         val newState = FinishedState.changeState(NarrationStateType.RECORDING_AGAIN)
         Assert.assertEquals(newState.type, NarrationStateType.RECORDING_AGAIN)
     }
 
 
     @Test
-    fun `IdleFinishedState changeState to ModifyingAudioState`() {
+    fun `FinishedState changeState to ModifyingAudioState`() {
         val newState = FinishedState.changeState(NarrationStateType.MODIFYING_AUDIO_FILE)
         Assert.assertEquals(newState.type, NarrationStateType.MODIFYING_AUDIO_FILE)
     }
 
 
     @Test
-    fun `IdleFinishedState changeState to IdleEmptyState`() {
+    fun `FinishedState changeState to NotStartedState`() {
         val newState = FinishedState.changeState(NarrationStateType.NOT_STARTED)
         Assert.assertEquals(newState.type, NarrationStateType.NOT_STARTED)
     }
 
     @Test
-    fun `IdleFinishedState changeState to IdleInProgressState`() {
-        val newState = FinishedState.changeState(NarrationStateType.HAS_RECORDINGS)
-        Assert.assertEquals(newState.type, NarrationStateType.HAS_RECORDINGS)
+    fun `FinishedState changeState to InProgressState`() {
+        val newState = FinishedState.changeState(NarrationStateType.IN_PROGRESS)
+        Assert.assertEquals(newState.type, NarrationStateType.IN_PROGRESS)
     }
 
 
     @Test
-    fun `IdleFinishedState changeState to PlayingAudioState`() {
+    fun `FinishedState changeState to PlayingAudioState`() {
         val newState = FinishedState.changeState(NarrationStateType.PLAYING)
         Assert.assertEquals(newState.type, NarrationStateType.PLAYING)
     }
 
     @Test
-    fun `IdleFinishedState changeState to MovingMarkerState`() {
+    fun `FinishedState changeState to MovingMarkerState`() {
         val newState = FinishedState.changeState(NarrationStateType.MOVING_MARKER)
         Assert.assertEquals(newState.type, NarrationStateType.MOVING_MARKER)
     }
@@ -504,7 +504,7 @@ class NarrationStateTest {
             Pair(NarrationStateType.RECORDING_AGAIN_PAUSED, true),
             Pair(NarrationStateType.PLAYING, false),
             Pair(NarrationStateType.NOT_STARTED, true),
-            Pair(NarrationStateType.HAS_RECORDINGS, false),
+            Pair(NarrationStateType.IN_PROGRESS, false),
             Pair(NarrationStateType.FINISHED, false),
             Pair(NarrationStateType.MODIFYING_AUDIO_FILE, true),
             Pair(NarrationStateType.MOVING_MARKER, false),
@@ -527,13 +527,13 @@ class NarrationStateTest {
     }
 
     @Test
-    fun `ModifyingAudioState changeState to IdleInProgressState`() {
-        val newState = ModifyingAudioState.changeState(NarrationStateType.HAS_RECORDINGS)
-        Assert.assertEquals(newState.type, NarrationStateType.HAS_RECORDINGS)
+    fun `ModifyingAudioState changeState to InProgressState`() {
+        val newState = ModifyingAudioState.changeState(NarrationStateType.IN_PROGRESS)
+        Assert.assertEquals(newState.type, NarrationStateType.IN_PROGRESS)
     }
 
     @Test
-    fun `ModifyingAudioState changeState to IdleFinishedState`() {
+    fun `ModifyingAudioState changeState to FinishedState`() {
         val newState = ModifyingAudioState.changeState(NarrationStateType.FINISHED)
         Assert.assertEquals(newState.type, NarrationStateType.FINISHED)
     }
@@ -568,7 +568,7 @@ class NarrationStateTest {
             Pair(NarrationStateType.RECORDING_AGAIN_PAUSED, true),
             Pair(NarrationStateType.PLAYING, true),
             Pair(NarrationStateType.NOT_STARTED, true),
-            Pair(NarrationStateType.HAS_RECORDINGS, false),
+            Pair(NarrationStateType.IN_PROGRESS, false),
             Pair(NarrationStateType.FINISHED, false),
             Pair(NarrationStateType.MODIFYING_AUDIO_FILE, false),
             Pair(NarrationStateType.MOVING_MARKER, true),
@@ -592,14 +592,14 @@ class NarrationStateTest {
 
 
     @Test
-    fun `MovingMarkerState changeState to IdleInProgressState`() {
-        val newState = MovingMarkerState.changeState(NarrationStateType.HAS_RECORDINGS)
-        Assert.assertEquals(newState.type, NarrationStateType.HAS_RECORDINGS)
+    fun `MovingMarkerState changeState to InProgressState`() {
+        val newState = MovingMarkerState.changeState(NarrationStateType.IN_PROGRESS)
+        Assert.assertEquals(newState.type, NarrationStateType.IN_PROGRESS)
     }
 
 
     @Test
-    fun `MovingMarkerState changeState to IdleFinishedState`() {
+    fun `MovingMarkerState changeState to FinishedState`() {
         val newState = MovingMarkerState.changeState(NarrationStateType.FINISHED)
         Assert.assertEquals(newState.type, NarrationStateType.FINISHED)
     }

--- a/common/src/test/kotlin/org/wycliffeassociates/otter/common/domain/narration/statemachine/TeleprompterStateMachineTest.kt
+++ b/common/src/test/kotlin/org/wycliffeassociates/otter/common/domain/narration/statemachine/TeleprompterStateMachineTest.kt
@@ -44,7 +44,7 @@ class TeleprompterStateMachineTest {
 
         TeleprompterStateMachine.initialize(activeVerses)
 
-        // Verifies that the narration context is in an idle empty state
+        // Verifies that the narration context is in a not started state
         Assert.assertEquals(NarrationStateType.NOT_STARTED, TeleprompterStateMachine.getNarrationContext())
 
         val contexts = TeleprompterStateMachine.getVerseItemStates()
@@ -71,8 +71,8 @@ class TeleprompterStateMachineTest {
 
         TeleprompterStateMachine.initialize(activeVerses)
 
-        // Verifies that the narration context is in an idle empty state
-        Assert.assertEquals(NarrationStateType.HAS_RECORDINGS, TeleprompterStateMachine.getNarrationContext())
+        // Verifies that the narration context is in a not started state
+        Assert.assertEquals(NarrationStateType.IN_PROGRESS, TeleprompterStateMachine.getNarrationContext())
 
         val contexts = TeleprompterStateMachine.getVerseItemStates()
 
@@ -96,7 +96,7 @@ class TeleprompterStateMachineTest {
 
         TeleprompterStateMachine.initialize(activeVerses)
 
-        // Verifies that the narration context is in an IDLE_FINISHED state
+        // Verifies that the narration context is in a FINISHED state
         Assert.assertEquals(NarrationStateType.FINISHED, TeleprompterStateMachine.getNarrationContext())
 
         val contexts = TeleprompterStateMachine.getVerseItemStates()
@@ -120,7 +120,7 @@ class TeleprompterStateMachineTest {
 
         TeleprompterStateMachine.initialize(activeVerses)
 
-        Assert.assertEquals(NarrationStateType.HAS_RECORDINGS, TeleprompterStateMachine.getNarrationContext())
+        Assert.assertEquals(NarrationStateType.IN_PROGRESS, TeleprompterStateMachine.getNarrationContext())
 
         val contexts = TeleprompterStateMachine.transition(NarrationStateTransition.PLAY_AUDIO, verseToPlay)
         Assert.assertEquals(NarrationStateType.PLAYING, TeleprompterStateMachine.getNarrationContext())
@@ -145,7 +145,7 @@ class TeleprompterStateMachineTest {
 
         TeleprompterStateMachine.initialize(activeVerses)
 
-        // Verifies that the narration context is in an idle empty state
+        // Verifies that the narration context is in a not started state
         Assert.assertEquals(NarrationStateType.NOT_STARTED, TeleprompterStateMachine.getNarrationContext())
 
         val index = 0
@@ -173,7 +173,7 @@ class TeleprompterStateMachineTest {
 
         TeleprompterStateMachine.initialize(activeVerses)
 
-        // Verifies that the narration context is in an idle empty state
+        // Verifies that the narration context is in a not started state
         Assert.assertEquals(NarrationStateType.NOT_STARTED, TeleprompterStateMachine.getNarrationContext())
 
 
@@ -211,8 +211,8 @@ class TeleprompterStateMachineTest {
 
         TeleprompterStateMachine.initialize(activeVerses)
 
-        // Verifies that the narration context is in an IDLE_IN_PROGRESS state
-        Assert.assertEquals(NarrationStateType.HAS_RECORDINGS, TeleprompterStateMachine.getNarrationContext())
+        // Verifies that the narration context is in an IN_PROGRESS state
+        Assert.assertEquals(NarrationStateType.IN_PROGRESS, TeleprompterStateMachine.getNarrationContext())
 
         val index = 1
         var newContext = TeleprompterStateMachine.transition(NarrationStateTransition.RECORD_AGAIN, index)
@@ -341,7 +341,7 @@ class TeleprompterStateMachineTest {
         Assert.assertEquals(NarrationStateType.RECORDING_PAUSED, TeleprompterStateMachine.getNarrationContext())
         TeleprompterStateMachine.transition(NarrationStateTransition.NEXT, 0)
 
-        Assert.assertEquals(NarrationStateType.HAS_RECORDINGS, TeleprompterStateMachine.getNarrationContext())
+        Assert.assertEquals(NarrationStateType.IN_PROGRESS, TeleprompterStateMachine.getNarrationContext())
 
         // Records verse 2
         TeleprompterStateMachine.transition(NarrationStateTransition.RECORD, 1)
@@ -350,7 +350,7 @@ class TeleprompterStateMachineTest {
         Assert.assertEquals(NarrationStateType.RECORDING_PAUSED, TeleprompterStateMachine.getNarrationContext())
         TeleprompterStateMachine.transition(NarrationStateTransition.NEXT, 1)
 
-        Assert.assertEquals(NarrationStateType.HAS_RECORDINGS, TeleprompterStateMachine.getNarrationContext())
+        Assert.assertEquals(NarrationStateType.IN_PROGRESS, TeleprompterStateMachine.getNarrationContext())
 
         // Starts recording for verse 3
         TeleprompterStateMachine.transition(NarrationStateTransition.RECORD, 2)
@@ -418,7 +418,7 @@ class TeleprompterStateMachineTest {
 
         TeleprompterStateMachine.initialize(activeVerses)
 
-        // Verifies that the narration context is in an IDLE_EMPTY state
+        // Verifies that the narration context is in a NOT_STARTED state
         Assert.assertEquals(NarrationStateType.NOT_STARTED, TeleprompterStateMachine.getNarrationContext())
 
         val index = 0
@@ -438,8 +438,8 @@ class TeleprompterStateMachineTest {
         // Next
         var newContext = TeleprompterStateMachine.transition(NarrationStateTransition.NEXT, index)
 
-        // Verifies that the narration context is in an IDLE_IN_PROGRESS state
-        Assert.assertEquals(NarrationStateType.HAS_RECORDINGS, TeleprompterStateMachine.getNarrationContext())
+        // Verifies that the narration context is in an IN_PROGRESS state
+        Assert.assertEquals(NarrationStateType.IN_PROGRESS, TeleprompterStateMachine.getNarrationContext())
 
         // Verify that newContext[index] is in the RECORD_AGAIN state
         Assert.assertEquals(TeleprompterItemState.RECORD_AGAIN, newContext[index].verseState)
@@ -528,7 +528,7 @@ class TeleprompterStateMachineTest {
         // Next
         TeleprompterStateMachine.transition(NarrationStateTransition.NEXT, index)
 
-        Assert.assertEquals(NarrationStateType.HAS_RECORDINGS, TeleprompterStateMachine.getNarrationContext())
+        Assert.assertEquals(NarrationStateType.IN_PROGRESS, TeleprompterStateMachine.getNarrationContext())
 
         TeleprompterStateMachine.transition(NarrationStateTransition.RECORD_AGAIN, index)
 
@@ -582,7 +582,7 @@ class TeleprompterStateMachineTest {
             // Next
             newContext = TeleprompterStateMachine.transition(NarrationStateTransition.NEXT, i)
 
-            Assert.assertEquals(NarrationStateType.HAS_RECORDINGS, TeleprompterStateMachine.getNarrationContext())
+            Assert.assertEquals(NarrationStateType.IN_PROGRESS, TeleprompterStateMachine.getNarrationContext())
         }
 
         // Records the last verse
@@ -620,7 +620,7 @@ class TeleprompterStateMachineTest {
         }
 
         TeleprompterStateMachine.initialize(activeVerses)
-        Assert.assertEquals(NarrationStateType.HAS_RECORDINGS, TeleprompterStateMachine.getNarrationContext())
+        Assert.assertEquals(NarrationStateType.IN_PROGRESS, TeleprompterStateMachine.getNarrationContext())
 
         val verseIndexToRecord = versesPreviouslyRecorded
         var newContext = TeleprompterStateMachine.transition(NarrationStateTransition.RECORD, verseIndexToRecord)
@@ -658,7 +658,7 @@ class TeleprompterStateMachineTest {
         }
 
         TeleprompterStateMachine.initialize(activeVerses)
-        Assert.assertEquals(NarrationStateType.HAS_RECORDINGS, TeleprompterStateMachine.getNarrationContext())
+        Assert.assertEquals(NarrationStateType.IN_PROGRESS, TeleprompterStateMachine.getNarrationContext())
 
         val verseIndexToRecord = versesPreviouslyRecorded
         var newContext = TeleprompterStateMachine.transition(NarrationStateTransition.RECORD, verseIndexToRecord)
@@ -781,7 +781,7 @@ class TeleprompterStateMachineTest {
         }
 
         TeleprompterStateMachine.initialize(activeVerses)
-        Assert.assertEquals(NarrationStateType.HAS_RECORDINGS, TeleprompterStateMachine.getNarrationContext())
+        Assert.assertEquals(NarrationStateType.IN_PROGRESS, TeleprompterStateMachine.getNarrationContext())
 
         val verseIndexToRecord = 5
         var newContext = TeleprompterStateMachine.transition(NarrationStateTransition.RECORD, verseIndexToRecord)
@@ -837,7 +837,7 @@ class TeleprompterStateMachineTest {
 
 
     @Test
-    fun `transition from MODIFYING_AUDIO_FILE, PLAYING, to IDLE_FINISHED with all verses previously recorded`() {
+    fun `transition from MODIFYING_AUDIO_FILE, PLAYING, to FINISHED with all verses previously recorded`() {
         val numMarkers = 10
         val audioMarkers = makeAudioMarkerLists(numMarkers)
         val TeleprompterStateMachine = TeleprompterStateMachine(audioMarkers)
@@ -898,7 +898,7 @@ class TeleprompterStateMachineTest {
 
 
     @Test
-    fun `transition from MODIFYING_AUDIO_FILE, MOVING_MARKER, to IDLE_IN_PROGRESS with all verses previously recorded`() {
+    fun `transition from MODIFYING_AUDIO_FILE, MOVING_MARKER, to IN_PROGRESS with all verses previously recorded`() {
         val numMarkers = 10
         val audioMarkers = makeAudioMarkerLists(numMarkers)
         val TeleprompterStateMachine = TeleprompterStateMachine(audioMarkers)

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/menu/NarrationMenu.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/menu/NarrationMenu.kt
@@ -56,7 +56,10 @@ class NarrationMenu : ContextMenu() {
             action {
                 FX.eventbus.fire(NarrationOpenInPluginEvent(PluginType.MARKER))
             }
-            enableWhen(narrationStateProperty.isEqualTo(NarrationStateType.HAS_RECORDINGS))
+            enableWhen(
+                narrationStateProperty.isEqualTo(NarrationStateType.IN_PROGRESS)
+                    .or(narrationStateProperty.isEqualTo(NarrationStateType.FINISHED))
+            )
         }
         val restartChapterOpt = MenuItem().apply {
             graphic = label(messages["restartChapter"]) {
@@ -68,7 +71,7 @@ class NarrationMenu : ContextMenu() {
             }
             enableWhen(
                 narrationStateProperty.isEqualTo(NarrationStateType.FINISHED)
-                    .or(narrationStateProperty.isEqualTo(NarrationStateType.HAS_RECORDINGS))
+                    .or(narrationStateProperty.isEqualTo(NarrationStateType.IN_PROGRESS))
             )
         }
 


### PR DESCRIPTION
Allows the verse marker app to be opened when any amount of recording is present

Renamed HasRecordingState to InProgressState

Updated tests to account for name changes

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/1117)
<!-- Reviewable:end -->
