### PR TITLE
Avoid setting property on IO thread [Bugfix: OTTER-88]

### DIFF
--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ChapterReviewViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ChapterReviewViewModel.kt
@@ -403,7 +403,6 @@ class ChapterReviewViewModel : ViewModel(), IMarkerViewModel {
                 waveformAudioPlayerProperty.set(audioPlayer)
                 OratureAudioFile(take.file)
             }
-            .subscribeOn(Schedulers.io())
     }
 
     private fun loadVerseMarkers(audio: OratureAudioFile, sourceAudio: OratureAudioFile?) {

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ChapterReviewViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ChapterReviewViewModel.kt
@@ -398,7 +398,9 @@ class ChapterReviewViewModel : ViewModel(), IMarkerViewModel {
                 }
                 audioController = AudioPlayerController().also { controller ->
                     controller.load(audioPlayer)
-                    isPlayingProperty.bind(controller.isPlayingProperty)
+                    runLater {
+                        isPlayingProperty.bind(controller.isPlayingProperty)
+                    }
                 }
                 waveformAudioPlayerProperty.set(audioPlayer)
                 OratureAudioFile(take.file)


### PR DESCRIPTION
Due to the isPlayingProperty being bound for setting an icon (which needs to be done on the ui thread), running this on the io thread can cause a crash.

As such, the subscribeOn is removed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/1194)
<!-- Reviewable:end -->
