### PR TITLE
Fall back to source audio inside project directory when applicable

### DIFF
--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ChunkingViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ChunkingViewModel.kt
@@ -148,10 +148,12 @@ class ChunkingViewModel : ViewModel(), IMarkerViewModel {
     private fun initializeSourceAudio(chapter: Int): Maybe<SourceAudio> {
         return Maybe.fromCallable {
             val workbook = workbookDataStore.workbook
-            ChunkAudioUseCase(directoryProvider, workbook.projectFilesAccessor)
-                .copySourceAudioToProject(sourceAudio.file)
-
             workbook.sourceAudioAccessor.getUserMarkedChapter(chapter, workbook.target)
+                ?: let {
+                    ChunkAudioUseCase(directoryProvider, workbook.projectFilesAccessor)
+                        .copySourceAudioToProject(sourceAudio.file)
+                    workbook.sourceAudioAccessor.getUserMarkedChapter(chapter, workbook.target)
+                }
         }
     }
 

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ChunkingViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ChunkingViewModel.kt
@@ -148,10 +148,11 @@ class ChunkingViewModel : ViewModel(), IMarkerViewModel {
     private fun initializeSourceAudio(chapter: Int): Maybe<SourceAudio> {
         return Maybe.fromCallable {
             val workbook = workbookDataStore.workbook
-            workbook.sourceAudioAccessor.getUserMarkedChapter(chapter, workbook.target)
+            workbook.sourceAudioAccessor.getUserMarkedChapter(chapter, workbook.target)  // this first call is intentional. See https://github.com/Bible-Translation-Tools/Orature/pull/1186
                 ?: let {
                     ChunkAudioUseCase(directoryProvider, workbook.projectFilesAccessor)
                         .copySourceAudioToProject(sourceAudio.file)
+
                     workbook.sourceAudioAccessor.getUserMarkedChapter(chapter, workbook.target)
                 }
         }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ConsumeViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ConsumeViewModel.kt
@@ -99,6 +99,7 @@ class ConsumeViewModel : ViewModel(), IMarkerViewModel {
         Maybe
             .fromCallable<SourceAudio> {
                 wb.sourceAudioAccessor.getChapter(chapter.sort, wb.target)
+                    ?: wb.sourceAudioAccessor.getUserMarkedChapter(chapter.sort, wb.target)
             }
             .subscribeOn(Schedulers.io())
             .observeOnFx()

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/TranslationViewModel2.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/TranslationViewModel2.kt
@@ -267,6 +267,7 @@ class TranslationViewModel2 : ViewModel() {
         Maybe
             .fromCallable {
                 wb.sourceAudioAccessor.getChapter(chapter.sort, wb.target)
+                    ?: wb.sourceAudioAccessor.getUserMarkedChapter(chapter.sort, wb.target)
             }
             .subscribeOn(Schedulers.io())
             .observeOnFx()


### PR DESCRIPTION
This retroactively handles the backup files created before #1185. Those project files would have source audio in a directory but not in the source RC `media/`. We opt to use the audio in such directory if the RC doesn't contain it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/1186)
<!-- Reviewable:end -->
