### PR TITLE
Language Table shortcut fix (OT-893)

### DIFF
--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/tableview/LanguageTableRow.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/components/tableview/LanguageTableRow.kt
@@ -37,7 +37,7 @@ class LanguageTableRow(
 
         isDisable = item in unavailableLanguages
         isMouseTransparent = isDisable
-        isFocusTraversable = !isDisable
+        isFocusTraversable = false
 
         setOnMouseClicked {
             if (it.clickCount == 1) { // avoid double fire()


### PR DESCRIPTION
Sets isFocusTraversable to false like WorkbookTableRow.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/1178)
<!-- Reviewable:end -->
