### PR TITLE
Hot-fix: Backup with source audio from Narration

### DIFF
--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/project/ProjectFilesAccessor.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/project/ProjectFilesAccessor.kt
@@ -677,8 +677,10 @@ class ProjectFilesAccessor(
         ResourceContainer.load(source).use {
             val inMap = it.accessor.getInputStreams(".", listOf())
                 .filterKeys { path ->
-                    if (path.contains("${RcConstants.SOURCE_MEDIA_DIR}/")) {
-                        path.contains("${RcConstants.SOURCE_MEDIA_DIR}/${project.slug}")
+                    val sourceAudioDir = "${RcConstants.SOURCE_MEDIA_DIR}/"
+                    if (path.contains(sourceAudioDir)) {
+                        path.substringAfter(sourceAudioDir)
+                            .contains("${sourceMetadata.identifier}_${project.slug}")
                     } else {
                         true
                     }


### PR DESCRIPTION
The issue came from source audio projects created from narration - the audio files did not follow the same path `media/{bookSlug}/...`, leaving the backup file not including source audio with it. This affects translation projects that we export.

Examples:

```
media/en_ulb_psa_c1.mp3
```
vs
```
media/psa/chapters/en_ulb_psa_c1.mp3
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/1185)
<!-- Reviewable:end -->
