### PR TITLE
Fixed translation recording waveform color 

### DIFF
--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/canvas/WaveformLayer.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/canvas/WaveformLayer.kt
@@ -25,11 +25,11 @@ import javafx.scene.canvas.GraphicsContext
 import javafx.scene.paint.Paint
 import org.slf4j.LoggerFactory
 import org.wycliffeassociates.otter.common.data.ColorTheme
+import org.wycliffeassociates.otter.common.data.WAV_COLOR_DARK
+import org.wycliffeassociates.otter.common.data.WAV_COLOR_LIGHT
 import org.wycliffeassociates.otter.common.recorder.ActiveRecordingRenderer
 
 private const val USHORT_SIZE = 65535.0
-const val WAV_COLOR_LIGHT = "#999999"
-const val WAV_COLOR_DARK = "#808080"
 
 class WaveformLayer(
     private val renderer: ActiveRecordingRenderer,


### PR DESCRIPTION
Translation recording waveform color was different than other translation waveform color

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/1154)
<!-- Reviewable:end -->
