### PR TITLE
File locking (Windows) when opening empty chapter in ocenaudio

### DIFF
--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/audio/AudioBouncer.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/audio/AudioBouncer.kt
@@ -2,16 +2,14 @@ package org.wycliffeassociates.otter.common.domain.audio
 
 import org.slf4j.LoggerFactory
 import org.wycliffeassociates.otter.common.audio.AudioFileReader
-import org.wycliffeassociates.otter.common.audio.DEFAULT_BITS_PER_SAMPLE
-import org.wycliffeassociates.otter.common.audio.DEFAULT_CHANNELS
-import org.wycliffeassociates.otter.common.audio.DEFAULT_SAMPLE_RATE
 import org.wycliffeassociates.otter.common.audio.wav.WavFile
 import org.wycliffeassociates.otter.common.audio.wav.WavOutputStream
 import org.wycliffeassociates.otter.common.data.audio.AudioMarker
 import java.io.File
 import java.util.concurrent.atomic.AtomicBoolean
+import javax.inject.Inject
 
-class AudioBouncer {
+class AudioBouncer @Inject constructor() {
 
     private val logger = LoggerFactory.getLogger(AudioBouncer::class.java)
 

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/Narration.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/Narration.kt
@@ -53,6 +53,7 @@ class Narration @AssistedInject constructor(
     private val directoryProvider: IDirectoryProvider,
     private val splitAudioOnCues: SplitAudioOnCues,
     private val audioFileUtils: AudioFileUtils,
+    private val audioBouncer: AudioBouncer,
     private val recorder: IAudioRecorder,
     private val player: IAudioPlayer,
     @Assisted private val workbook: Workbook,
@@ -513,7 +514,7 @@ class Narration @AssistedInject constructor(
 
                 // bounce to a temp file to avoid Windows file-locking issue when editing with external app
                 val tempFile = directoryProvider.createTempFile("bounced-${take.name}",".wav")
-                AudioBouncer().bounceAudio(
+                audioBouncer.bounceAudio(
                     tempFile,
                     chapterRepresentation.getAudioFileReader(),
                     activeVerses

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/Narration.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/Narration.kt
@@ -40,7 +40,9 @@ import org.wycliffeassociates.otter.common.data.workbook.Take
 import org.wycliffeassociates.otter.common.data.workbook.Workbook
 import org.wycliffeassociates.otter.common.device.IAudioPlayer
 import org.wycliffeassociates.otter.common.device.IAudioRecorder
+import org.wycliffeassociates.otter.common.domain.audio.AudioBouncer
 import org.wycliffeassociates.otter.common.domain.content.WorkbookFileNamerBuilder
+import org.wycliffeassociates.otter.common.persistence.IDirectoryProvider
 import org.wycliffeassociates.otter.common.recorder.WavFileWriter
 import java.io.File
 import java.time.LocalDate
@@ -48,6 +50,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 
 class Narration @AssistedInject constructor(
+    private val directoryProvider: IDirectoryProvider,
     private val splitAudioOnCues: SplitAudioOnCues,
     private val audioFileUtils: AudioFileUtils,
     private val recorder: IAudioRecorder,
@@ -486,7 +489,7 @@ class Narration @AssistedInject constructor(
      */
     fun createChapterTakeWithAudio(): Single<Take> {
         return chapter.audio.getNewTakeNumber()
-            .flatMap { takeNumber ->
+            .map { takeNumber ->
                 val namer = WorkbookFileNamerBuilder.createFileNamer(
                     workbook,
                     chapter,
@@ -503,18 +506,22 @@ class Narration @AssistedInject constructor(
 
                 chapter.audio.insertTake(take)
 
-                Single.just(take)
+                take
             }
-            .flatMap { take ->
+            .map { take ->
                 takeToModify = take
 
-                NarrationTakeModifier
-                    .modifyAudioDataTask(
-                        take,
-                        chapterRepresentation.getAudioFileReader(),
-                        activeVerses
-                    )
-                    .andThen(Single.just(take))
+                // bounce to a temp file to avoid Windows file-locking issue when editing with external app
+                val tempFile = directoryProvider.createTempFile("bounced-${take.name}",".wav")
+                AudioBouncer().bounceAudio(
+                    tempFile,
+                    chapterRepresentation.getAudioFileReader(),
+                    activeVerses
+                )
+                tempFile.copyTo(take.file, overwrite = true)
+                tempFile.deleteOnExit()
+
+                take
             }
     }
 


### PR DESCRIPTION
It seems that somewhere in the process of bouncing audio caused the file to be held opened by Windows which prevented opening the chapter in ocenaudio.

### Solution: use a temp file to bounce audio and then copy it over to take file

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/1124)
<!-- Reviewable:end -->
