### PR TITLE
Return Maybe.empty() if no versification found

### DIFF
--- a/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/persistence/repositories/VersificationRepository.kt
+++ b/jvm/workbookapp/src/main/kotlin/org/wycliffeassociates/otter/jvm/workbookapp/persistence/repositories/VersificationRepository.kt
@@ -49,7 +49,7 @@ class VersificationRepository @Inject constructor(
         return Maybe
             .fromCallable {
                 directoryProvider.versificationDirectory.mkdirs()
-                val vrsFileName = versificationDao.fetchVersificationFile(slug)
+                val vrsFileName = versificationDao.fetchVersificationFile(slug) ?: return@fromCallable Maybe.empty()
                 val vrsFile = File(directoryProvider.versificationDirectory, vrsFileName)
                 val mapper = ObjectMapper(JsonFactory())
                 mapper.registerKotlinModule()


### PR DESCRIPTION
If a versification file is not found, currently import will fail due to an exception with trying to access a null file.

Rather, we should return Maybe.empty, as the maybe is meant to imply the return value may or may not exist.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/1214)
<!-- Reviewable:end -->
