### PR TITLE
Rendering error after edit chapter action with no audio (OT-866 Cont)

### DIFF
--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/Narration.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/Narration.kt
@@ -45,6 +45,7 @@ import org.wycliffeassociates.otter.common.domain.content.WorkbookFileNamerBuild
 import org.wycliffeassociates.otter.common.persistence.IDirectoryProvider
 import org.wycliffeassociates.otter.common.recorder.WavFileWriter
 import java.io.File
+import java.lang.Integer.max
 import java.time.LocalDate
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
@@ -517,7 +518,6 @@ class Narration @AssistedInject constructor(
                 )
             }
 
-
         val scratchAudio = chapterRepresentation.scratchAudio
         var start = if (scratchAudio.totalFrames == 0) 0 else scratchAudio.totalFrames + 1
         var end: Int
@@ -525,7 +525,7 @@ class Narration @AssistedInject constructor(
 
         segments.forEach { (marker, file) ->
             val verseAudio = AudioFile(file)
-            end = start + verseAudio.totalFrames - 1
+            end = max(start + verseAudio.totalFrames - 1, 0)
 
             val node = VerseNode(
                 true,


### PR DESCRIPTION
Opening a blank chapter in OcenAudio then closing OcenAudio without adding any recording caused verseNodes to have sectors with negative end values.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/1134)
<!-- Reviewable:end -->
