### PR TITLE
Fix for redo edit chapter after restart chapter bug (OT-866)

### DIFF
--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/NarrationActions.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/NarrationActions.kt
@@ -339,6 +339,6 @@ internal class ChapterEditedAction(
         logger.info("Redoing chapter edited action")
 
         totalVerses.clear()
-        totalVerses.addAll(newList)
+        totalVerses.addAll(newList.map { it.copy() })
     }
 }

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/NarrationActions.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/NarrationActions.kt
@@ -325,7 +325,7 @@ internal class ChapterEditedAction(
 
         nodes.addAll(totalVerses)
         totalVerses.clear()
-        totalVerses.addAll(newList)
+        totalVerses.addAll(newList.map { it.copy() })
     }
 
     override fun undo(totalVerses: MutableList<VerseNode>) {


### PR DESCRIPTION
The reason the bug was happening was because when we called `totalVerses.forEach { it.clear() }` in ResetAllAction's execute method ,it was also clearing ChapterEditedAction's newList nodes, since at that point, totalVerses and newList contained the same nodes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/1120)
<!-- Reviewable:end -->
