### PR TITLE
Tstudio import freeze (OT-899)

### DIFF
--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/project/importer/ExistingSourceImporter.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/project/importer/ExistingSourceImporter.kt
@@ -62,7 +62,6 @@ class ExistingSourceImporter @Inject constructor(
 
         var sameVersion: Boolean
         var sameVersification: Boolean
-
         try {
             ResourceContainer.load(file).use { rc ->
                 sameVersion = (rc.manifest.dublinCore.version == existingSource.version)
@@ -146,6 +145,9 @@ class ExistingSourceImporter @Inject constructor(
             .fromCallable {
                 try {
                     ResourceContainer.load(file).use { rc ->
+                        // Ensures that the existing source creator value stays the same after updating.
+                        rc.manifest.dublinCore.creator = metadata.creator
+
                         val tree = try {
                             IProjectReader.constructContainerTree(rc, zipEntryTreeBuilder)
                         } catch (e: ImportException) {

--- a/jvm/workbookapp/src/integration-test/kotlin/integrationtest/projects/importer/TestExistingSourceImporter.kt
+++ b/jvm/workbookapp/src/integration-test/kotlin/integrationtest/projects/importer/TestExistingSourceImporter.kt
@@ -337,12 +337,19 @@ class TestExistingSourceImporter {
         val oldSource = resourceMetadataRepository.getAllSources().blockingGet().single()
         Assert.assertEquals("Door43 World Missions Community", oldSource.creator)
 
-        // Imports psa 1 narration that was exported as source and has a source.creator equal to Orature
-        importer.import(getSourceFile("resource-containers/en-ulb-psa-source-test.zip"))
+        val base = ResourceContainerBuilder()
+            .setVersion(12)
+            .setTargetLanguage(Language("en", "English", "English", "ltr", false, "Western Europe"))
+            .build()
+        base.manifest.dublinCore.subject = "Bible"
 
-        val newSource = resourceMetadataRepository.getAllSources().blockingGet().single()
+        // Verifies that the new resource source creator is Orature
+        Assert.assertEquals("Orature", base.manifest.dublinCore.creator)
+
+        importer.import(base.file)
 
         // Verifies that the source.creator value was not overwritten
+        val newSource = resourceMetadataRepository.getAllSources().blockingGet().single()
         Assert.assertEquals(oldSource.creator, newSource.creator)
     }
 }


### PR DESCRIPTION
Ensures that the source creator values is not overwritten in cases where we are importing source audio from Orature.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/1162)
<!-- Reviewable:end -->
