### PR TITLE
Wk rm jfx web

### DIFF
--- a/.github/workflows/mac_store_build.yml
+++ b/.github/workflows/mac_store_build.yml
@@ -130,7 +130,7 @@ jobs:
           -e MAC_NOTARY_ISSUER \
           -e MAC_NOTARY_KEY_ID \
           wycliffeassociates/install4j-docker:11.0.2 \
-          ./gradlew build :jvm:workbookapp:install4jdeploy "-Dorg.gradle.jvmargs=-Xmx4096m -Dnet.bytebuddy.experimental=true -XX:MaxMetaspaceSize=1024m" -x test
+          ./gradlew build :jvm:workbookapp:install4jdeploy "-Dorg.gradle.jvmargs=-Xmx4096m -Dnet.bytebuddy.experimental=true -XX:MaxMetaspaceSize=1024m" -x test -x integrationTest
         env:
           UPDATE_PATH: ${{ needs.set-env-vars.outputs.UPDATE_PATH }}
           ORG_GRADLE_PROJECT_gradlewCommandVersionProp: ${{ needs.set-env-vars.outputs.GHA_VERSION }}

--- a/jvm/workbookapp/otter.install4j
+++ b/jvm/workbookapp/otter.install4j
@@ -17,6 +17,7 @@
     <jreBundles jdkProviderId="Liberica" release="21/latest">
       <modules>
         <defaultModules set="all" />
+        <module name="javafx.web" exclude="true" />
       </modules>
     </jreBundles>
   </application>

--- a/jvm/workbookapp/otter.install4j
+++ b/jvm/workbookapp/otter.install4j
@@ -21,7 +21,7 @@
       </modules>
     </jreBundles>
   </application>
-  <files>
+  <files globalExcludeSuffixes="**/lib/libjfxwebkit.dylib">
     <mountPoints>
       <mountPoint id="58" />
     </mountPoints>


### PR DESCRIPTION
Ok, here we go again. Time to cut a new release, and I sure hope I'm to the end of breaking things.  For posterity sake, we have:

1. This error: 
![image](https://github.com/user-attachments/assets/6d894bdc-a50a-4a32-ad06-b238af41293e)

To Fix: 
 - I thought upgrading controlsfx would do it since we used it as a dep and transitively javafx.web was a dep on our version, but this didn't fix this.  But it's good to upgrade anyway
 - The bundled jre (liberica 21) includes javafx (siince Orature isn't modularized.).  That Jre, when you look at the modules, has the following. 
<img width="771" alt="image" src="https://github.com/user-attachments/assets/0b2513b2-22fb-409e-a044-cb0bae29480d" />
- So, we told install4j to exclude   <module name="javafx.web" exclude="true" /> from all bundles (can't do this on a platform basis afaik.  JRE bundled is same per app. 
- This still didn't fully fix the issue, cause that jre also includes this dylib, which is what apple was mad about in the first place
- 
<img width="392" alt="image" src="https://github.com/user-attachments/assets/9c623db4-1cce-4885-b595-30d20f01cc3d" />
- i4j also let's you say broad exlcusion rules, hence the <files globalExcludeSuffixes="**/lib/libjfxwebkit.dylib">. Which, for the latest mac build shows it's no longer there. 
<img width="573" alt="image" src="https://github.com/user-attachments/assets/0ef46280-19f1-4f44-b162-ee49715cc5bc" />


Next to last, Joe said we can kill tests for the mac build since it and the rest of the builds should stay in lockstep.  

Lastly, this already merged into dev, but for records keeping, I did this:https://github.com/Bible-Translation-Tools/Orature/blob/dev/jvm/workbookapp/otter.install4j#L927-L941, which is why the 3.1.30 linux and window builds bricked. I forgot / didn't full realize i4j for each media was building each launder, so that exclude for those limits them to the previous launcher.  The mac dmg launcher is fine cause you can only have one on apple platforms anyway.  

Here's to hoping it passes review and no more breakage.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/1207)
<!-- Reviewable:end -->
