### PR TITLE
Non-sequential sectors fix

### DIFF
--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/ChapterRepresentation.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/ChapterRepresentation.kt
@@ -157,7 +157,7 @@ internal class ChapterRepresentation(
     fun finalizeVerse(verseIndex: Int, history: NarrationHistory? = null): Int {
         val endIndex = frameToIndex(scratchAudio.totalFrames)
 
-        history?.finalizeVerse(endIndex, totalVerses)
+        history?.finalizeVerse(endIndex - 1, totalVerses)
         onVersesUpdated()
         return endIndex - 1 // subtract 1 due to the sector being finalized with `until`
     }

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/ChapterRepresentation.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/ChapterRepresentation.kt
@@ -155,11 +155,11 @@ internal class ChapterRepresentation(
     }
 
     fun finalizeVerse(verseIndex: Int, history: NarrationHistory? = null): Int {
-        val endIndex = frameToIndex(scratchAudio.totalFrames)
+        val endIndex = frameToIndex(scratchAudio.totalFrames) - 1
 
-        history?.finalizeVerse(endIndex - 1, totalVerses)
+        history?.finalizeVerse(endIndex, totalVerses)
         onVersesUpdated()
-        return endIndex - 1 // subtract 1 due to the sector being finalized with `until`
+        return endIndex
     }
 
     fun onVersesUpdated() {
@@ -346,7 +346,7 @@ internal class ChapterRepresentation(
         verses
             .find { it.marker.label == verse.label }
             ?.let { _verse ->
-                return indexToFrame(_verse.firstIndex()) .. indexToFrame(_verse.lastIndex())
+                return indexToFrame(_verse.firstIndex())..indexToFrame(_verse.lastIndex())
             }
         return null
     }

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/Narration.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/Narration.kt
@@ -538,7 +538,7 @@ class Narration @AssistedInject constructor(
             }
 
         val scratchAudio = chapterRepresentation.scratchAudio
-        var start = if (scratchAudio.totalFrames == 0) 0 else scratchAudio.totalFrames + 1
+        var start = if (scratchAudio.totalFrames == 0) 0 else scratchAudio.totalFrames
         var end: Int
         val frameSizeInBytes = chapterRepresentation.frameSizeInBytes
 

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/Narration.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/Narration.kt
@@ -549,10 +549,9 @@ class Narration @AssistedInject constructor(
             val node = VerseNode(
                 true,
                 marker,
-                mutableListOf(start * frameSizeInBytes until end * frameSizeInBytes)
+                mutableListOf(start * frameSizeInBytes..end * frameSizeInBytes + 1)
             )
             nodes.add(node)
-
             start = end + 1
         }
 

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/Narration.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/Narration.kt
@@ -545,15 +545,15 @@ class Narration @AssistedInject constructor(
 
         segments.forEach { (marker, file) ->
             val verseAudio = AudioFile(file)
-            end = max(start + verseAudio.totalFrames - 1, 0)
+            end = max(start + verseAudio.totalFrames, 0)
 
             val node = VerseNode(
                 true,
                 marker,
-                mutableListOf(start * frameSizeInBytes..end * frameSizeInBytes + 1)
+                mutableListOf(start * frameSizeInBytes until end * frameSizeInBytes)
             )
             nodes.add(node)
-            start = end + 1
+            start = end
         }
 
         return nodes.sortedBy { it.marker.sort } // sort order of book-chapter-verse

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/Narration.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/Narration.kt
@@ -310,9 +310,10 @@ class Narration @AssistedInject constructor(
 
         return Completable.fromAction {
             val scratchAudio = chapterRepresentation.scratchAudio
-            val start = if (scratchAudio.totalFrames == 0) 0 else scratchAudio.totalFrames + 1
+            val start = if (scratchAudio.totalFrames == 0) 0 else scratchAudio.totalFrames
             audioFileUtils.appendFile(chapterRepresentation.scratchAudio, editedFile)
-            val end = chapterRepresentation.scratchAudio.totalFrames
+            val verseAudio = AudioFile(editedFile)
+            val end = max(start + verseAudio.totalFrames, 0)
 
             /* When a new verse recorded with an EXTERNAL plugin comes back empty,
             {start} could be greater than {end} by 1, which is invalid and may cause a crash.

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/NarrationActions.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/NarrationActions.kt
@@ -53,7 +53,7 @@ internal class NewVerseAction(
     override fun execute(
         totalVerses: MutableList<VerseNode>, workingAudio: AudioFile
     ) {
-        val start = (if (workingAudio.totalFrames == 0) 0 else workingAudio.totalFrames + 1) * frameSizeInBytes
+        val start = (if (workingAudio.totalFrames == 0) 0 else workingAudio.totalFrames) * frameSizeInBytes
         val end = start
 
         logger.info("New marker added: ${totalVerses[verseIndex].marker.formattedLabel} at $start")

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/NarrationActions.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/NarrationActions.kt
@@ -105,7 +105,7 @@ internal class RecordAgainAction(
         logger.info("Recording again for: ${totalVerses[verseIndex].marker.formattedLabel}")
         previous = totalVerses[verseIndex].copy()
 
-        val start = (if (workingAudio.totalFrames == 0) 0 else workingAudio.totalFrames + 1) * frameSizeInBytes
+        val start = (if (workingAudio.totalFrames == 0) 0 else workingAudio.totalFrames) * frameSizeInBytes
         val end = start
 
         node = VerseNode(

--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/VerseNode.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/narration/VerseNode.kt
@@ -63,7 +63,7 @@ internal data class VerseNode(
         if (sectors.isNotEmpty()) {
             val last = sectors.last()
             sectors.removeLast()
-            sectors.add(last.first until end)
+            sectors.add(last.first..end)
         } else {
             throw IllegalStateException("Tried to finalize VerseNode ${marker.label} that was not started!")
         }

--- a/common/src/test/kotlin/org/wycliffeassociates/otter/common/domain/narration/NewVerseActionTest.kt
+++ b/common/src/test/kotlin/org/wycliffeassociates/otter/common/domain/narration/NewVerseActionTest.kt
@@ -49,8 +49,8 @@ class NewVerseActionTest {
     }
 
     fun initializeTotalVerses() {
-        for(i in 0 until numTestVerses){
-            val verseMarker = VerseMarker((i+1), (i+1), 0)
+        for (i in 0 until numTestVerses) {
+            val verseMarker = VerseMarker((i + 1), (i + 1), 0)
             val sectors = mutableListOf<IntRange>()
             val verseNode = VerseNode(false, verseMarker, sectors)
             totalVerses.add(verseNode)
@@ -95,7 +95,8 @@ class NewVerseActionTest {
         newVerseAction.execute(totalVerses, workingAudioFile)
 
         // verify that NewVerseAction.node is valid
-        val expectedIndexRange = (totalFramesInTestAudio + 1) * frameSizeInBytes..(totalFramesInTestAudio + 1) * frameSizeInBytes
+        val expectedIndexRange =
+            (totalFramesInTestAudio) * frameSizeInBytes..(totalFramesInTestAudio) * frameSizeInBytes
         Assert.assertEquals(expectedIndexRange, newVerseAction.node?.sectors?.last())
         Assert.assertEquals(true, newVerseAction?.node?.placed)
 
@@ -112,7 +113,7 @@ class NewVerseActionTest {
         try {
             newVerseAction.undo(totalVerses)
             Assert.fail("expecting IndexOutOfBoundsException")
-        } catch (illegalIndex: IndexOutOfBoundsException){
+        } catch (illegalIndex: IndexOutOfBoundsException) {
             // Success: expecting IndexOutOfBoundsException
         }
     }

--- a/common/src/test/kotlin/org/wycliffeassociates/otter/common/domain/narration/RecordAgainActionTest.kt
+++ b/common/src/test/kotlin/org/wycliffeassociates/otter/common/domain/narration/RecordAgainActionTest.kt
@@ -47,8 +47,8 @@ class RecordAgainActionTest {
     }
 
     fun initializeTotalVerses() {
-        for(i in 0 until numTestVerses){
-            val verseMarker = VerseMarker((i+1), (i+1), 0)
+        for (i in 0 until numTestVerses) {
+            val verseMarker = VerseMarker((i + 1), (i + 1), 0)
             val sectors = mutableListOf<IntRange>()
             val verseNode = VerseNode(false, verseMarker, sectors)
             totalVerses.add(verseNode)
@@ -74,7 +74,7 @@ class RecordAgainActionTest {
         recordAgainAction.execute(totalVerses, workingAudioFile)
 
         // verify that RecordAgainAction.node is valid
-        val expectedEnd = workingAudioFile.totalFrames + 1
+        val expectedEnd = workingAudioFile.totalFrames
         Assert.assertEquals(
             expectedEnd * frameSizeInBytes..expectedEnd * frameSizeInBytes,
             recordAgainAction.node?.sectors?.last()
@@ -112,7 +112,7 @@ class RecordAgainActionTest {
         recordAgainAction.execute(totalVerses, workingAudioFile)
 
         // verify that RecordAgainAction.node is valid
-        val expectedEnd = workingAudioFile.totalFrames + 1
+        val expectedEnd = workingAudioFile.totalFrames
         Assert.assertEquals(
             expectedEnd * frameSizeInBytes..expectedEnd * frameSizeInBytes,
             recordAgainAction.node?.sectors?.last()
@@ -140,7 +140,7 @@ class RecordAgainActionTest {
         try {
             recordAgainAction.execute(totalVerses, workingAudioFile)
             Assert.fail("expecting IndexOutOfBoundsException")
-        } catch (illegalIndex: IndexOutOfBoundsException){
+        } catch (illegalIndex: IndexOutOfBoundsException) {
             // Success: expecting IndexOutOfBoundsException
         }
     }
@@ -172,7 +172,7 @@ class RecordAgainActionTest {
         recordAgainAction.execute(totalVerses, workingAudioFile)
 
         // verify that totalVerses[verseIndex] is valid
-        val expectedEnd = workingAudioFile.totalFrames + 1
+        val expectedEnd = workingAudioFile.totalFrames
         Assert.assertEquals(
             expectedEnd * frameSizeInBytes..expectedEnd * frameSizeInBytes,
             totalVerses[verseIndex].sectors.last()
@@ -198,7 +198,7 @@ class RecordAgainActionTest {
         recordAgainAction.execute(totalVerses, workingAudioFile)
 
         // verify that totalVerses[verseIndex] is valid
-        val expectedEnd = workingAudioFile.totalFrames + 1
+        val expectedEnd = workingAudioFile.totalFrames
         Assert.assertEquals(
             expectedEnd * frameSizeInBytes..expectedEnd * frameSizeInBytes,
             totalVerses[verseIndex].sectors.last()
@@ -215,8 +215,7 @@ class RecordAgainActionTest {
 
         // verify that totalVerses[verseIndex] is redone
         Assert.assertEquals(
-            expectedEnd * frameSizeInBytes..expectedEnd * frameSizeInBytes
-            , totalVerses[verseIndex].sectors.last()
+            expectedEnd * frameSizeInBytes..expectedEnd * frameSizeInBytes, totalVerses[verseIndex].sectors.last()
         )
         Assert.assertTrue(totalVerses[verseIndex].placed)
     }
@@ -251,7 +250,7 @@ class RecordAgainActionTest {
         recordAgainAction.execute(totalVerses, workingAudioFile)
 
         // Verify that totalVerse[verseIndex] has been updated
-        val expectedEnd = workingAudioFile.totalFrames + 1
+        val expectedEnd = workingAudioFile.totalFrames
         Assert.assertEquals(
             expectedEnd * frameSizeInBytes..expectedEnd * frameSizeInBytes,
             totalVerses[verseIndex].sectors.last()
@@ -262,7 +261,7 @@ class RecordAgainActionTest {
 
         // Verify that totalVerse[verseIndex] has been finalized
         Assert.assertEquals(
-            expectedEnd * frameSizeInBytes .. 882000 * frameSizeInBytes,
+            expectedEnd * frameSizeInBytes..882000 * frameSizeInBytes,
             totalVerses[verseIndex].sectors.last()
         )
         Assert.assertTrue(previousNode.placed)

--- a/common/src/test/kotlin/org/wycliffeassociates/otter/common/domain/narration/VerseNodeTest.kt
+++ b/common/src/test/kotlin/org/wycliffeassociates/otter/common/domain/narration/VerseNodeTest.kt
@@ -49,9 +49,9 @@ class VerseNodeTest {
     fun `length of multiple sectors`() {
         val verseMarker = VerseMarker(1, 1, 0)
         val sectors = mutableListOf<IntRange>()
-        sectors.add(IntRange(0,999))
-        sectors.add(IntRange(1000,1999))
-        sectors.add(IntRange(2000,2999))
+        sectors.add(IntRange(0, 999))
+        sectors.add(IntRange(1000, 1999))
+        sectors.add(IntRange(2000, 2999))
 
         val verseNode = VerseNode(true, verseMarker, sectors)
 
@@ -72,7 +72,7 @@ class VerseNodeTest {
     fun `first frame one sector`() {
         val verseMarker = VerseMarker(1, 1, 0)
         val sectors = mutableListOf<IntRange>()
-        sectors.add(IntRange(1000,1999))
+        sectors.add(IntRange(1000, 1999))
 
         val verseNode = VerseNode(true, verseMarker, sectors)
 
@@ -83,8 +83,8 @@ class VerseNodeTest {
     fun `first frame two sectors out of order`() {
         val verseMarker = VerseMarker(1, 1, 0)
         val sectors = mutableListOf<IntRange>()
-        sectors.add(IntRange(3000,3999))
-        sectors.add(IntRange(1000,1999))
+        sectors.add(IntRange(3000, 3999))
+        sectors.add(IntRange(1000, 1999))
 
         val verseNode = VerseNode(true, verseMarker, sectors)
 
@@ -105,7 +105,7 @@ class VerseNodeTest {
     fun `last frame one sector`() {
         val verseMarker = VerseMarker(1, 1, 0)
         val sectors = mutableListOf<IntRange>()
-        sectors.add(IntRange(2000,2999))
+        sectors.add(IntRange(2000, 2999))
 
         val verseNode = VerseNode(true, verseMarker, sectors)
 
@@ -116,8 +116,8 @@ class VerseNodeTest {
     fun `last frame two sectors out of order`() {
         val verseMarker = VerseMarker(1, 1, 0)
         val sectors = mutableListOf<IntRange>()
-        sectors.add(IntRange(3000,3999))
-        sectors.add(IntRange(1000,1999))
+        sectors.add(IntRange(3000, 3999))
+        sectors.add(IntRange(1000, 1999))
 
         val verseNode = VerseNode(true, verseMarker, sectors)
 
@@ -181,12 +181,12 @@ class VerseNodeTest {
     fun `finalize last equals UNPLACED_END`() {
         val verseMarker = VerseMarker(1, 1, 0)
         val sectors = mutableListOf<IntRange>()
-        sectors.add(0.. -1)
+        sectors.add(0..-1)
         val verseNode = VerseNode(true, verseMarker, sectors)
 
         try {
             verseNode.finalize(500)
-            Assert.assertEquals(0 until 500, sectors.last())
+            Assert.assertEquals(0..500, sectors.last())
         } catch (ise: IllegalStateException) {
             Assert.fail("Not expecting illegal state exception")
         }
@@ -196,19 +196,20 @@ class VerseNodeTest {
     fun `finalize last equals first`() {
         val verseMarker = VerseMarker(1, 1, 0)
         val sectors = mutableListOf<IntRange>()
-        sectors.add(1000.. 1000)
+        sectors.add(1000..1000)
         val verseNode = VerseNode(true, verseMarker, sectors)
 
         try {
             verseNode.finalize(2000)
-            Assert.assertEquals(1000..1999, sectors.last())
+            Assert.assertEquals(1000..2000, sectors.last())
         } catch (ise: IllegalStateException) {
             Assert.fail("Not expecting illegal state exception")
         }
     }
 
 
-    @Test fun `take frames from start with no sectors`() {
+    @Test
+    fun `take frames from start with no sectors`() {
         val verseMarker = VerseMarker(1, 1, 0)
         val sectors = mutableListOf<IntRange>()
         val verseNode = VerseNode(true, verseMarker, sectors)
@@ -224,97 +225,101 @@ class VerseNodeTest {
     }
 
 
-    @Test fun `take frames from start with less frames than needed`() {
+    @Test
+    fun `take frames from start with less frames than needed`() {
         val verseMarker = VerseMarker(1, 1, 0)
         val sectors = mutableListOf<IntRange>()
-        sectors.add(1000.. 1999)
+        sectors.add(1000..1999)
 
         val verseNode = VerseNode(true, verseMarker, sectors)
 
         val sectorsTaken = verseNode.takeIndicesFromStart(2000)
 
         Assert.assertEquals(1, sectorsTaken.size)
-        Assert.assertEquals(1000 .. 1998, sectorsTaken[0])
+        Assert.assertEquals(1000..1998, sectorsTaken[0])
 
         Assert.assertEquals(1, verseNode.sectors.size)
-        Assert.assertEquals(1999 .. 1999, verseNode.sectors[0])
+        Assert.assertEquals(1999..1999, verseNode.sectors[0])
     }
 
 
-    @Test fun `take frames from start with same number of frames needed`() {
+    @Test
+    fun `take frames from start with same number of frames needed`() {
         val verseMarker = VerseMarker(1, 1, 0)
         val sectors = mutableListOf<IntRange>()
-        sectors.add(1000.. 1999)
-        sectors.add(2000 .. 2999)
-        sectors.add(3000 .. 3999)
+        sectors.add(1000..1999)
+        sectors.add(2000..2999)
+        sectors.add(3000..3999)
         val verseNode = VerseNode(true, verseMarker, sectors)
 
         val sectorsTaken = verseNode.takeIndicesFromStart(3000)
 
         val expectedSectorsTaken = mutableListOf<IntRange>()
-        expectedSectorsTaken.add(1000.. 1999)
-        expectedSectorsTaken.add(2000 .. 2999)
-        expectedSectorsTaken.add(3000 .. 3998)
+        expectedSectorsTaken.add(1000..1999)
+        expectedSectorsTaken.add(2000..2999)
+        expectedSectorsTaken.add(3000..3998)
 
         Assert.assertTrue(sectorsTaken.equals(expectedSectorsTaken))
         Assert.assertEquals(1, verseNode.sectors.size)
 
         Assert.assertEquals(1, verseNode.sectors.size)
-        Assert.assertEquals(3999 .. 3999, verseNode.sectors[0])
+        Assert.assertEquals(3999..3999, verseNode.sectors[0])
 
     }
 
 
-
-    @Test fun `take frames from start with more frames than needed and without splitting a node`() {
+    @Test
+    fun `take frames from start with more frames than needed and without splitting a node`() {
 
         val verseMarker = VerseMarker(1, 1, 0)
         val sectors = mutableListOf<IntRange>()
-        sectors.add(1000.. 1999)
-        sectors.add(2000 .. 2999)
-        sectors.add(3000 .. 3999)
+        sectors.add(1000..1999)
+        sectors.add(2000..2999)
+        sectors.add(3000..3999)
         val verseNode = VerseNode(true, verseMarker, sectors)
 
         val sectorsTaken = verseNode.takeIndicesFromStart(2000)
 
         val expectedSectorsTaken = mutableListOf<IntRange>()
-        expectedSectorsTaken.add(1000.. 1999)
-        expectedSectorsTaken.add(2000 .. 2999)
+        expectedSectorsTaken.add(1000..1999)
+        expectedSectorsTaken.add(2000..2999)
 
         Assert.assertTrue(sectorsTaken.equals(expectedSectorsTaken))
 
         val expectedVerseNodeSectors = mutableListOf<IntRange>()
-        expectedVerseNodeSectors.add(3000 .. 3999)
+        expectedVerseNodeSectors.add(3000..3999)
 
         Assert.assertTrue(verseNode.sectors.equals(expectedVerseNodeSectors))
     }
 
-    @Test fun `take frames from start with more frames than needed and with splitting a node`() {
+    @Test
+    fun `take frames from start with more frames than needed and with splitting a node`() {
 
         val verseMarker = VerseMarker(1, 1, 0)
         val sectors = mutableListOf<IntRange>()
-        sectors.add(1000.. 1999)
-        sectors.add(2000 .. 2999)
-        sectors.add(3000 .. 3999)
+        sectors.add(1000..1999)
+        sectors.add(2000..2999)
+        sectors.add(3000..3999)
         val verseNode = VerseNode(true, verseMarker, sectors)
 
         val sectorsTaken = verseNode.takeIndicesFromStart(2500)
 
         val expectedSectorsTaken = mutableListOf<IntRange>()
-        expectedSectorsTaken.add(1000.. 1999)
-        expectedSectorsTaken.add(2000 .. 2999)
-        expectedSectorsTaken.add(3000 .. 3499)
+        expectedSectorsTaken.add(1000..1999)
+        expectedSectorsTaken.add(2000..2999)
+        expectedSectorsTaken.add(3000..3499)
 
         Assert.assertTrue(sectorsTaken.equals(expectedSectorsTaken))
 
         val expectedVerseNodeSectors = mutableListOf<IntRange>()
-        expectedVerseNodeSectors.add(3500 .. 3999)
+        expectedVerseNodeSectors.add(3500..3999)
 
         Assert.assertTrue(verseNode.sectors.equals(expectedVerseNodeSectors))
     }
 
 
-    @Test fun `take frames from end with no sectors`() {
+    @Test
+    fun `take frames from end with no sectors`() {
         val verseMarker = VerseMarker(1, 1, 0)
         val sectors = mutableListOf<IntRange>()
         val verseNode = VerseNode(true, verseMarker, sectors)
@@ -328,87 +333,91 @@ class VerseNodeTest {
         }
     }
 
-    @Test fun `take frames from end with less frames than needed`() {
+    @Test
+    fun `take frames from end with less frames than needed`() {
         val verseMarker = VerseMarker(1, 1, 0)
         val sectors = mutableListOf<IntRange>()
-        sectors.add(1000.. 1999)
+        sectors.add(1000..1999)
         val verseNode = VerseNode(true, verseMarker, sectors)
 
         val sectorsTaken = verseNode.takeIndicesFromEnd(2000)
 
         Assert.assertEquals(1, sectorsTaken.size)
-        Assert.assertEquals(1001 .. 1999, sectorsTaken[0])
+        Assert.assertEquals(1001..1999, sectorsTaken[0])
 
         Assert.assertEquals(1, verseNode.sectors.size)
-        Assert.assertEquals(1000 .. 1000, verseNode.sectors[0])
+        Assert.assertEquals(1000..1000, verseNode.sectors[0])
     }
 
-    @Test fun `take frames from end with same number of frames needed`() {
+    @Test
+    fun `take frames from end with same number of frames needed`() {
         val verseMarker = VerseMarker(1, 1, 0)
         val sectors = mutableListOf<IntRange>()
-        sectors.add(1000.. 1999)
-        sectors.add(2000 .. 2999)
-        sectors.add(3000 .. 3999)
+        sectors.add(1000..1999)
+        sectors.add(2000..2999)
+        sectors.add(3000..3999)
         val verseNode = VerseNode(true, verseMarker, sectors)
 
         val sectorsTaken = verseNode.takeIndicesFromEnd(3000)
 
         val expectedSectorsTaken = mutableListOf<IntRange>()
-        expectedSectorsTaken.add(1001.. 1999)
-        expectedSectorsTaken.add(2000 .. 2999)
-        expectedSectorsTaken.add(3000 .. 3999)
+        expectedSectorsTaken.add(1001..1999)
+        expectedSectorsTaken.add(2000..2999)
+        expectedSectorsTaken.add(3000..3999)
 
         Assert.assertTrue(sectorsTaken.equals(expectedSectorsTaken))
 
         Assert.assertEquals(1, verseNode.sectors.size)
-        Assert.assertEquals(1000 .. 1000, verseNode.sectors[0])
+        Assert.assertEquals(1000..1000, verseNode.sectors[0])
     }
 
 
-    @Test fun `take frames from end with more frames than needed and without splitting a node`() {
+    @Test
+    fun `take frames from end with more frames than needed and without splitting a node`() {
 
         val verseMarker = VerseMarker(1, 1, 0)
         val sectors = mutableListOf<IntRange>()
-        sectors.add(1000.. 1999)
-        sectors.add(2000 .. 2999)
-        sectors.add(3000 .. 3999)
+        sectors.add(1000..1999)
+        sectors.add(2000..2999)
+        sectors.add(3000..3999)
         val verseNode = VerseNode(true, verseMarker, sectors)
 
         val sectorsTaken = verseNode.takeIndicesFromEnd(2000)
 
         val expectedSectorsTaken = mutableListOf<IntRange>()
-        expectedSectorsTaken.add(2000 .. 2999)
-        expectedSectorsTaken.add(3000 .. 3999)
+        expectedSectorsTaken.add(2000..2999)
+        expectedSectorsTaken.add(3000..3999)
 
         Assert.assertTrue(sectorsTaken.equals(expectedSectorsTaken))
 
         val expectedVerseNodeSectors = mutableListOf<IntRange>()
-        expectedVerseNodeSectors.add(1000.. 1999)
+        expectedVerseNodeSectors.add(1000..1999)
 
         Assert.assertTrue(verseNode.sectors.equals(expectedVerseNodeSectors))
 
     }
 
-    @Test fun `take frames from end with more frames than needed and with splitting a node`() {
+    @Test
+    fun `take frames from end with more frames than needed and with splitting a node`() {
 
         val verseMarker = VerseMarker(1, 1, 0)
         val sectors = mutableListOf<IntRange>()
-        sectors.add(1000.. 1999)
-        sectors.add(2000 .. 2999)
-        sectors.add(3000 .. 3999)
+        sectors.add(1000..1999)
+        sectors.add(2000..2999)
+        sectors.add(3000..3999)
         val verseNode = VerseNode(true, verseMarker, sectors)
 
         val sectorsTaken = verseNode.takeIndicesFromEnd(2500)
 
         val expectedSectorsTaken = mutableListOf<IntRange>()
-        expectedSectorsTaken.add(1500 .. 1999)
-        expectedSectorsTaken.add(2000 .. 2999)
-        expectedSectorsTaken.add(3000 .. 3999)
+        expectedSectorsTaken.add(1500..1999)
+        expectedSectorsTaken.add(2000..2999)
+        expectedSectorsTaken.add(3000..3999)
 
         Assert.assertTrue(sectorsTaken.equals(expectedSectorsTaken))
 
         val expectedVerseNodeSectors = mutableListOf<IntRange>()
-        expectedVerseNodeSectors.add(1000.. 1499)
+        expectedVerseNodeSectors.add(1000..1499)
 
         Assert.assertTrue(verseNode.sectors.equals(expectedVerseNodeSectors))
 
@@ -421,7 +430,7 @@ class VerseNodeTest {
         val sectors = mutableListOf<IntRange>()
         val verseNode = VerseNode(true, verseMarker, sectors)
 
-        val emptyList:  List<IntRange> = emptyList()
+        val emptyList: List<IntRange> = emptyList()
 
         verseNode.addRange(emptyList)
 
@@ -434,7 +443,7 @@ class VerseNodeTest {
         val sectors = mutableListOf<IntRange>()
         val verseNode = VerseNode(true, verseMarker, sectors)
 
-        val oneItemList = List(1) {1000..1999}
+        val oneItemList = List(1) { 1000..1999 }
 
         verseNode.addRange(oneItemList)
 
@@ -450,9 +459,9 @@ class VerseNodeTest {
         val verseNode = VerseNode(true, verseMarker, sectors)
 
         val ranges = mutableListOf<IntRange>()
-        ranges.add(1000 .. 1999)
-        ranges.add(2000 .. 2999)
-        ranges.add(3000 .. 3999)
+        ranges.add(1000..1999)
+        ranges.add(2000..2999)
+        ranges.add(3000..3999)
 
         verseNode.addRange(ranges)
 
@@ -468,9 +477,9 @@ class VerseNodeTest {
         val verseNode = VerseNode(true, verseMarker, sectors)
 
         val ranges = mutableListOf<IntRange>()
-        ranges.add(1000 .. 1999)
-        ranges.add(1999 .. 2999)
-        ranges.add(3000 .. 3999)
+        ranges.add(1000..1999)
+        ranges.add(1999..2999)
+        ranges.add(3000..3999)
 
         verseNode.addRange(ranges)
         Assert.assertTrue(verseNode.sectors.equals(ranges))
@@ -484,9 +493,9 @@ class VerseNodeTest {
         val verseNode = VerseNode(true, verseMarker, sectors)
 
         val ranges = mutableListOf<IntRange>()
-        ranges.add(1999 .. 2999)
-        ranges.add(1000 .. 1999)
-        ranges.add(3000 .. 3999)
+        ranges.add(1999..2999)
+        ranges.add(1000..1999)
+        ranges.add(3000..3999)
 
         verseNode.addRange(ranges)
         Assert.assertTrue(verseNode.sectors.equals(ranges))
@@ -511,8 +520,8 @@ class VerseNodeTest {
     fun `clear with multiple sectors and placed equal to true`() {
         val verseMarker = VerseMarker(1, 1, 0)
         val sectors = mutableListOf<IntRange>()
-        sectors.add(1000.. 1999)
-        sectors.add(6000.. 6999)
+        sectors.add(1000..1999)
+        sectors.add(6000..6999)
         val verseNode = VerseNode(true, verseMarker, sectors)
 
         Assert.assertEquals(2, verseNode.sectors.size)
@@ -538,7 +547,7 @@ class VerseNodeTest {
     fun `contains with one sector without frame`() {
         val verseMarker = VerseMarker(1, 1, 0)
         val sectors = mutableListOf<IntRange>()
-        sectors.add(6000.. 6999)
+        sectors.add(6000..6999)
         val verseNode = VerseNode(true, verseMarker, sectors)
 
         Assert.assertFalse(verseNode.contains(500))
@@ -548,7 +557,7 @@ class VerseNodeTest {
     fun `contains with one sector with frame`() {
         val verseMarker = VerseMarker(1, 1, 0)
         val sectors = mutableListOf<IntRange>()
-        sectors.add(6000.. 6999)
+        sectors.add(6000..6999)
         val verseNode = VerseNode(true, verseMarker, sectors)
 
         Assert.assertTrue(verseNode.contains(6250))
@@ -558,9 +567,9 @@ class VerseNodeTest {
     fun `contains with multiple sectors without frame`() {
         val verseMarker = VerseMarker(1, 1, 0)
         val sectors = mutableListOf<IntRange>()
-        sectors.add(3000.. 3999)
-        sectors.add(2000.. 2999)
-        sectors.add(6000.. 6999)
+        sectors.add(3000..3999)
+        sectors.add(2000..2999)
+        sectors.add(6000..6999)
         val verseNode = VerseNode(true, verseMarker, sectors)
 
         Assert.assertFalse(verseNode.contains(500))
@@ -570,9 +579,9 @@ class VerseNodeTest {
     fun `contains with multiple sectors with frame`() {
         val verseMarker = VerseMarker(1, 1, 0)
         val sectors = mutableListOf<IntRange>()
-        sectors.add(3000.. 3999)
-        sectors.add(2000.. 2999)
-        sectors.add(6000.. 6999)
+        sectors.add(3000..3999)
+        sectors.add(2000..2999)
+        sectors.add(6000..6999)
         val verseNode = VerseNode(true, verseMarker, sectors)
 
         Assert.assertTrue(verseNode.contains(6250))
@@ -583,9 +592,9 @@ class VerseNodeTest {
     fun `frames to position with absolute frame out of bounds`() {
         val verseMarker = VerseMarker(1, 1, 0)
         val sectors = mutableListOf<IntRange>()
-        sectors.add(3000.. 3999)
-        sectors.add(2000.. 2999)
-        sectors.add(6000.. 6999)
+        sectors.add(3000..3999)
+        sectors.add(2000..2999)
+        sectors.add(6000..6999)
         val verseNode = VerseNode(true, verseMarker, sectors)
 
 
@@ -601,9 +610,9 @@ class VerseNodeTest {
     fun `frames to position with absolute frame in first sector`() {
         val verseMarker = VerseMarker(1, 1, 0)
         val sectors = mutableListOf<IntRange>()
-        sectors.add(2000.. 2999)
-        sectors.add(3000.. 3999)
-        sectors.add(6000.. 6999)
+        sectors.add(2000..2999)
+        sectors.add(3000..3999)
+        sectors.add(6000..6999)
         val verseNode = VerseNode(true, verseMarker, sectors)
 
 
@@ -619,9 +628,9 @@ class VerseNodeTest {
     fun `frames to position with absolute frame in last sector`() {
         val verseMarker = VerseMarker(1, 1, 0)
         val sectors = mutableListOf<IntRange>()
-        sectors.add(2000.. 2999)
-        sectors.add(3000.. 3999)
-        sectors.add(6000.. 6999)
+        sectors.add(2000..2999)
+        sectors.add(3000..3999)
+        sectors.add(6000..6999)
         val verseNode = VerseNode(true, verseMarker, sectors)
 
 
@@ -647,9 +656,9 @@ class VerseNodeTest {
     fun `get sectors from offset with negative ftr and does not contains frame position`() {
         val verseMarker = VerseMarker(1, 1, 0)
         val sectors = mutableListOf<IntRange>()
-        sectors.add(1000.. 1999)
-        sectors.add(5000.. 5999)
-        sectors.add(8000.. 8999)
+        sectors.add(1000..1999)
+        sectors.add(5000..5999)
+        sectors.add(8000..8999)
 
         val verseNode = VerseNode(true, verseMarker, sectors)
 
@@ -661,9 +670,9 @@ class VerseNodeTest {
     fun `get sectors from offset positive ftr and does not contain frame position`() {
         val verseMarker = VerseMarker(1, 1, 0)
         val sectors = mutableListOf<IntRange>()
-        sectors.add(1000.. 1999)
-        sectors.add(5000.. 5999)
-        sectors.add(8000.. 8999)
+        sectors.add(1000..1999)
+        sectors.add(5000..5999)
+        sectors.add(8000..8999)
 
         val verseNode = VerseNode(true, verseMarker, sectors)
 
@@ -676,15 +685,15 @@ class VerseNodeTest {
     fun `get sectors from offset with framePosition equal to first sector's start and ftr less than first sector's end`() {
         val verseMarker = VerseMarker(1, 1, 0)
         val sectors = mutableListOf<IntRange>()
-        sectors.add(1000.. 1999)
-        sectors.add(5000.. 5999)
-        sectors.add(8000.. 8999)
+        sectors.add(1000..1999)
+        sectors.add(5000..5999)
+        sectors.add(8000..8999)
 
         val verseNode = VerseNode(true, verseMarker, sectors)
 
         val sectorsFromOffset = verseNode.getSectorsFromOffset(1000, 300)
         Assert.assertEquals(1, sectorsFromOffset.size)
-        Assert.assertEquals(1000 .. 1299, sectorsFromOffset.first())
+        Assert.assertEquals(1000..1299, sectorsFromOffset.first())
 
     }
 
@@ -692,33 +701,33 @@ class VerseNodeTest {
     fun `get sectors from offset with framePosition equal to first sector's start and ftr greater than first sector's end`() {
         val verseMarker = VerseMarker(1, 1, 0)
         val sectors = mutableListOf<IntRange>()
-        sectors.add(1000.. 1999)
-        sectors.add(5000.. 5999)
-        sectors.add(8000.. 8999)
+        sectors.add(1000..1999)
+        sectors.add(5000..5999)
+        sectors.add(8000..8999)
 
         val verseNode = VerseNode(true, verseMarker, sectors)
 
         val sectorsFromOffset = verseNode.getSectorsFromOffset(1000, 1300)
         Assert.assertEquals(2, sectorsFromOffset.size)
-        Assert.assertEquals(1000 .. 1999, sectorsFromOffset[0])
-        Assert.assertEquals(5000 .. 5299, sectorsFromOffset[1])
+        Assert.assertEquals(1000..1999, sectorsFromOffset[0])
+        Assert.assertEquals(5000..5299, sectorsFromOffset[1])
     }
 
     @Test
     fun `get sectors from offset with framePosition equal to first sector's start and ftr greater than sector's length`() {
         val verseMarker = VerseMarker(1, 1, 0)
         val sectors = mutableListOf<IntRange>()
-        sectors.add(1000.. 1999)
-        sectors.add(5000.. 5999)
-        sectors.add(8000.. 8999)
+        sectors.add(1000..1999)
+        sectors.add(5000..5999)
+        sectors.add(8000..8999)
 
         val verseNode = VerseNode(true, verseMarker, sectors)
 
         val sectorsFromOffset = verseNode.getSectorsFromOffset(1000, 4000)
         Assert.assertEquals(3, sectorsFromOffset.size)
-        Assert.assertEquals(1000 .. 1999, sectorsFromOffset[0])
-        Assert.assertEquals(5000 .. 5999, sectorsFromOffset[1])
-        Assert.assertEquals(8000 .. 8999, sectorsFromOffset[2])
+        Assert.assertEquals(1000..1999, sectorsFromOffset[0])
+        Assert.assertEquals(5000..5999, sectorsFromOffset[1])
+        Assert.assertEquals(8000..8999, sectorsFromOffset[2])
     }
 
 
@@ -726,16 +735,16 @@ class VerseNodeTest {
     fun `get sectors from offset with framePosition not equal to first sector's start and ftr less than sector's length`() {
         val verseMarker = VerseMarker(1, 1, 0)
         val sectors = mutableListOf<IntRange>()
-        sectors.add(1000.. 1999)
-        sectors.add(5000.. 5999)
-        sectors.add(8000.. 8999)
+        sectors.add(1000..1999)
+        sectors.add(5000..5999)
+        sectors.add(8000..8999)
 
         val verseNode = VerseNode(true, verseMarker, sectors)
 
         val sectorsFromOffset = verseNode.getSectorsFromOffset(1500, 1000)
         Assert.assertEquals(2, sectorsFromOffset.size)
-        Assert.assertEquals(1500 .. 1999, sectorsFromOffset[0])
-        Assert.assertEquals(5000 .. 5499, sectorsFromOffset[1])
+        Assert.assertEquals(1500..1999, sectorsFromOffset[0])
+        Assert.assertEquals(5000..5499, sectorsFromOffset[1])
     }
 }
 


### PR DESCRIPTION
Ensures that VerseNode sectors have correct start/end values and do not have "dead space" between them. 


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/1175)
<!-- Reviewable:end -->
