### PR TITLE
Handle rechunking with warning

### DIFF
--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/dialog/ConfirmDialog.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/dialog/ConfirmDialog.kt
@@ -129,7 +129,6 @@ class ConfirmDialog : OtterDialog() {
             }
 
             region {
-                addClass("confirm-dialog__footer-spacer")
                 hgrow = Priority.ALWAYS
                 managedProperty().bind(onCancelActionProperty.isNotNull)
             }

--- a/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/event/ChunkingPageEvents.kt
+++ b/jvm/controls/src/main/kotlin/org/wycliffeassociates/otter/jvm/controls/event/ChunkingPageEvents.kt
@@ -23,6 +23,7 @@ import org.wycliffeassociates.otter.jvm.controls.model.ChunkingStep
 import tornadofx.FXEvent
 import java.io.File
 
+class ChunkingStepTransitionEvent(val step: ChunkingStep): FXEvent()
 class ChunkingStepSelectedEvent(val step: ChunkingStep) : FXEvent()
 class ChunkSelectedEvent(val chunkNumber: Int): FXEvent()
 class ChunkExportedEvent(val chunkTake: Take, val outputFile: File): FXEvent()

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/ChunkingTranslationPage.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/ChunkingTranslationPage.kt
@@ -26,7 +26,7 @@ import org.wycliffeassociates.otter.jvm.controls.event.ChunkExportedEvent
 import org.wycliffeassociates.otter.jvm.controls.styles.tryImportStylesheet
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.components.drawer.SourceTextDrawer
 import org.wycliffeassociates.otter.jvm.controls.event.ChunkSelectedEvent
-import org.wycliffeassociates.otter.jvm.controls.event.ChunkingStepSelectedEvent
+import org.wycliffeassociates.otter.jvm.controls.event.ChunkingStepTransitionEvent
 import org.wycliffeassociates.otter.jvm.controls.event.GoToNextChapterEvent
 import org.wycliffeassociates.otter.jvm.controls.event.GoToPreviousChapterEvent
 import org.wycliffeassociates.otter.jvm.controls.event.NavigateChapterEvent
@@ -139,7 +139,7 @@ class ChunkingTranslationPage : View() {
         tryImportStylesheet("/css/source-audio-missing.css")
         tryImportStylesheet("/css/add-plugin-dialog.css")
 
-        subscribe<ChunkingStepSelectedEvent> {
+        subscribe<ChunkingStepTransitionEvent> {
             viewModel.navigateStep(it.step)
         }
         subscribe<ChunkSelectedEvent> {

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/BlindDraft.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/BlindDraft.kt
@@ -36,6 +36,8 @@ import org.wycliffeassociates.otter.jvm.controls.media.simpleaudioplayer
 import org.wycliffeassociates.otter.jvm.controls.styles.tryImportStylesheet
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.components.ChunkTakeCard
 import org.wycliffeassociates.otter.jvm.controls.event.ChunkTakeEvent
+import org.wycliffeassociates.otter.jvm.controls.event.ChunkingStepSelectedEvent
+import org.wycliffeassociates.otter.jvm.controls.event.ChunkingStepTransitionEvent
 import org.wycliffeassociates.otter.jvm.controls.event.RedoChunkingPageEvent
 import org.wycliffeassociates.otter.jvm.controls.event.ReturnFromPluginEvent
 import org.wycliffeassociates.otter.jvm.controls.event.TakeAction
@@ -246,6 +248,10 @@ class BlindDraft : View() {
                 mainSectionProperty.set(takesView)
             }
         }.also { listenerDisposers.add(it) }
+
+        subscribe<ChunkingStepSelectedEvent> {
+            FX.eventbus.fire(ChunkingStepTransitionEvent(it.step))
+        }.also { eventSubscriptions.add(it) }
         
         subscribe<ChunkTakeEvent> {
             when (it.action) {

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/ChapterReview.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/ChapterReview.kt
@@ -36,6 +36,8 @@ import org.wycliffeassociates.otter.jvm.controls.Shortcut
 import org.wycliffeassociates.otter.jvm.controls.button.debouncedButton
 import org.wycliffeassociates.otter.jvm.controls.createAudioScrollBar
 import org.wycliffeassociates.otter.jvm.controls.dialog.PluginOpenedPage
+import org.wycliffeassociates.otter.jvm.controls.event.ChunkingStepSelectedEvent
+import org.wycliffeassociates.otter.jvm.controls.event.ChunkingStepTransitionEvent
 import org.wycliffeassociates.otter.jvm.controls.event.TranslationNavigationEvent
 import org.wycliffeassociates.otter.jvm.controls.event.GoToNextChapterEvent
 import org.wycliffeassociates.otter.jvm.controls.event.MarkerDeletedEvent
@@ -250,6 +252,10 @@ class ChapterReview : View() {
 
     private fun subscribeEvents() {
         addShortcut()
+
+        subscribe<ChunkingStepSelectedEvent> {
+            FX.eventbus.fire(ChunkingStepTransitionEvent(it.step))
+        }.also { eventSubscriptions.add(it) }
 
         subscribe<MarkerDeletedEvent> {
             viewModel.deleteMarker(it.markerId)

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/Chunking.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/Chunking.kt
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory
 import org.wycliffeassociates.otter.jvm.controls.Shortcut
 import org.wycliffeassociates.otter.jvm.controls.button.debouncedButton
 import org.wycliffeassociates.otter.jvm.controls.createAudioScrollBar
+import org.wycliffeassociates.otter.jvm.controls.dialog.confirmdialog
 import org.wycliffeassociates.otter.jvm.controls.event.TranslationNavigationEvent
 import org.wycliffeassociates.otter.jvm.controls.event.MarkerDeletedEvent
 import org.wycliffeassociates.otter.jvm.controls.event.MarkerMovedEvent
@@ -231,6 +232,14 @@ class Chunking : View() {
             .addTo(viewModel.compositeDisposable)
     }
 
+    private val successDialog = confirmdialog {
+        titleTextProperty.set("Title")
+        messageTextProperty.set("Message")
+        orientationProperty.set(settingsViewModel.orientationProperty.value)
+        themeProperty.set(settingsViewModel.appColorMode.value)
+
+        cancelButtonTextProperty.set(messages["closeApp"])
+    }
 
     private fun setUpWaveformActionHandlers() {
         waveform.apply {

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/Chunking.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/Chunking.kt
@@ -35,6 +35,7 @@ import org.wycliffeassociates.otter.jvm.controls.Shortcut
 import org.wycliffeassociates.otter.jvm.controls.button.debouncedButton
 import org.wycliffeassociates.otter.jvm.controls.createAudioScrollBar
 import org.wycliffeassociates.otter.jvm.controls.dialog.confirmdialog
+import org.wycliffeassociates.otter.jvm.controls.event.ChunkingStepSelectedEvent
 import org.wycliffeassociates.otter.jvm.controls.event.TranslationNavigationEvent
 import org.wycliffeassociates.otter.jvm.controls.event.MarkerDeletedEvent
 import org.wycliffeassociates.otter.jvm.controls.event.MarkerMovedEvent
@@ -46,7 +47,6 @@ import org.wycliffeassociates.otter.jvm.controls.model.pixelsToFrames
 import org.wycliffeassociates.otter.jvm.controls.waveform.MarkerWaveform
 import org.wycliffeassociates.otter.jvm.controls.waveform.startAnimationTimer
 import org.wycliffeassociates.otter.jvm.utils.ListenerDisposer
-import org.wycliffeassociates.otter.jvm.utils.onChangeWithDisposer
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.viewmodel.ChunkingViewModel
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.viewmodel.SettingsViewModel
 import tornadofx.*
@@ -196,6 +196,10 @@ class Chunking : View() {
     private fun subscribeEvents() {
         addShortcut()
 
+        subscribe<ChunkingStepSelectedEvent> {
+            viewModel.requestToNavigate(it.step)
+        }.also { eventSubscriptions.add(it) }
+
         subscribe<MarkerDeletedEvent> {
             viewModel.deleteMarker(it.markerId)
         }.also { eventSubscriptions.add(it) }
@@ -230,15 +234,6 @@ class Chunking : View() {
                 waveform.addWaveformImage(it)
             }
             .addTo(viewModel.compositeDisposable)
-    }
-
-    private val successDialog = confirmdialog {
-        titleTextProperty.set("Title")
-        messageTextProperty.set("Message")
-        orientationProperty.set(settingsViewModel.orientationProperty.value)
-        themeProperty.set(settingsViewModel.appColorMode.value)
-
-        cancelButtonTextProperty.set(messages["closeApp"])
     }
 
     private fun setUpWaveformActionHandlers() {

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/Consume.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/Consume.kt
@@ -31,6 +31,8 @@ import org.kordamp.ikonli.materialdesign.MaterialDesign
 import org.slf4j.LoggerFactory
 import org.wycliffeassociates.otter.jvm.controls.Shortcut
 import org.wycliffeassociates.otter.jvm.controls.createAudioScrollBar
+import org.wycliffeassociates.otter.jvm.controls.event.ChunkingStepSelectedEvent
+import org.wycliffeassociates.otter.jvm.controls.event.ChunkingStepTransitionEvent
 import org.wycliffeassociates.otter.jvm.controls.event.TranslationNavigationEvent
 import org.wycliffeassociates.otter.jvm.controls.model.pixelsToFrames
 import org.wycliffeassociates.otter.jvm.workbookapp.ui.viewmodel.ConsumeViewModel
@@ -174,6 +176,10 @@ class Consume : View() {
 
     private fun subscribeEvents() {
         addShortcut()
+
+        subscribe<ChunkingStepSelectedEvent> {
+            FX.eventbus.fire(ChunkingStepTransitionEvent(it.step))
+        }.also { eventSubscriptions.add(it) }
 
         subscribe<TranslationNavigationEvent> {
             viewModel.cleanupWaveform()

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/PeerEdit.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/screens/translation/PeerEdit.kt
@@ -36,6 +36,8 @@ import org.slf4j.LoggerFactory
 import org.wycliffeassociates.otter.jvm.controls.Shortcut
 import org.wycliffeassociates.otter.jvm.controls.createAudioScrollBar
 import org.wycliffeassociates.otter.jvm.controls.dialog.PluginOpenedPage
+import org.wycliffeassociates.otter.jvm.controls.event.ChunkingStepSelectedEvent
+import org.wycliffeassociates.otter.jvm.controls.event.ChunkingStepTransitionEvent
 import org.wycliffeassociates.otter.jvm.controls.event.TranslationNavigationEvent
 import org.wycliffeassociates.otter.jvm.controls.event.RedoChunkingPageEvent
 import org.wycliffeassociates.otter.jvm.controls.event.ReturnFromPluginEvent
@@ -264,6 +266,10 @@ open class PeerEdit : View() {
                 mainSectionProperty.set(playbackView)
             }
         }.also { listenerDisposers.add(it) }
+
+        subscribe<ChunkingStepSelectedEvent> {
+            FX.eventbus.fire(ChunkingStepTransitionEvent(it.step))
+        }.also { eventSubscriptions.add(it) }
 
         subscribe<UndoChunkingPageEvent> {
             viewModel.undo()

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ChunkingViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ChunkingViewModel.kt
@@ -294,7 +294,8 @@ class ChunkingViewModel : ViewModel(), IMarkerViewModel {
     }
 
     fun requestToNavigate(targetStep: ChunkingStep) {
-        if ((hasNewChanges() && targetStep.ordinal > ChunkingStep.CHUNKING.ordinal)) {
+        val chunkCount = workbookDataStore.chapter.chunkCount.blockingGet()
+        if (hasNewChanges() && chunkCount > 0 && targetStep.ordinal > ChunkingStep.CHUNKING.ordinal) {
             val dialog = find<ConfirmDialog> {
                 titleTextProperty.set(messages["warning"])
                 messageTextProperty.set(messages["rechunk_data_loss_warning"])

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ChunkingViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ChunkingViewModel.kt
@@ -338,7 +338,11 @@ class ChunkingViewModel : ViewModel(), IMarkerViewModel {
     private fun onUndoableAction() {
         translationViewModel.canUndoProperty.set(true)
         translationViewModel.canRedoProperty.set(false)
-        // any changes in chunking will affect the subsequent steps
-        translationViewModel.reachableStepProperty.set(ChunkingStep.BLIND_DRAFT)
+        if (markers.size > 0) {
+            // enable next step when chunks are placed
+            translationViewModel.reachableStepProperty.set(ChunkingStep.BLIND_DRAFT)
+        } else {
+            translationViewModel.reachableStepProperty.set(ChunkingStep.CHUNKING)
+        }
     }
 }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ChunkingViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ChunkingViewModel.kt
@@ -31,7 +31,6 @@ import javafx.beans.property.SimpleIntegerProperty
 import javafx.beans.property.SimpleObjectProperty
 import javafx.scene.image.Image
 import javafx.scene.paint.Color
-import org.wycliffeassociates.otter.common.data.ColorTheme
 import org.wycliffeassociates.otter.common.data.audio.ChunkMarker
 import org.wycliffeassociates.otter.common.data.getWaveformColors
 import javax.inject.Inject
@@ -48,6 +47,8 @@ import org.wycliffeassociates.otter.common.domain.model.MarkerItem
 import org.wycliffeassociates.otter.jvm.controls.model.SECONDS_ON_SCREEN
 import org.wycliffeassociates.otter.common.domain.model.MarkerPlacementModel
 import org.wycliffeassociates.otter.common.domain.model.MarkerPlacementType
+import org.wycliffeassociates.otter.jvm.controls.dialog.ConfirmDialog
+import org.wycliffeassociates.otter.jvm.controls.event.ChunkingStepSelectedEvent
 import org.wycliffeassociates.otter.jvm.controls.waveform.IMarkerViewModel
 import org.wycliffeassociates.otter.jvm.controls.waveform.ObservableWaveformBuilder
 import org.wycliffeassociates.otter.jvm.device.audio.AudioConnectionFactory
@@ -285,6 +286,30 @@ class ChunkingViewModel : ViewModel(), IMarkerViewModel {
 
     fun subscribeOnWaveformImages() {
         subscribeOnWaveformImagesProperty.value.invoke()
+    }
+
+    fun hasNewChanges(): Boolean {
+        return markerCountProperty.value != 0 && markerModel?.canUndo() == true
+    }
+
+    fun requestToNavigate(targetStep: ChunkingStep) {
+        val dialog = find<ConfirmDialog>() {
+            titleTextProperty.set("Confirm")
+            messageTextProperty.set("message body")
+            orientationProperty.set(settingsViewModel.orientationProperty.value)
+            themeProperty.set(settingsViewModel.appColorMode.value)
+
+            onConfirmAction {
+                this.close()
+                saveChanges()
+                markerModel = null
+                FX.eventbus.fire(ChunkingStepSelectedEvent(targetStep))
+            }
+            onCancelAction {
+                this.close()
+            }
+        }
+        dialog.open()
     }
 
     private fun createWaveformImages(audio: OratureAudioFile) {

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ChunkingViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ChunkingViewModel.kt
@@ -296,10 +296,10 @@ class ChunkingViewModel : ViewModel(), IMarkerViewModel {
     fun requestToNavigate(targetStep: ChunkingStep) {
         if ((hasNewChanges() && targetStep.ordinal > ChunkingStep.CHUNKING.ordinal)) {
             val dialog = find<ConfirmDialog> {
-                titleTextProperty.set("Confirm")
-                messageTextProperty.set("Possible data loss")
-                confirmButtonTextProperty.set("Proceed")
-                cancelButtonTextProperty.set("Cancel")
+                titleTextProperty.set(messages["warning"])
+                messageTextProperty.set(messages["rechunk_data_loss_warning"])
+                confirmButtonTextProperty.set(messages["continue"])
+                cancelButtonTextProperty.set(messages["cancel"])
                 orientationProperty.set(settingsViewModel.orientationProperty.value)
                 themeProperty.set(settingsViewModel.appColorMode.value)
 

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ChunkingViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ChunkingViewModel.kt
@@ -49,6 +49,7 @@ import org.wycliffeassociates.otter.common.domain.model.MarkerPlacementModel
 import org.wycliffeassociates.otter.common.domain.model.MarkerPlacementType
 import org.wycliffeassociates.otter.jvm.controls.dialog.ConfirmDialog
 import org.wycliffeassociates.otter.jvm.controls.event.ChunkingStepSelectedEvent
+import org.wycliffeassociates.otter.jvm.controls.event.ChunkingStepTransitionEvent
 import org.wycliffeassociates.otter.jvm.controls.waveform.IMarkerViewModel
 import org.wycliffeassociates.otter.jvm.controls.waveform.ObservableWaveformBuilder
 import org.wycliffeassociates.otter.jvm.device.audio.AudioConnectionFactory
@@ -293,23 +294,27 @@ class ChunkingViewModel : ViewModel(), IMarkerViewModel {
     }
 
     fun requestToNavigate(targetStep: ChunkingStep) {
-        val dialog = find<ConfirmDialog>() {
-            titleTextProperty.set("Confirm")
-            messageTextProperty.set("message body")
-            orientationProperty.set(settingsViewModel.orientationProperty.value)
-            themeProperty.set(settingsViewModel.appColorMode.value)
+        if ((hasNewChanges() && targetStep.ordinal > ChunkingStep.CHUNKING.ordinal)) {
+            val dialog = find<ConfirmDialog> {
+                titleTextProperty.set("Confirm")
+                messageTextProperty.set("Possible data loss")
+                confirmButtonTextProperty.set("Proceed")
+                cancelButtonTextProperty.set("Cancel")
+                orientationProperty.set(settingsViewModel.orientationProperty.value)
+                themeProperty.set(settingsViewModel.appColorMode.value)
 
-            onConfirmAction {
-                this.close()
-                saveChanges()
-                markerModel = null
-                FX.eventbus.fire(ChunkingStepSelectedEvent(targetStep))
+                onConfirmAction {
+                    this.close()
+                    FX.eventbus.fire(ChunkingStepTransitionEvent(targetStep))
+                }
+                onCancelAction {
+                    this.close()
+                }
             }
-            onCancelAction {
-                this.close()
-            }
+            dialog.open()
+        } else {
+            FX.eventbus.fire(ChunkingStepTransitionEvent(targetStep))
         }
-        dialog.open()
     }
 
     private fun createWaveformImages(audio: OratureAudioFile) {

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ChunkingViewModel.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/ChunkingViewModel.kt
@@ -48,7 +48,6 @@ import org.wycliffeassociates.otter.jvm.controls.model.SECONDS_ON_SCREEN
 import org.wycliffeassociates.otter.common.domain.model.MarkerPlacementModel
 import org.wycliffeassociates.otter.common.domain.model.MarkerPlacementType
 import org.wycliffeassociates.otter.jvm.controls.dialog.ConfirmDialog
-import org.wycliffeassociates.otter.jvm.controls.event.ChunkingStepSelectedEvent
 import org.wycliffeassociates.otter.jvm.controls.event.ChunkingStepTransitionEvent
 import org.wycliffeassociates.otter.jvm.controls.waveform.IMarkerViewModel
 import org.wycliffeassociates.otter.jvm.controls.waveform.ObservableWaveformBuilder
@@ -134,8 +133,7 @@ class ChunkingViewModel : ViewModel(), IMarkerViewModel {
         pause()
         translationViewModel.selectedStepProperty.value?.let {
             // handle when navigating to the next step
-            val hasUnsavedChanges = markerCountProperty.value != 0 && markerModel?.canUndo() == true
-            if ((hasUnsavedChanges && it.ordinal > ChunkingStep.CHUNKING.ordinal)) {
+            if (hasUnsavedChanges() && it.ordinal > ChunkingStep.CHUNKING.ordinal) {
                 saveChanges()
             }
             translationViewModel.updateStep()
@@ -253,7 +251,44 @@ class ChunkingViewModel : ViewModel(), IMarkerViewModel {
         cleanupWaveform()
     }
 
-    fun saveChanges() {
+    fun pause() {
+        audioController?.pause()
+    }
+
+    fun cleanupWaveform() {
+        cleanupWaveformProperty.value.invoke()
+    }
+
+    fun subscribeOnWaveformImages() {
+        subscribeOnWaveformImagesProperty.value.invoke()
+    }
+
+    fun requestToNavigate(targetStep: ChunkingStep) {
+        val chunkCount = workbookDataStore.chapter.chunkCount.blockingGet()
+        if (hasUnsavedChanges() && chunkCount > 0 && targetStep.ordinal > ChunkingStep.CHUNKING.ordinal) {
+            val dialog = find<ConfirmDialog> {
+                titleTextProperty.set(messages["warning"])
+                messageTextProperty.set(messages["rechunk_data_loss_warning"])
+                confirmButtonTextProperty.set(messages["continue"])
+                cancelButtonTextProperty.set(messages["cancel"])
+                orientationProperty.set(settingsViewModel.orientationProperty.value)
+                themeProperty.set(settingsViewModel.appColorMode.value)
+
+                onConfirmAction {
+                    this.close()
+                    FX.eventbus.fire(ChunkingStepTransitionEvent(targetStep))
+                }
+                onCancelAction {
+                    this.close()
+                }
+            }
+            dialog.open()
+        } else {
+            FX.eventbus.fire(ChunkingStepTransitionEvent(targetStep))
+        }
+    }
+    
+    private fun saveChanges() {
         compositeDisposable.clear()
         audioConnectionFactory.clearPlayerConnections()
         waveformAudioPlayerProperty.value.close()
@@ -275,47 +310,6 @@ class ChunkingViewModel : ViewModel(), IMarkerViewModel {
                 completable.onComplete()
             }
             .blockingAwait() // ensures chunks are written before going to next step
-    }
-
-    fun pause() {
-        audioController?.pause()
-    }
-
-    fun cleanupWaveform() {
-        cleanupWaveformProperty.value.invoke()
-    }
-
-    fun subscribeOnWaveformImages() {
-        subscribeOnWaveformImagesProperty.value.invoke()
-    }
-
-    fun hasNewChanges(): Boolean {
-        return markerCountProperty.value != 0 && markerModel?.canUndo() == true
-    }
-
-    fun requestToNavigate(targetStep: ChunkingStep) {
-        val chunkCount = workbookDataStore.chapter.chunkCount.blockingGet()
-        if (hasNewChanges() && chunkCount > 0 && targetStep.ordinal > ChunkingStep.CHUNKING.ordinal) {
-            val dialog = find<ConfirmDialog> {
-                titleTextProperty.set(messages["warning"])
-                messageTextProperty.set(messages["rechunk_data_loss_warning"])
-                confirmButtonTextProperty.set(messages["continue"])
-                cancelButtonTextProperty.set(messages["cancel"])
-                orientationProperty.set(settingsViewModel.orientationProperty.value)
-                themeProperty.set(settingsViewModel.appColorMode.value)
-
-                onConfirmAction {
-                    this.close()
-                    FX.eventbus.fire(ChunkingStepTransitionEvent(targetStep))
-                }
-                onCancelAction {
-                    this.close()
-                }
-            }
-            dialog.open()
-        } else {
-            FX.eventbus.fire(ChunkingStepTransitionEvent(targetStep))
-        }
     }
 
     private fun createWaveformImages(audio: OratureAudioFile) {
@@ -344,5 +338,9 @@ class ChunkingViewModel : ViewModel(), IMarkerViewModel {
         } else {
             translationViewModel.reachableStepProperty.set(ChunkingStep.CHUNKING)
         }
+    }
+
+    private fun hasUnsavedChanges(): Boolean {
+        return markerCountProperty.value != 0 && markerModel?.canUndo() == true
     }
 }

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/TranslationViewModel2.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/TranslationViewModel2.kt
@@ -132,6 +132,21 @@ class TranslationViewModel2 : ViewModel() {
     }
 
     fun navigateStep(target: ChunkingStep) {
+        val readyForTransition = when (selectedStepProperty.value) {
+            ChunkingStep.CHUNKING -> {
+                val chunkingVm = find<ChunkingViewModel>()
+                if (!chunkingVm.hasNewChanges()) {
+                    true
+                } else {
+                    chunkingVm.requestToNavigate(target)
+                    false
+                }
+            }
+
+            else -> true
+        }
+        if (!readyForTransition) return /** STOP NAVIGATION UPON CONDITION */
+
         FX.eventbus.fire(TranslationNavigationEvent())
 
         if (!loadingStepProperty.value) {

--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/TranslationViewModel2.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/ui/viewmodel/TranslationViewModel2.kt
@@ -132,21 +132,6 @@ class TranslationViewModel2 : ViewModel() {
     }
 
     fun navigateStep(target: ChunkingStep) {
-        val readyForTransition = when (selectedStepProperty.value) {
-            ChunkingStep.CHUNKING -> {
-                val chunkingVm = find<ChunkingViewModel>()
-                if (!chunkingVm.hasNewChanges()) {
-                    true
-                } else {
-                    chunkingVm.requestToNavigate(target)
-                    false
-                }
-            }
-
-            else -> true
-        }
-        if (!readyForTransition) return /** STOP NAVIGATION UPON CONDITION */
-
         FX.eventbus.fire(TranslationNavigationEvent())
 
         if (!loadingStepProperty.value) {

--- a/jvm/workbookapp/src/main/resources/Messages_en.properties
+++ b/jvm/workbookapp/src/main/resources/Messages_en.properties
@@ -111,6 +111,7 @@ no = No
 remove = Remove
 add = Add
 confirm = Confirm
+rechunk_data_loss_warning = Modifying chunks will result in losing your recordings for this chapter. Do you wish to continue?
 
 # Project Creation
 createProjectMessageTitle = Create a Project to Get Started


### PR DESCRIPTION
When a step transition event is fired, it will be first captured by the main view before sending the event to the navigation handler. This allows any cleanup/preparation to execute first
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/1195)
<!-- Reviewable:end -->
