### PR TITLE
Exclude non-verse markers when highlighting

### DIFF
--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/media/SourceContent.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/media/SourceContent.kt
@@ -497,7 +497,7 @@ class SourceContent : StackPane() {
 
             highlightedChunk.onChangeAndDoNowWithDisposer { highlightedIndex ->
                 val isHighlighted = highlightedIndex == index
-                toggleClass("source-content__text--highlighted", isHighlighted)
+                togglePseudoClass("highlighted", isHighlighted)
                 if (isHighlighted) {
                     sourceTextChunksContainer.scrollTo(index)
                 }

--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/waveform/IMarkerViewModel.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/waveform/IMarkerViewModel.kt
@@ -21,19 +21,21 @@ package org.wycliffeassociates.otter.jvm.controls.waveform
 import javafx.beans.binding.IntegerBinding
 import javafx.beans.property.SimpleIntegerProperty
 import javafx.collections.ObservableList
-import org.wycliffeassociates.otter.common.data.audio.BookMarker
-import org.wycliffeassociates.otter.common.data.audio.ChapterMarker
+import org.wycliffeassociates.otter.common.data.audio.ChunkMarker
+import org.wycliffeassociates.otter.common.data.audio.VerseMarker
 import org.wycliffeassociates.otter.jvm.controls.controllers.AudioPlayerController
 import org.wycliffeassociates.otter.jvm.controls.controllers.ScrollSpeed
 import org.wycliffeassociates.otter.common.domain.model.MarkerItem
 import org.wycliffeassociates.otter.common.domain.model.MarkerPlacementModel
+
+private val highlightableMarkers = setOf(VerseMarker::class, ChunkMarker::class)
 
 interface IMarkerViewModel : IWaveformViewModel {
     var markerModel: MarkerPlacementModel?
     val markers: ObservableList<MarkerItem>
     val markerCountProperty: IntegerBinding
     var audioController: AudioPlayerController?
-    val currentMarkerNumberProperty: SimpleIntegerProperty
+    val highlightedMarkerIndexProperty: SimpleIntegerProperty
 
     var resumeAfterScroll: Boolean
 
@@ -85,16 +87,16 @@ interface IMarkerViewModel : IWaveformViewModel {
 
     fun seek(location: Int) {
         audioController?.seek(location)
-        updateCurrentPlaybackMarker(location)
+        updateHighlightedIndex(location)
     }
 
-    private fun updateCurrentPlaybackMarker(currentFrame: Int) {
-        val excludedMarkerCount = markers.count { it.marker is BookMarker || it.marker is ChapterMarker }
+    private fun updateHighlightedIndex(currentFrame: Int) {
+        val excludedMarkerCount = markers.count { it.marker::class !in highlightableMarkers }
         markerModel?.let { markerModel ->
             val currentMarkerFrame = markerModel.seekCurrent(currentFrame)
             val currentMarker = markers.find { it.frame == currentMarkerFrame }
             val index = currentMarker?.let { markers.indexOf(it) } ?: 0
-            currentMarkerNumberProperty.set(index - excludedMarkerCount)
+            highlightedMarkerIndexProperty.set(index - excludedMarkerCount)
         }
     }
 
@@ -142,16 +144,16 @@ interface IMarkerViewModel : IWaveformViewModel {
     fun mediaToggle() {
         if (audioController?.isPlayingProperty?.value == false) {
             /* trigger change to auto-scroll when it starts playing */
-            val currentMarkerIndex = currentMarkerNumberProperty.value
-            currentMarkerNumberProperty.set(-1)
-            currentMarkerNumberProperty.set(currentMarkerIndex)
+            val currentMarkerIndex = highlightedMarkerIndexProperty.value
+            highlightedMarkerIndexProperty.set(-1)
+            highlightedMarkerIndexProperty.set(currentMarkerIndex)
         }
         audioController?.toggle()
     }
 
     override fun calculatePosition() {
         super.calculatePosition()
-        updateCurrentPlaybackMarker(audioPositionProperty.value ?: 0)
+        updateHighlightedIndex(audioPositionProperty.value ?: 0)
     }
 
     private fun isPlaying(): Boolean {

--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/waveform/IMarkerViewModel.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/waveform/IMarkerViewModel.kt
@@ -21,6 +21,8 @@ package org.wycliffeassociates.otter.jvm.controls.waveform
 import javafx.beans.binding.IntegerBinding
 import javafx.beans.property.SimpleIntegerProperty
 import javafx.collections.ObservableList
+import org.wycliffeassociates.otter.common.data.audio.BookMarker
+import org.wycliffeassociates.otter.common.data.audio.ChapterMarker
 import org.wycliffeassociates.otter.jvm.controls.controllers.AudioPlayerController
 import org.wycliffeassociates.otter.jvm.controls.controllers.ScrollSpeed
 import org.wycliffeassociates.otter.common.domain.model.MarkerItem
@@ -87,11 +89,12 @@ interface IMarkerViewModel : IWaveformViewModel {
     }
 
     private fun updateCurrentPlaybackMarker(currentFrame: Int) {
+        val excludedMarkerCount = markers.count { it.marker is BookMarker || it.marker is ChapterMarker }
         markerModel?.let { markerModel ->
             val currentMarkerFrame = markerModel.seekCurrent(currentFrame)
             val currentMarker = markers.find { it.frame == currentMarkerFrame }
             val index = currentMarker?.let { markers.indexOf(it) } ?: 0
-            currentMarkerNumberProperty.set(index)
+            currentMarkerNumberProperty.set(index - excludedMarkerCount)
         }
     }
 

--- a/jvm/controls/src/main/resources/css/source-content.css
+++ b/jvm/controls/src/main/resources/css/source-content.css
@@ -107,6 +107,7 @@
     -fx-wrap-text: true;
 }
 
+.source-content__text:highlighted,
 .source-content__chunk:highlighted .label {
     -fx-text-fill: -wa-highlight-text;
 }

--- a/jvm/markerapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/markerapp/app/view/MarkerView.kt
+++ b/jvm/markerapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/markerapp/app/view/MarkerView.kt
@@ -23,7 +23,6 @@ import com.sun.javafx.util.Utils
 import javafx.geometry.Orientation
 import org.wycliffeassociates.otter.jvm.controls.Shortcut
 import org.wycliffeassociates.otter.jvm.controls.event.MarkerMovedEvent
-import org.wycliffeassociates.otter.jvm.controls.event.NavigationRequestBlockedEvent
 import org.wycliffeassociates.otter.jvm.controls.model.pixelsToFrames
 import org.wycliffeassociates.otter.jvm.controls.styles.tryImportStylesheet
 import org.wycliffeassociates.otter.jvm.controls.waveform.AudioSlider
@@ -108,7 +107,7 @@ class MarkerView : PluginEntrypoint() {
         vbox {
             add(
                 SourceTextFragment().apply {
-                    highlightedChunkNumberProperty.bind(viewModel.currentMarkerNumberProperty)
+                    highlightedChunkNumberProperty.bind(viewModel.highlightedMarkerIndexProperty)
                 }
             )
         }

--- a/jvm/markerapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/markerapp/app/viewmodel/VerseMarkerViewModel.kt
+++ b/jvm/markerapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/markerapp/app/viewmodel/VerseMarkerViewModel.kt
@@ -68,7 +68,7 @@ class VerseMarkerViewModel : ViewModel(), IMarkerViewModel {
     lateinit var waveform: Observable<Image>
     val waveformMinimapImage = SimpleObjectProperty<Image>()
 
-    override val currentMarkerNumberProperty = SimpleIntegerProperty(0)
+    override val highlightedMarkerIndexProperty = SimpleIntegerProperty(0)
     override val audioPositionProperty = SimpleIntegerProperty()
     override var markerModel: MarkerPlacementModel? = null
     override val markers = observableListOf<MarkerItem>()
@@ -235,7 +235,7 @@ class VerseMarkerViewModel : ViewModel(), IMarkerViewModel {
         timer?.stop()
         compositeDisposable.clear()
         waveformMinimapImage.set(null)
-        currentMarkerNumberProperty.set(-1)
+        highlightedMarkerIndexProperty.set(-1)
         audioController!!.release()
         audioController = null
         asyncBuilder.cancel()

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ChapterReviewViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ChapterReviewViewModel.kt
@@ -39,7 +39,6 @@ import javafx.scene.paint.Color
 import org.slf4j.LoggerFactory
 import org.wycliffeassociates.otter.common.audio.AudioFileFormat
 import org.wycliffeassociates.otter.common.audio.wav.IWaveFileCreator
-import org.wycliffeassociates.otter.common.data.ColorTheme
 import org.wycliffeassociates.otter.common.data.audio.AudioMarker
 import org.wycliffeassociates.otter.common.data.audio.ChunkMarker
 import org.wycliffeassociates.otter.common.data.audio.VerseMarker
@@ -109,7 +108,7 @@ class ChapterReviewViewModel : ViewModel(), IMarkerViewModel {
     override val markers = observableListOf<MarkerItem>()
 
     override val markerCountProperty = markers.sizeProperty
-    override val currentMarkerNumberProperty = SimpleIntegerProperty(-1)
+    override val highlightedMarkerIndexProperty = SimpleIntegerProperty(-1)
     override var resumeAfterScroll: Boolean = false
 
     override var audioController: AudioPlayerController? = null
@@ -155,7 +154,7 @@ class ChapterReviewViewModel : ViewModel(), IMarkerViewModel {
     fun dock() {
         sourcePlayerProperty.bind(audioDataStore.sourceAudioPlayerProperty)
         workbookDataStore.activeChunkProperty.set(null)
-        translationViewModel.currentMarkerProperty.bind(currentMarkerNumberProperty)
+        translationViewModel.currentMarkerProperty.bind(highlightedMarkerIndexProperty)
 
         Completable
             .fromAction {

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ChunkingViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ChunkingViewModel.kt
@@ -82,7 +82,7 @@ class ChunkingViewModel : ViewModel(), IMarkerViewModel {
     override val markers = observableListOf<MarkerItem>()
 
     override val markerCountProperty = markers.sizeProperty
-    override val currentMarkerNumberProperty = SimpleIntegerProperty(-1)
+    override val highlightedMarkerIndexProperty = SimpleIntegerProperty(-1)
     override var resumeAfterScroll: Boolean = false
 
     override var audioController: AudioPlayerController? = null

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ConsumeViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ConsumeViewModel.kt
@@ -30,7 +30,6 @@ import javafx.beans.property.SimpleIntegerProperty
 import javafx.beans.property.SimpleObjectProperty
 import javafx.scene.image.Image
 import javafx.scene.paint.Color
-import org.wycliffeassociates.otter.common.data.ColorTheme
 import org.wycliffeassociates.otter.common.data.audio.VerseMarker
 import org.wycliffeassociates.otter.common.data.getWaveformColors
 import org.wycliffeassociates.otter.common.device.IAudioPlayer
@@ -70,7 +69,7 @@ class ConsumeViewModel : ViewModel(), IMarkerViewModel {
     override var markerModel: MarkerPlacementModel? = null
     override val markers = observableListOf<MarkerItem>()
     override val markerCountProperty = markers.sizeProperty
-    override val currentMarkerNumberProperty = SimpleIntegerProperty(-1)
+    override val highlightedMarkerIndexProperty = SimpleIntegerProperty(-1)
     override var resumeAfterScroll: Boolean = false
 
     override var audioController: AudioPlayerController? = null
@@ -114,7 +113,7 @@ class ConsumeViewModel : ViewModel(), IMarkerViewModel {
                 loadSourceMarkers(audio)
             }
 
-        translationViewModel.currentMarkerProperty.bind(currentMarkerNumberProperty)
+        translationViewModel.currentMarkerProperty.bind(highlightedMarkerIndexProperty)
     }
 
     fun onUndockConsume() {


### PR DESCRIPTION
Source text are split by line break `\n`, thus it has no information about which marker each text item is associated with.
This PR excludes the Book and Chapter Marker(s) when computing the index to highlight - which only applies to Translation View and Edit Marker View. 

Narration is not affected, since the teleprompter items `NarratableItemModel` contains Chunk and AudioMarker
 
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/1165)
<!-- Reviewable:end -->
