### PR TITLE
Multiple chapter imports causes distorted take file (OT-870)

### DIFF
--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/Narration.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/Narration.kt
@@ -186,8 +186,8 @@ class Narration @AssistedInject constructor(
 
 
             val verseNodes = createVersesFromVerseSegments(newSegments)
-            onChapterAudioImported(verseNodes)
             appendVerseSegmentsToScratchAudio(newSegments)
+            onChapterAudioImported(verseNodes)
         }
     }
 


### PR DESCRIPTION
Was caused due to trying to bounce audio before appending to scratch audio.

So even though everything looked fine in Narration (and in the pcm file), the take file was distorted.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/1127)
<!-- Reviewable:end -->
