### PR TITLE
Async Init Narration

### DIFF
--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/Narration.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/Narration.kt
@@ -104,15 +104,17 @@ class Narration @AssistedInject constructor(
 
     private var lockedVerseIndex: Int? = null
 
-    private var takeToModify: Take?
+    private var takeToModify: Take? = null
 
     init {
         firstVerse = getFirstVerseMarker()
         restoreFromExistingChapterAudio()
-        chapterRepresentation.loadFromSerializedVerses()
-        disposables.add(resetUncommittedFramesOnUpdatedVerses())
-        loadChapterIntoPlayer()
-        takeToModify = chapter.getSelectedTake()
+            .subscribe {
+                chapterRepresentation.loadFromSerializedVerses()
+                disposables.add(resetUncommittedFramesOnUpdatedVerses())
+                loadChapterIntoPlayer()
+                takeToModify = chapter.getSelectedTake()
+            }
     }
 
     fun startMicrophone() {
@@ -157,9 +159,7 @@ class Narration @AssistedInject constructor(
     }
 
     fun loadFromSelectedChapterFile(): Completable {
-        return Completable.fromAction {
-            restoreFromExistingChapterAudio(true)
-        }
+        return restoreFromExistingChapterAudio(true)
     }
 
 
@@ -468,24 +468,27 @@ class Narration @AssistedInject constructor(
         chapterRepresentation.onVersesUpdated()
     }
 
-    private fun restoreFromExistingChapterAudio(
-        forceUpdate: Boolean = false
-    ) {
-        val chapterFile = chapter.getSelectedTake()?.file
-        val chapterFileExists = chapterFile?.exists() ?: false
+    private fun restoreFromExistingChapterAudio(forceUpdate: Boolean = false): Completable {
+        return Completable
+            .fromAction {
+                val chapterFile = chapter.getSelectedTake()?.file
+                val chapterFileExists = chapterFile?.exists() ?: false
 
-        val narrationEmpty = chapterRepresentation.scratchAudio.totalFrames == 0
-        val narrationFromChapter = chapterFileExists && narrationEmpty
+                val narrationEmpty = chapterRepresentation.scratchAudio.totalFrames == 0
+                val narrationFromChapter = chapterFileExists && narrationEmpty
 
-        if (narrationFromChapter || forceUpdate) {
-            val segments = splitAudioOnCues.execute(chapterFile!!, firstVerse)
-            val verseNodes = createVersesFromVerseSegments(segments)
-            appendVerseSegmentsToScratchAudio(segments)
-            onChapterEdited(verseNodes)
-            if (!forceUpdate) {
-                history.clear()
+                if (narrationFromChapter || forceUpdate) {
+                    val segments = splitAudioOnCues.execute(chapterFile!!, firstVerse)
+                    val verseNodes = createVersesFromVerseSegments(segments)
+                    appendVerseSegmentsToScratchAudio(segments)
+                    onChapterEdited(verseNodes)
+                    if (!forceUpdate) {
+                        history.clear()
+                    }
+                }
             }
-        }
+            .doOnError { logger.error("Error while restoring chapter audio.", it) }
+            .subscribeOn(Schedulers.io())
     }
 
     private fun appendVerseSegmentsToScratchAudio(segments: VerseSegments) {

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/Narration.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/Narration.kt
@@ -108,12 +108,16 @@ class Narration @AssistedInject constructor(
 
     init {
         firstVerse = getFirstVerseMarker()
-        restoreFromExistingChapterAudio()
-            .subscribe {
+    }
+
+    fun initialize(): Completable {
+        return restoreFromExistingChapterAudio()
+            .andThen {
                 chapterRepresentation.loadFromSerializedVerses()
                 disposables.add(resetUncommittedFramesOnUpdatedVerses())
                 loadChapterIntoPlayer()
                 takeToModify = chapter.getSelectedTake()
+                it.onComplete()
             }
     }
 

--- a/jvm/workbookapp/src/integration-test/kotlin/integrationtest/NarrationRenderingTest.kt
+++ b/jvm/workbookapp/src/integration-test/kotlin/integrationtest/NarrationRenderingTest.kt
@@ -64,6 +64,7 @@ class NarrationRenderingTest {
         chapter = mockChapter()
 
         narration = narrationFactory.create(workbookWithAudio, chapter)
+        narration.initialize().blockingAwait()
     }
 
     @Test

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/NarrationPage.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/narration/NarrationPage.kt
@@ -284,7 +284,7 @@ class NarrationPage : View() {
         find<LoadingModal>().apply {
             orientationProperty.set(settingsViewModel.orientationProperty.value)
             themeProperty.set(settingsViewModel.appColorMode.value)
-            messageProperty.set(messages["savingProjectWait"])
+            messageProperty.bind(viewModel.loadingModalTextProperty)
 
             viewModel.openLoadingModalProperty.onChangeWithDisposer {
                 it?.let {


### PR DESCRIPTION
Pushing the execution of `load from existing chapter audio` to a background thread. This commonly happens when importing Ot1 project or migration from Ot1

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/1126)
<!-- Reviewable:end -->
