### PR TITLE
Missing marker after using maker app (OT-931)

### DIFF
--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/model/MarkerPlacementModel.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/model/MarkerPlacementModel.kt
@@ -137,8 +137,8 @@ class MarkerPlacementModel(
             .map { marker -> MarkerItem(marker, false) }
 
         val missing = all
-            .filter { marker ->
-                placedMarkerItems.any { it.marker.label == marker.label }.not()
+            .filter { markerItem ->
+                placedMarkerItems.any { it.marker.formattedLabel == markerItem.marker.formattedLabel }.not()
             }
             .toTypedArray()
 


### PR DESCRIPTION
The issue here is that it was checking based on the label and not the formatted label. The label for chapter maker 2 and verse marker 2 is just "2", however, the formatted label is something more like "chapter-marker-2" and "verse-marker-2"

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/1190)
<!-- Reviewable:end -->
