### PR TITLE
Return null for source audio with 0 length

### DIFF
--- a/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/SourceAudioAccessor.kt
+++ b/common/src/main/kotlin/org/wycliffeassociates/otter/common/domain/resourcecontainer/SourceAudioAccessor.kt
@@ -120,6 +120,9 @@ class SourceAudioAccessor(
 
                 val oratureAudioFile = OratureAudioFile(file)
                 val size = oratureAudioFile.totalFrames
+
+                if (size == 0) return null
+
                 SourceAudio(file, 0, size)
             } else {
                 null
@@ -142,6 +145,9 @@ class SourceAudioAccessor(
                 val nextMarker = if (chunks.lastIndex > markerIndex) chunks[markerIndex + 1] else null
                 val start = marker.location
                 val end = nextMarker?.location ?: oratureAudioFile.totalFrames
+
+                if (end - start == 0) return null
+
                 return SourceAudio(file, start, end)
             }
         }
@@ -161,6 +167,9 @@ class SourceAudioAccessor(
                 val nextMarker = if (verses.lastIndex > markerIndex) verses[markerIndex + 1] else null
                 val start = marker.location
                 val end = nextMarker?.location ?: oratureAudioFile.totalFrames
+
+                if (end - start == 0) return null
+
                 return SourceAudio(file, start, end)
             }
         }


### PR DESCRIPTION
Prevent some crashes if a 0 length source audio is loaded for translation.

Returns null as a 0 length file for source audio is effectively equivalent to not being found at all. This prevents crashing on the consume page if a source audio file is empty.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Bible-Translation-Tools/Orature/1215)
<!-- Reviewable:end -->
